### PR TITLE
view tests: drop views with cascade

### DIFF
--- a/test/index/view/10/slt_good_1.test
+++ b/test/index/view/10/slt_good_1.test
@@ -192,13 +192,13 @@ SELECT pk FROM tab0 WHERE col0 = 49
 ----
 
 statement ok
-DROP VIEW view_1_tab0_153
+DROP VIEW IF EXISTS view_1_tab0_153 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_153
+DROP VIEW IF EXISTS view_2_tab0_153 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_153
+DROP VIEW IF EXISTS view_3_tab0_153 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -284,13 +284,13 @@ SELECT pk FROM tab1 WHERE col0 = 49
 ----
 
 statement ok
-DROP VIEW view_1_tab1_153
+DROP VIEW IF EXISTS view_1_tab1_153 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_153
+DROP VIEW IF EXISTS view_2_tab1_153 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_153
+DROP VIEW IF EXISTS view_3_tab1_153 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -376,13 +376,13 @@ SELECT pk FROM tab2 WHERE col0 = 49
 ----
 
 statement ok
-DROP VIEW view_1_tab2_153
+DROP VIEW IF EXISTS view_1_tab2_153 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_153
+DROP VIEW IF EXISTS view_2_tab2_153 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_153
+DROP VIEW IF EXISTS view_3_tab2_153 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -468,13 +468,13 @@ SELECT pk FROM tab3 WHERE col0 = 49
 ----
 
 statement ok
-DROP VIEW view_1_tab3_153
+DROP VIEW IF EXISTS view_1_tab3_153 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_153
+DROP VIEW IF EXISTS view_2_tab3_153 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_153
+DROP VIEW IF EXISTS view_3_tab3_153 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -560,13 +560,13 @@ SELECT pk FROM tab4 WHERE col0 = 49
 ----
 
 statement ok
-DROP VIEW view_1_tab4_153
+DROP VIEW IF EXISTS view_1_tab4_153 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_153
+DROP VIEW IF EXISTS view_2_tab4_153 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_153
+DROP VIEW IF EXISTS view_3_tab4_153 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -669,13 +669,13 @@ SELECT pk FROM tab0 WHERE col0 > 56
 9
 
 statement ok
-DROP VIEW view_1_tab0_154
+DROP VIEW IF EXISTS view_1_tab0_154 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_154
+DROP VIEW IF EXISTS view_2_tab0_154 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_154
+DROP VIEW IF EXISTS view_3_tab0_154 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -778,13 +778,13 @@ SELECT pk FROM tab1 WHERE col0 > 56
 9
 
 statement ok
-DROP VIEW view_1_tab1_154
+DROP VIEW IF EXISTS view_1_tab1_154 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_154
+DROP VIEW IF EXISTS view_2_tab1_154 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_154
+DROP VIEW IF EXISTS view_3_tab1_154 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -887,13 +887,13 @@ SELECT pk FROM tab2 WHERE col0 > 56
 9
 
 statement ok
-DROP VIEW view_1_tab2_154
+DROP VIEW IF EXISTS view_1_tab2_154 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_154
+DROP VIEW IF EXISTS view_2_tab2_154 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_154
+DROP VIEW IF EXISTS view_3_tab2_154 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -996,13 +996,13 @@ SELECT pk FROM tab3 WHERE col0 > 56
 9
 
 statement ok
-DROP VIEW view_1_tab3_154
+DROP VIEW IF EXISTS view_1_tab3_154 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_154
+DROP VIEW IF EXISTS view_2_tab3_154 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_154
+DROP VIEW IF EXISTS view_3_tab3_154 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1105,13 +1105,13 @@ SELECT pk FROM tab4 WHERE col0 > 56
 9
 
 statement ok
-DROP VIEW view_1_tab4_154
+DROP VIEW IF EXISTS view_1_tab4_154 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_154
+DROP VIEW IF EXISTS view_2_tab4_154 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_154
+DROP VIEW IF EXISTS view_3_tab4_154 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1204,13 +1204,13 @@ SELECT pk FROM tab0 WHERE ((col4 >= 74.79) OR col3 > 93 AND col0 < 27 OR (col0 >
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab0_155
+DROP VIEW IF EXISTS view_1_tab0_155 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_155
+DROP VIEW IF EXISTS view_2_tab0_155 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_155
+DROP VIEW IF EXISTS view_3_tab0_155 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1303,13 +1303,13 @@ SELECT pk FROM tab1 WHERE ((col4 >= 74.79) OR col3 > 93 AND col0 < 27 OR (col0 >
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab1_155
+DROP VIEW IF EXISTS view_1_tab1_155 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_155
+DROP VIEW IF EXISTS view_2_tab1_155 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_155
+DROP VIEW IF EXISTS view_3_tab1_155 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1402,13 +1402,13 @@ SELECT pk FROM tab2 WHERE ((col4 >= 74.79) OR col3 > 93 AND col0 < 27 OR (col0 >
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab2_155
+DROP VIEW IF EXISTS view_1_tab2_155 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_155
+DROP VIEW IF EXISTS view_2_tab2_155 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_155
+DROP VIEW IF EXISTS view_3_tab2_155 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1501,13 +1501,13 @@ SELECT pk FROM tab3 WHERE ((col4 >= 74.79) OR col3 > 93 AND col0 < 27 OR (col0 >
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab3_155
+DROP VIEW IF EXISTS view_1_tab3_155 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_155
+DROP VIEW IF EXISTS view_2_tab3_155 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_155
+DROP VIEW IF EXISTS view_3_tab3_155 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1600,13 +1600,13 @@ SELECT pk FROM tab4 WHERE ((col4 >= 74.79) OR col3 > 93 AND col0 < 27 OR (col0 >
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab4_155
+DROP VIEW IF EXISTS view_1_tab4_155 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_155
+DROP VIEW IF EXISTS view_2_tab4_155 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_155
+DROP VIEW IF EXISTS view_3_tab4_155 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1699,13 +1699,13 @@ SELECT pk FROM tab0 WHERE (col1 >= 18.44)
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab0_156
+DROP VIEW IF EXISTS view_1_tab0_156 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_156
+DROP VIEW IF EXISTS view_2_tab0_156 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_156
+DROP VIEW IF EXISTS view_3_tab0_156 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1798,13 +1798,13 @@ SELECT pk FROM tab1 WHERE (col1 >= 18.44)
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab1_156
+DROP VIEW IF EXISTS view_1_tab1_156 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_156
+DROP VIEW IF EXISTS view_2_tab1_156 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_156
+DROP VIEW IF EXISTS view_3_tab1_156 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1897,13 +1897,13 @@ SELECT pk FROM tab2 WHERE (col1 >= 18.44)
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab2_156
+DROP VIEW IF EXISTS view_1_tab2_156 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_156
+DROP VIEW IF EXISTS view_2_tab2_156 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_156
+DROP VIEW IF EXISTS view_3_tab2_156 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1996,13 +1996,13 @@ SELECT pk FROM tab3 WHERE (col1 >= 18.44)
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab3_156
+DROP VIEW IF EXISTS view_1_tab3_156 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_156
+DROP VIEW IF EXISTS view_2_tab3_156 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_156
+DROP VIEW IF EXISTS view_3_tab3_156 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2095,13 +2095,13 @@ SELECT pk FROM tab4 WHERE (col1 >= 18.44)
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab4_156
+DROP VIEW IF EXISTS view_1_tab4_156 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_156
+DROP VIEW IF EXISTS view_2_tab4_156 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_156
+DROP VIEW IF EXISTS view_3_tab4_156 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2204,13 +2204,13 @@ SELECT pk FROM tab0 WHERE (col0 IN (SELECT col3 FROM tab0 WHERE ((col0 IS NULL) 
 9
 
 statement ok
-DROP VIEW view_1_tab0_157
+DROP VIEW IF EXISTS view_1_tab0_157 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_157
+DROP VIEW IF EXISTS view_2_tab0_157 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_157
+DROP VIEW IF EXISTS view_3_tab0_157 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2313,13 +2313,13 @@ SELECT pk FROM tab1 WHERE (col0 IN (SELECT col3 FROM tab1 WHERE ((col0 IS NULL) 
 9
 
 statement ok
-DROP VIEW view_1_tab1_157
+DROP VIEW IF EXISTS view_1_tab1_157 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_157
+DROP VIEW IF EXISTS view_2_tab1_157 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_157
+DROP VIEW IF EXISTS view_3_tab1_157 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2422,13 +2422,13 @@ SELECT pk FROM tab2 WHERE (col0 IN (SELECT col3 FROM tab2 WHERE ((col0 IS NULL) 
 9
 
 statement ok
-DROP VIEW view_1_tab2_157
+DROP VIEW IF EXISTS view_1_tab2_157 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_157
+DROP VIEW IF EXISTS view_2_tab2_157 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_157
+DROP VIEW IF EXISTS view_3_tab2_157 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2531,13 +2531,13 @@ SELECT pk FROM tab3 WHERE (col0 IN (SELECT col3 FROM tab3 WHERE ((col0 IS NULL) 
 9
 
 statement ok
-DROP VIEW view_1_tab3_157
+DROP VIEW IF EXISTS view_1_tab3_157 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_157
+DROP VIEW IF EXISTS view_2_tab3_157 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_157
+DROP VIEW IF EXISTS view_3_tab3_157 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2640,13 +2640,13 @@ SELECT pk FROM tab4 WHERE (col0 IN (SELECT col3 FROM tab4 WHERE ((col0 IS NULL) 
 9
 
 statement ok
-DROP VIEW view_1_tab4_157
+DROP VIEW IF EXISTS view_1_tab4_157 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_157
+DROP VIEW IF EXISTS view_2_tab4_157 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_157
+DROP VIEW IF EXISTS view_3_tab4_157 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2732,13 +2732,13 @@ SELECT pk FROM tab0 WHERE col4 = 77.58 AND (col4 <= 98.11) AND col3 >= 70 AND co
 ----
 
 statement ok
-DROP VIEW view_1_tab0_158
+DROP VIEW IF EXISTS view_1_tab0_158 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_158
+DROP VIEW IF EXISTS view_2_tab0_158 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_158
+DROP VIEW IF EXISTS view_3_tab0_158 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2824,13 +2824,13 @@ SELECT pk FROM tab1 WHERE col4 = 77.58 AND (col4 <= 98.11) AND col3 >= 70 AND co
 ----
 
 statement ok
-DROP VIEW view_1_tab1_158
+DROP VIEW IF EXISTS view_1_tab1_158 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_158
+DROP VIEW IF EXISTS view_2_tab1_158 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_158
+DROP VIEW IF EXISTS view_3_tab1_158 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2916,13 +2916,13 @@ SELECT pk FROM tab2 WHERE col4 = 77.58 AND (col4 <= 98.11) AND col3 >= 70 AND co
 ----
 
 statement ok
-DROP VIEW view_1_tab2_158
+DROP VIEW IF EXISTS view_1_tab2_158 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_158
+DROP VIEW IF EXISTS view_2_tab2_158 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_158
+DROP VIEW IF EXISTS view_3_tab2_158 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3008,13 +3008,13 @@ SELECT pk FROM tab3 WHERE col4 = 77.58 AND (col4 <= 98.11) AND col3 >= 70 AND co
 ----
 
 statement ok
-DROP VIEW view_1_tab3_158
+DROP VIEW IF EXISTS view_1_tab3_158 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_158
+DROP VIEW IF EXISTS view_2_tab3_158 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_158
+DROP VIEW IF EXISTS view_3_tab3_158 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3100,13 +3100,13 @@ SELECT pk FROM tab4 WHERE col4 = 77.58 AND (col4 <= 98.11) AND col3 >= 70 AND co
 ----
 
 statement ok
-DROP VIEW view_1_tab4_158
+DROP VIEW IF EXISTS view_1_tab4_158 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_158
+DROP VIEW IF EXISTS view_2_tab4_158 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_158
+DROP VIEW IF EXISTS view_3_tab4_158 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3192,13 +3192,13 @@ SELECT pk FROM tab0 WHERE (col3 < 75) AND ((col0 >= 55 AND ((col3 < 14))))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_159
+DROP VIEW IF EXISTS view_1_tab0_159 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_159
+DROP VIEW IF EXISTS view_2_tab0_159 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_159
+DROP VIEW IF EXISTS view_3_tab0_159 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3284,13 +3284,13 @@ SELECT pk FROM tab1 WHERE (col3 < 75) AND ((col0 >= 55 AND ((col3 < 14))))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_159
+DROP VIEW IF EXISTS view_1_tab1_159 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_159
+DROP VIEW IF EXISTS view_2_tab1_159 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_159
+DROP VIEW IF EXISTS view_3_tab1_159 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3376,13 +3376,13 @@ SELECT pk FROM tab2 WHERE (col3 < 75) AND ((col0 >= 55 AND ((col3 < 14))))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_159
+DROP VIEW IF EXISTS view_1_tab2_159 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_159
+DROP VIEW IF EXISTS view_2_tab2_159 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_159
+DROP VIEW IF EXISTS view_3_tab2_159 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3468,13 +3468,13 @@ SELECT pk FROM tab3 WHERE (col3 < 75) AND ((col0 >= 55 AND ((col3 < 14))))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_159
+DROP VIEW IF EXISTS view_1_tab3_159 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_159
+DROP VIEW IF EXISTS view_2_tab3_159 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_159
+DROP VIEW IF EXISTS view_3_tab3_159 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3560,13 +3560,13 @@ SELECT pk FROM tab4 WHERE (col3 < 75) AND ((col0 >= 55 AND ((col3 < 14))))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_159
+DROP VIEW IF EXISTS view_1_tab4_159 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_159
+DROP VIEW IF EXISTS view_2_tab4_159 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_159
+DROP VIEW IF EXISTS view_3_tab4_159 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3680,13 +3680,13 @@ SELECT pk FROM tab0 WHERE ((col3 = 34)) OR col0 > 61
 9
 
 statement ok
-DROP VIEW view_1_tab0_160
+DROP VIEW IF EXISTS view_1_tab0_160 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_160
+DROP VIEW IF EXISTS view_2_tab0_160 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_160
+DROP VIEW IF EXISTS view_3_tab0_160 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3800,13 +3800,13 @@ SELECT pk FROM tab1 WHERE ((col3 = 34)) OR col0 > 61
 9
 
 statement ok
-DROP VIEW view_1_tab1_160
+DROP VIEW IF EXISTS view_1_tab1_160 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_160
+DROP VIEW IF EXISTS view_2_tab1_160 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_160
+DROP VIEW IF EXISTS view_3_tab1_160 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3920,13 +3920,13 @@ SELECT pk FROM tab2 WHERE ((col3 = 34)) OR col0 > 61
 9
 
 statement ok
-DROP VIEW view_1_tab2_160
+DROP VIEW IF EXISTS view_1_tab2_160 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_160
+DROP VIEW IF EXISTS view_2_tab2_160 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_160
+DROP VIEW IF EXISTS view_3_tab2_160 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4040,13 +4040,13 @@ SELECT pk FROM tab3 WHERE ((col3 = 34)) OR col0 > 61
 9
 
 statement ok
-DROP VIEW view_1_tab3_160
+DROP VIEW IF EXISTS view_1_tab3_160 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_160
+DROP VIEW IF EXISTS view_2_tab3_160 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_160
+DROP VIEW IF EXISTS view_3_tab3_160 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4160,13 +4160,13 @@ SELECT pk FROM tab4 WHERE ((col3 = 34)) OR col0 > 61
 9
 
 statement ok
-DROP VIEW view_1_tab4_160
+DROP VIEW IF EXISTS view_1_tab4_160 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_160
+DROP VIEW IF EXISTS view_2_tab4_160 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_160
+DROP VIEW IF EXISTS view_3_tab4_160 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4284,13 +4284,13 @@ SELECT pk FROM tab0 WHERE col4 > 2.7
 9
 
 statement ok
-DROP VIEW view_1_tab0_162
+DROP VIEW IF EXISTS view_1_tab0_162 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_162
+DROP VIEW IF EXISTS view_2_tab0_162 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_162
+DROP VIEW IF EXISTS view_3_tab0_162 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4408,13 +4408,13 @@ SELECT pk FROM tab1 WHERE col4 > 2.7
 9
 
 statement ok
-DROP VIEW view_1_tab1_162
+DROP VIEW IF EXISTS view_1_tab1_162 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_162
+DROP VIEW IF EXISTS view_2_tab1_162 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_162
+DROP VIEW IF EXISTS view_3_tab1_162 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4532,13 +4532,13 @@ SELECT pk FROM tab2 WHERE col4 > 2.7
 9
 
 statement ok
-DROP VIEW view_1_tab2_162
+DROP VIEW IF EXISTS view_1_tab2_162 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_162
+DROP VIEW IF EXISTS view_2_tab2_162 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_162
+DROP VIEW IF EXISTS view_3_tab2_162 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4656,13 +4656,13 @@ SELECT pk FROM tab3 WHERE col4 > 2.7
 9
 
 statement ok
-DROP VIEW view_1_tab3_162
+DROP VIEW IF EXISTS view_1_tab3_162 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_162
+DROP VIEW IF EXISTS view_2_tab3_162 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_162
+DROP VIEW IF EXISTS view_3_tab3_162 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4780,13 +4780,13 @@ SELECT pk FROM tab4 WHERE col4 > 2.7
 9
 
 statement ok
-DROP VIEW view_1_tab4_162
+DROP VIEW IF EXISTS view_1_tab4_162 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_162
+DROP VIEW IF EXISTS view_2_tab4_162 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_162
+DROP VIEW IF EXISTS view_3_tab4_162 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4889,13 +4889,13 @@ SELECT pk FROM tab0 WHERE col3 > 63 AND col0 <= 85
 5
 
 statement ok
-DROP VIEW view_1_tab0_163
+DROP VIEW IF EXISTS view_1_tab0_163 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_163
+DROP VIEW IF EXISTS view_2_tab0_163 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_163
+DROP VIEW IF EXISTS view_3_tab0_163 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4998,13 +4998,13 @@ SELECT pk FROM tab1 WHERE col3 > 63 AND col0 <= 85
 5
 
 statement ok
-DROP VIEW view_1_tab1_163
+DROP VIEW IF EXISTS view_1_tab1_163 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_163
+DROP VIEW IF EXISTS view_2_tab1_163 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_163
+DROP VIEW IF EXISTS view_3_tab1_163 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5107,13 +5107,13 @@ SELECT pk FROM tab2 WHERE col3 > 63 AND col0 <= 85
 5
 
 statement ok
-DROP VIEW view_1_tab2_163
+DROP VIEW IF EXISTS view_1_tab2_163 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_163
+DROP VIEW IF EXISTS view_2_tab2_163 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_163
+DROP VIEW IF EXISTS view_3_tab2_163 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5216,13 +5216,13 @@ SELECT pk FROM tab3 WHERE col3 > 63 AND col0 <= 85
 5
 
 statement ok
-DROP VIEW view_1_tab3_163
+DROP VIEW IF EXISTS view_1_tab3_163 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_163
+DROP VIEW IF EXISTS view_2_tab3_163 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_163
+DROP VIEW IF EXISTS view_3_tab3_163 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5325,13 +5325,13 @@ SELECT pk FROM tab4 WHERE col3 > 63 AND col0 <= 85
 5
 
 statement ok
-DROP VIEW view_1_tab4_163
+DROP VIEW IF EXISTS view_1_tab4_163 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_163
+DROP VIEW IF EXISTS view_2_tab4_163 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_163
+DROP VIEW IF EXISTS view_3_tab4_163 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5417,13 +5417,13 @@ SELECT pk FROM tab0 WHERE col3 = 46
 ----
 
 statement ok
-DROP VIEW view_1_tab0_164
+DROP VIEW IF EXISTS view_1_tab0_164 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_164
+DROP VIEW IF EXISTS view_2_tab0_164 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_164
+DROP VIEW IF EXISTS view_3_tab0_164 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5509,13 +5509,13 @@ SELECT pk FROM tab1 WHERE col3 = 46
 ----
 
 statement ok
-DROP VIEW view_1_tab1_164
+DROP VIEW IF EXISTS view_1_tab1_164 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_164
+DROP VIEW IF EXISTS view_2_tab1_164 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_164
+DROP VIEW IF EXISTS view_3_tab1_164 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5601,13 +5601,13 @@ SELECT pk FROM tab2 WHERE col3 = 46
 ----
 
 statement ok
-DROP VIEW view_1_tab2_164
+DROP VIEW IF EXISTS view_1_tab2_164 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_164
+DROP VIEW IF EXISTS view_2_tab2_164 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_164
+DROP VIEW IF EXISTS view_3_tab2_164 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5693,13 +5693,13 @@ SELECT pk FROM tab3 WHERE col3 = 46
 ----
 
 statement ok
-DROP VIEW view_1_tab3_164
+DROP VIEW IF EXISTS view_1_tab3_164 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_164
+DROP VIEW IF EXISTS view_2_tab3_164 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_164
+DROP VIEW IF EXISTS view_3_tab3_164 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5785,13 +5785,13 @@ SELECT pk FROM tab4 WHERE col3 = 46
 ----
 
 statement ok
-DROP VIEW view_1_tab4_164
+DROP VIEW IF EXISTS view_1_tab4_164 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_164
+DROP VIEW IF EXISTS view_2_tab4_164 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_164
+DROP VIEW IF EXISTS view_3_tab4_164 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5905,13 +5905,13 @@ SELECT pk FROM tab0 WHERE col4 = 54.74 AND (col0 < 41 AND ((col3 < 49)) OR col3 
 9
 
 statement ok
-DROP VIEW view_1_tab0_165
+DROP VIEW IF EXISTS view_1_tab0_165 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_165
+DROP VIEW IF EXISTS view_2_tab0_165 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_165
+DROP VIEW IF EXISTS view_3_tab0_165 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6025,13 +6025,13 @@ SELECT pk FROM tab1 WHERE col4 = 54.74 AND (col0 < 41 AND ((col3 < 49)) OR col3 
 9
 
 statement ok
-DROP VIEW view_1_tab1_165
+DROP VIEW IF EXISTS view_1_tab1_165 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_165
+DROP VIEW IF EXISTS view_2_tab1_165 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_165
+DROP VIEW IF EXISTS view_3_tab1_165 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6145,13 +6145,13 @@ SELECT pk FROM tab2 WHERE col4 = 54.74 AND (col0 < 41 AND ((col3 < 49)) OR col3 
 9
 
 statement ok
-DROP VIEW view_1_tab2_165
+DROP VIEW IF EXISTS view_1_tab2_165 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_165
+DROP VIEW IF EXISTS view_2_tab2_165 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_165
+DROP VIEW IF EXISTS view_3_tab2_165 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6265,13 +6265,13 @@ SELECT pk FROM tab3 WHERE col4 = 54.74 AND (col0 < 41 AND ((col3 < 49)) OR col3 
 9
 
 statement ok
-DROP VIEW view_1_tab3_165
+DROP VIEW IF EXISTS view_1_tab3_165 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_165
+DROP VIEW IF EXISTS view_2_tab3_165 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_165
+DROP VIEW IF EXISTS view_3_tab3_165 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6385,13 +6385,13 @@ SELECT pk FROM tab4 WHERE col4 = 54.74 AND (col0 < 41 AND ((col3 < 49)) OR col3 
 9
 
 statement ok
-DROP VIEW view_1_tab4_165
+DROP VIEW IF EXISTS view_1_tab4_165 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_165
+DROP VIEW IF EXISTS view_2_tab4_165 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_165
+DROP VIEW IF EXISTS view_3_tab4_165 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6477,13 +6477,13 @@ SELECT pk FROM tab0 WHERE (col3 = 22) AND col3 > 39 AND col1 >= 50.31
 ----
 
 statement ok
-DROP VIEW view_1_tab0_166
+DROP VIEW IF EXISTS view_1_tab0_166 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_166
+DROP VIEW IF EXISTS view_2_tab0_166 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_166
+DROP VIEW IF EXISTS view_3_tab0_166 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6569,13 +6569,13 @@ SELECT pk FROM tab1 WHERE (col3 = 22) AND col3 > 39 AND col1 >= 50.31
 ----
 
 statement ok
-DROP VIEW view_1_tab1_166
+DROP VIEW IF EXISTS view_1_tab1_166 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_166
+DROP VIEW IF EXISTS view_2_tab1_166 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_166
+DROP VIEW IF EXISTS view_3_tab1_166 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6661,13 +6661,13 @@ SELECT pk FROM tab2 WHERE (col3 = 22) AND col3 > 39 AND col1 >= 50.31
 ----
 
 statement ok
-DROP VIEW view_1_tab2_166
+DROP VIEW IF EXISTS view_1_tab2_166 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_166
+DROP VIEW IF EXISTS view_2_tab2_166 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_166
+DROP VIEW IF EXISTS view_3_tab2_166 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6753,13 +6753,13 @@ SELECT pk FROM tab3 WHERE (col3 = 22) AND col3 > 39 AND col1 >= 50.31
 ----
 
 statement ok
-DROP VIEW view_1_tab3_166
+DROP VIEW IF EXISTS view_1_tab3_166 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_166
+DROP VIEW IF EXISTS view_2_tab3_166 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_166
+DROP VIEW IF EXISTS view_3_tab3_166 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6845,13 +6845,13 @@ SELECT pk FROM tab4 WHERE (col3 = 22) AND col3 > 39 AND col1 >= 50.31
 ----
 
 statement ok
-DROP VIEW view_1_tab4_166
+DROP VIEW IF EXISTS view_1_tab4_166 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_166
+DROP VIEW IF EXISTS view_2_tab4_166 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_166
+DROP VIEW IF EXISTS view_3_tab4_166 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6937,13 +6937,13 @@ SELECT pk FROM tab0 WHERE col0 = 83
 ----
 
 statement ok
-DROP VIEW view_1_tab0_167
+DROP VIEW IF EXISTS view_1_tab0_167 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_167
+DROP VIEW IF EXISTS view_2_tab0_167 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_167
+DROP VIEW IF EXISTS view_3_tab0_167 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7029,13 +7029,13 @@ SELECT pk FROM tab1 WHERE col0 = 83
 ----
 
 statement ok
-DROP VIEW view_1_tab1_167
+DROP VIEW IF EXISTS view_1_tab1_167 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_167
+DROP VIEW IF EXISTS view_2_tab1_167 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_167
+DROP VIEW IF EXISTS view_3_tab1_167 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7121,13 +7121,13 @@ SELECT pk FROM tab2 WHERE col0 = 83
 ----
 
 statement ok
-DROP VIEW view_1_tab2_167
+DROP VIEW IF EXISTS view_1_tab2_167 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_167
+DROP VIEW IF EXISTS view_2_tab2_167 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_167
+DROP VIEW IF EXISTS view_3_tab2_167 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7213,13 +7213,13 @@ SELECT pk FROM tab3 WHERE col0 = 83
 ----
 
 statement ok
-DROP VIEW view_1_tab3_167
+DROP VIEW IF EXISTS view_1_tab3_167 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_167
+DROP VIEW IF EXISTS view_2_tab3_167 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_167
+DROP VIEW IF EXISTS view_3_tab3_167 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7305,13 +7305,13 @@ SELECT pk FROM tab4 WHERE col0 = 83
 ----
 
 statement ok
-DROP VIEW view_1_tab4_167
+DROP VIEW IF EXISTS view_1_tab4_167 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_167
+DROP VIEW IF EXISTS view_2_tab4_167 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_167
+DROP VIEW IF EXISTS view_3_tab4_167 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7397,13 +7397,13 @@ SELECT pk FROM tab0 WHERE ((col0 = 13 OR col0 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_168
+DROP VIEW IF EXISTS view_1_tab0_168 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_168
+DROP VIEW IF EXISTS view_2_tab0_168 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_168
+DROP VIEW IF EXISTS view_3_tab0_168 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7489,13 +7489,13 @@ SELECT pk FROM tab1 WHERE ((col0 = 13 OR col0 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_168
+DROP VIEW IF EXISTS view_1_tab1_168 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_168
+DROP VIEW IF EXISTS view_2_tab1_168 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_168
+DROP VIEW IF EXISTS view_3_tab1_168 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7581,13 +7581,13 @@ SELECT pk FROM tab2 WHERE ((col0 = 13 OR col0 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_168
+DROP VIEW IF EXISTS view_1_tab2_168 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_168
+DROP VIEW IF EXISTS view_2_tab2_168 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_168
+DROP VIEW IF EXISTS view_3_tab2_168 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7673,13 +7673,13 @@ SELECT pk FROM tab3 WHERE ((col0 = 13 OR col0 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_168
+DROP VIEW IF EXISTS view_1_tab3_168 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_168
+DROP VIEW IF EXISTS view_2_tab3_168 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_168
+DROP VIEW IF EXISTS view_3_tab3_168 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7765,13 +7765,13 @@ SELECT pk FROM tab4 WHERE ((col0 = 13 OR col0 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_168
+DROP VIEW IF EXISTS view_1_tab4_168 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_168
+DROP VIEW IF EXISTS view_2_tab4_168 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_168
+DROP VIEW IF EXISTS view_3_tab4_168 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7890,13 +7890,13 @@ SELECT pk FROM tab0 WHERE (col0 <= 83)
 8
 
 statement ok
-DROP VIEW view_1_tab0_169
+DROP VIEW IF EXISTS view_1_tab0_169 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_169
+DROP VIEW IF EXISTS view_2_tab0_169 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_169
+DROP VIEW IF EXISTS view_3_tab0_169 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8015,13 +8015,13 @@ SELECT pk FROM tab1 WHERE (col0 <= 83)
 8
 
 statement ok
-DROP VIEW view_1_tab1_169
+DROP VIEW IF EXISTS view_1_tab1_169 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_169
+DROP VIEW IF EXISTS view_2_tab1_169 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_169
+DROP VIEW IF EXISTS view_3_tab1_169 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8140,13 +8140,13 @@ SELECT pk FROM tab2 WHERE (col0 <= 83)
 8
 
 statement ok
-DROP VIEW view_1_tab2_169
+DROP VIEW IF EXISTS view_1_tab2_169 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_169
+DROP VIEW IF EXISTS view_2_tab2_169 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_169
+DROP VIEW IF EXISTS view_3_tab2_169 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8265,13 +8265,13 @@ SELECT pk FROM tab3 WHERE (col0 <= 83)
 8
 
 statement ok
-DROP VIEW view_1_tab3_169
+DROP VIEW IF EXISTS view_1_tab3_169 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_169
+DROP VIEW IF EXISTS view_2_tab3_169 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_169
+DROP VIEW IF EXISTS view_3_tab3_169 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8390,13 +8390,13 @@ SELECT pk FROM tab4 WHERE (col0 <= 83)
 8
 
 statement ok
-DROP VIEW view_1_tab4_169
+DROP VIEW IF EXISTS view_1_tab4_169 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_169
+DROP VIEW IF EXISTS view_2_tab4_169 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_169
+DROP VIEW IF EXISTS view_3_tab4_169 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8489,13 +8489,13 @@ SELECT pk FROM tab0 WHERE (((col0 < 21)))
 6
 
 statement ok
-DROP VIEW view_1_tab0_170
+DROP VIEW IF EXISTS view_1_tab0_170 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_170
+DROP VIEW IF EXISTS view_2_tab0_170 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_170
+DROP VIEW IF EXISTS view_3_tab0_170 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8588,13 +8588,13 @@ SELECT pk FROM tab1 WHERE (((col0 < 21)))
 6
 
 statement ok
-DROP VIEW view_1_tab1_170
+DROP VIEW IF EXISTS view_1_tab1_170 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_170
+DROP VIEW IF EXISTS view_2_tab1_170 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_170
+DROP VIEW IF EXISTS view_3_tab1_170 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8687,13 +8687,13 @@ SELECT pk FROM tab2 WHERE (((col0 < 21)))
 6
 
 statement ok
-DROP VIEW view_1_tab2_170
+DROP VIEW IF EXISTS view_1_tab2_170 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_170
+DROP VIEW IF EXISTS view_2_tab2_170 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_170
+DROP VIEW IF EXISTS view_3_tab2_170 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8786,13 +8786,13 @@ SELECT pk FROM tab3 WHERE (((col0 < 21)))
 6
 
 statement ok
-DROP VIEW view_1_tab3_170
+DROP VIEW IF EXISTS view_1_tab3_170 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_170
+DROP VIEW IF EXISTS view_2_tab3_170 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_170
+DROP VIEW IF EXISTS view_3_tab3_170 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8885,13 +8885,13 @@ SELECT pk FROM tab4 WHERE (((col0 < 21)))
 6
 
 statement ok
-DROP VIEW view_1_tab4_170
+DROP VIEW IF EXISTS view_1_tab4_170 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_170
+DROP VIEW IF EXISTS view_2_tab4_170 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_170
+DROP VIEW IF EXISTS view_3_tab4_170 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8984,13 +8984,13 @@ SELECT pk FROM tab0 WHERE ((col0 < 1) AND col3 > 81 OR col1 < 33.10)
 8
 
 statement ok
-DROP VIEW view_1_tab0_171
+DROP VIEW IF EXISTS view_1_tab0_171 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_171
+DROP VIEW IF EXISTS view_2_tab0_171 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_171
+DROP VIEW IF EXISTS view_3_tab0_171 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9083,13 +9083,13 @@ SELECT pk FROM tab1 WHERE ((col0 < 1) AND col3 > 81 OR col1 < 33.10)
 8
 
 statement ok
-DROP VIEW view_1_tab1_171
+DROP VIEW IF EXISTS view_1_tab1_171 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_171
+DROP VIEW IF EXISTS view_2_tab1_171 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_171
+DROP VIEW IF EXISTS view_3_tab1_171 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9182,13 +9182,13 @@ SELECT pk FROM tab2 WHERE ((col0 < 1) AND col3 > 81 OR col1 < 33.10)
 8
 
 statement ok
-DROP VIEW view_1_tab2_171
+DROP VIEW IF EXISTS view_1_tab2_171 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_171
+DROP VIEW IF EXISTS view_2_tab2_171 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_171
+DROP VIEW IF EXISTS view_3_tab2_171 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9281,13 +9281,13 @@ SELECT pk FROM tab3 WHERE ((col0 < 1) AND col3 > 81 OR col1 < 33.10)
 8
 
 statement ok
-DROP VIEW view_1_tab3_171
+DROP VIEW IF EXISTS view_1_tab3_171 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_171
+DROP VIEW IF EXISTS view_2_tab3_171 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_171
+DROP VIEW IF EXISTS view_3_tab3_171 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9380,13 +9380,13 @@ SELECT pk FROM tab4 WHERE ((col0 < 1) AND col3 > 81 OR col1 < 33.10)
 8
 
 statement ok
-DROP VIEW view_1_tab4_171
+DROP VIEW IF EXISTS view_1_tab4_171 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_171
+DROP VIEW IF EXISTS view_2_tab4_171 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_171
+DROP VIEW IF EXISTS view_3_tab4_171 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9479,13 +9479,13 @@ SELECT pk FROM tab0 WHERE col3 >= 37
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab0_172
+DROP VIEW IF EXISTS view_1_tab0_172 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_172
+DROP VIEW IF EXISTS view_2_tab0_172 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_172
+DROP VIEW IF EXISTS view_3_tab0_172 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9578,13 +9578,13 @@ SELECT pk FROM tab1 WHERE col3 >= 37
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab1_172
+DROP VIEW IF EXISTS view_1_tab1_172 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_172
+DROP VIEW IF EXISTS view_2_tab1_172 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_172
+DROP VIEW IF EXISTS view_3_tab1_172 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9677,13 +9677,13 @@ SELECT pk FROM tab2 WHERE col3 >= 37
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab2_172
+DROP VIEW IF EXISTS view_1_tab2_172 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_172
+DROP VIEW IF EXISTS view_2_tab2_172 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_172
+DROP VIEW IF EXISTS view_3_tab2_172 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9776,13 +9776,13 @@ SELECT pk FROM tab3 WHERE col3 >= 37
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab3_172
+DROP VIEW IF EXISTS view_1_tab3_172 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_172
+DROP VIEW IF EXISTS view_2_tab3_172 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_172
+DROP VIEW IF EXISTS view_3_tab3_172 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9875,13 +9875,13 @@ SELECT pk FROM tab4 WHERE col3 >= 37
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab4_172
+DROP VIEW IF EXISTS view_1_tab4_172 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_172
+DROP VIEW IF EXISTS view_2_tab4_172 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_172
+DROP VIEW IF EXISTS view_3_tab4_172 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9970,13 +9970,13 @@ SELECT pk FROM tab0 WHERE col1 > 56.1 AND col0 < 88 OR (col4 < 93.8)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_173
+DROP VIEW IF EXISTS view_1_tab0_173 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_173
+DROP VIEW IF EXISTS view_2_tab0_173 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_173
+DROP VIEW IF EXISTS view_3_tab0_173 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10065,13 +10065,13 @@ SELECT pk FROM tab1 WHERE col1 > 56.1 AND col0 < 88 OR (col4 < 93.8)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_173
+DROP VIEW IF EXISTS view_1_tab1_173 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_173
+DROP VIEW IF EXISTS view_2_tab1_173 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_173
+DROP VIEW IF EXISTS view_3_tab1_173 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10160,13 +10160,13 @@ SELECT pk FROM tab2 WHERE col1 > 56.1 AND col0 < 88 OR (col4 < 93.8)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_173
+DROP VIEW IF EXISTS view_1_tab2_173 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_173
+DROP VIEW IF EXISTS view_2_tab2_173 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_173
+DROP VIEW IF EXISTS view_3_tab2_173 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10255,13 +10255,13 @@ SELECT pk FROM tab3 WHERE col1 > 56.1 AND col0 < 88 OR (col4 < 93.8)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_173
+DROP VIEW IF EXISTS view_1_tab3_173 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_173
+DROP VIEW IF EXISTS view_2_tab3_173 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_173
+DROP VIEW IF EXISTS view_3_tab3_173 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10350,13 +10350,13 @@ SELECT pk FROM tab4 WHERE col1 > 56.1 AND col0 < 88 OR (col4 < 93.8)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_173
+DROP VIEW IF EXISTS view_1_tab4_173 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_173
+DROP VIEW IF EXISTS view_2_tab4_173 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_173
+DROP VIEW IF EXISTS view_3_tab4_173 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10445,13 +10445,13 @@ SELECT pk FROM tab0 WHERE (col3 >= 16)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_174
+DROP VIEW IF EXISTS view_1_tab0_174 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_174
+DROP VIEW IF EXISTS view_2_tab0_174 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_174
+DROP VIEW IF EXISTS view_3_tab0_174 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10540,13 +10540,13 @@ SELECT pk FROM tab1 WHERE (col3 >= 16)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_174
+DROP VIEW IF EXISTS view_1_tab1_174 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_174
+DROP VIEW IF EXISTS view_2_tab1_174 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_174
+DROP VIEW IF EXISTS view_3_tab1_174 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10635,13 +10635,13 @@ SELECT pk FROM tab2 WHERE (col3 >= 16)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_174
+DROP VIEW IF EXISTS view_1_tab2_174 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_174
+DROP VIEW IF EXISTS view_2_tab2_174 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_174
+DROP VIEW IF EXISTS view_3_tab2_174 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10730,13 +10730,13 @@ SELECT pk FROM tab3 WHERE (col3 >= 16)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_174
+DROP VIEW IF EXISTS view_1_tab3_174 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_174
+DROP VIEW IF EXISTS view_2_tab3_174 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_174
+DROP VIEW IF EXISTS view_3_tab3_174 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10825,13 +10825,13 @@ SELECT pk FROM tab4 WHERE (col3 >= 16)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_174
+DROP VIEW IF EXISTS view_1_tab4_174 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_174
+DROP VIEW IF EXISTS view_2_tab4_174 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_174
+DROP VIEW IF EXISTS view_3_tab4_174 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10924,13 +10924,13 @@ SELECT pk FROM tab0 WHERE col0 IS NULL OR col3 = 32 OR (col0 > 89)
 1
 
 statement ok
-DROP VIEW view_1_tab0_175
+DROP VIEW IF EXISTS view_1_tab0_175 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_175
+DROP VIEW IF EXISTS view_2_tab0_175 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_175
+DROP VIEW IF EXISTS view_3_tab0_175 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11023,13 +11023,13 @@ SELECT pk FROM tab1 WHERE col0 IS NULL OR col3 = 32 OR (col0 > 89)
 1
 
 statement ok
-DROP VIEW view_1_tab1_175
+DROP VIEW IF EXISTS view_1_tab1_175 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_175
+DROP VIEW IF EXISTS view_2_tab1_175 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_175
+DROP VIEW IF EXISTS view_3_tab1_175 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11122,13 +11122,13 @@ SELECT pk FROM tab2 WHERE col0 IS NULL OR col3 = 32 OR (col0 > 89)
 1
 
 statement ok
-DROP VIEW view_1_tab2_175
+DROP VIEW IF EXISTS view_1_tab2_175 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_175
+DROP VIEW IF EXISTS view_2_tab2_175 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_175
+DROP VIEW IF EXISTS view_3_tab2_175 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11221,13 +11221,13 @@ SELECT pk FROM tab3 WHERE col0 IS NULL OR col3 = 32 OR (col0 > 89)
 1
 
 statement ok
-DROP VIEW view_1_tab3_175
+DROP VIEW IF EXISTS view_1_tab3_175 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_175
+DROP VIEW IF EXISTS view_2_tab3_175 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_175
+DROP VIEW IF EXISTS view_3_tab3_175 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11320,13 +11320,13 @@ SELECT pk FROM tab4 WHERE col0 IS NULL OR col3 = 32 OR (col0 > 89)
 1
 
 statement ok
-DROP VIEW view_1_tab4_175
+DROP VIEW IF EXISTS view_1_tab4_175 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_175
+DROP VIEW IF EXISTS view_2_tab4_175 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_175
+DROP VIEW IF EXISTS view_3_tab4_175 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11419,13 +11419,13 @@ SELECT pk FROM tab0 WHERE col0 > 89
 1
 
 statement ok
-DROP VIEW view_1_tab0_176
+DROP VIEW IF EXISTS view_1_tab0_176 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_176
+DROP VIEW IF EXISTS view_2_tab0_176 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_176
+DROP VIEW IF EXISTS view_3_tab0_176 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11518,13 +11518,13 @@ SELECT pk FROM tab1 WHERE col0 > 89
 1
 
 statement ok
-DROP VIEW view_1_tab1_176
+DROP VIEW IF EXISTS view_1_tab1_176 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_176
+DROP VIEW IF EXISTS view_2_tab1_176 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_176
+DROP VIEW IF EXISTS view_3_tab1_176 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11617,13 +11617,13 @@ SELECT pk FROM tab2 WHERE col0 > 89
 1
 
 statement ok
-DROP VIEW view_1_tab2_176
+DROP VIEW IF EXISTS view_1_tab2_176 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_176
+DROP VIEW IF EXISTS view_2_tab2_176 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_176
+DROP VIEW IF EXISTS view_3_tab2_176 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11716,13 +11716,13 @@ SELECT pk FROM tab3 WHERE col0 > 89
 1
 
 statement ok
-DROP VIEW view_1_tab3_176
+DROP VIEW IF EXISTS view_1_tab3_176 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_176
+DROP VIEW IF EXISTS view_2_tab3_176 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_176
+DROP VIEW IF EXISTS view_3_tab3_176 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11815,13 +11815,13 @@ SELECT pk FROM tab4 WHERE col0 > 89
 1
 
 statement ok
-DROP VIEW view_1_tab4_176
+DROP VIEW IF EXISTS view_1_tab4_176 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_176
+DROP VIEW IF EXISTS view_2_tab4_176 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_176
+DROP VIEW IF EXISTS view_3_tab4_176 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11935,13 +11935,13 @@ SELECT pk FROM tab0 WHERE col3 IN (SELECT col0 FROM tab0 WHERE ((col0 >= 99 AND 
 7
 
 statement ok
-DROP VIEW view_1_tab0_177
+DROP VIEW IF EXISTS view_1_tab0_177 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_177
+DROP VIEW IF EXISTS view_2_tab0_177 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_177
+DROP VIEW IF EXISTS view_3_tab0_177 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12055,13 +12055,13 @@ SELECT pk FROM tab1 WHERE col3 IN (SELECT col0 FROM tab1 WHERE ((col0 >= 99 AND 
 7
 
 statement ok
-DROP VIEW view_1_tab1_177
+DROP VIEW IF EXISTS view_1_tab1_177 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_177
+DROP VIEW IF EXISTS view_2_tab1_177 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_177
+DROP VIEW IF EXISTS view_3_tab1_177 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12175,13 +12175,13 @@ SELECT pk FROM tab2 WHERE col3 IN (SELECT col0 FROM tab2 WHERE ((col0 >= 99 AND 
 7
 
 statement ok
-DROP VIEW view_1_tab2_177
+DROP VIEW IF EXISTS view_1_tab2_177 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_177
+DROP VIEW IF EXISTS view_2_tab2_177 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_177
+DROP VIEW IF EXISTS view_3_tab2_177 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12295,13 +12295,13 @@ SELECT pk FROM tab3 WHERE col3 IN (SELECT col0 FROM tab3 WHERE ((col0 >= 99 AND 
 7
 
 statement ok
-DROP VIEW view_1_tab3_177
+DROP VIEW IF EXISTS view_1_tab3_177 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_177
+DROP VIEW IF EXISTS view_2_tab3_177 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_177
+DROP VIEW IF EXISTS view_3_tab3_177 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12415,13 +12415,13 @@ SELECT pk FROM tab4 WHERE col3 IN (SELECT col0 FROM tab4 WHERE ((col0 >= 99 AND 
 7
 
 statement ok
-DROP VIEW view_1_tab4_177
+DROP VIEW IF EXISTS view_1_tab4_177 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_177
+DROP VIEW IF EXISTS view_2_tab4_177 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_177
+DROP VIEW IF EXISTS view_3_tab4_177 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12510,13 +12510,13 @@ SELECT pk FROM tab0 WHERE (((col0 = 19 AND col3 < 41)) OR (col0 <= 25 OR col1 > 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_178
+DROP VIEW IF EXISTS view_1_tab0_178 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_178
+DROP VIEW IF EXISTS view_2_tab0_178 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_178
+DROP VIEW IF EXISTS view_3_tab0_178 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12605,13 +12605,13 @@ SELECT pk FROM tab1 WHERE (((col0 = 19 AND col3 < 41)) OR (col0 <= 25 OR col1 > 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_178
+DROP VIEW IF EXISTS view_1_tab1_178 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_178
+DROP VIEW IF EXISTS view_2_tab1_178 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_178
+DROP VIEW IF EXISTS view_3_tab1_178 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12700,13 +12700,13 @@ SELECT pk FROM tab2 WHERE (((col0 = 19 AND col3 < 41)) OR (col0 <= 25 OR col1 > 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_178
+DROP VIEW IF EXISTS view_1_tab2_178 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_178
+DROP VIEW IF EXISTS view_2_tab2_178 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_178
+DROP VIEW IF EXISTS view_3_tab2_178 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12795,13 +12795,13 @@ SELECT pk FROM tab3 WHERE (((col0 = 19 AND col3 < 41)) OR (col0 <= 25 OR col1 > 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_178
+DROP VIEW IF EXISTS view_1_tab3_178 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_178
+DROP VIEW IF EXISTS view_2_tab3_178 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_178
+DROP VIEW IF EXISTS view_3_tab3_178 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12890,13 +12890,13 @@ SELECT pk FROM tab4 WHERE (((col0 = 19 AND col3 < 41)) OR (col0 <= 25 OR col1 > 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_178
+DROP VIEW IF EXISTS view_1_tab4_178 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_178
+DROP VIEW IF EXISTS view_2_tab4_178 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_178
+DROP VIEW IF EXISTS view_3_tab4_178 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13003,13 +13003,13 @@ SELECT pk FROM tab0 WHERE (col0 >= 82)
 9
 
 statement ok
-DROP VIEW view_1_tab0_179
+DROP VIEW IF EXISTS view_1_tab0_179 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_179
+DROP VIEW IF EXISTS view_2_tab0_179 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_179
+DROP VIEW IF EXISTS view_3_tab0_179 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13116,13 +13116,13 @@ SELECT pk FROM tab1 WHERE (col0 >= 82)
 9
 
 statement ok
-DROP VIEW view_1_tab1_179
+DROP VIEW IF EXISTS view_1_tab1_179 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_179
+DROP VIEW IF EXISTS view_2_tab1_179 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_179
+DROP VIEW IF EXISTS view_3_tab1_179 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13229,13 +13229,13 @@ SELECT pk FROM tab2 WHERE (col0 >= 82)
 9
 
 statement ok
-DROP VIEW view_1_tab2_179
+DROP VIEW IF EXISTS view_1_tab2_179 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_179
+DROP VIEW IF EXISTS view_2_tab2_179 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_179
+DROP VIEW IF EXISTS view_3_tab2_179 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13342,13 +13342,13 @@ SELECT pk FROM tab3 WHERE (col0 >= 82)
 9
 
 statement ok
-DROP VIEW view_1_tab3_179
+DROP VIEW IF EXISTS view_1_tab3_179 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_179
+DROP VIEW IF EXISTS view_2_tab3_179 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_179
+DROP VIEW IF EXISTS view_3_tab3_179 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13455,13 +13455,13 @@ SELECT pk FROM tab4 WHERE (col0 >= 82)
 9
 
 statement ok
-DROP VIEW view_1_tab4_179
+DROP VIEW IF EXISTS view_1_tab4_179 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_179
+DROP VIEW IF EXISTS view_2_tab4_179 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_179
+DROP VIEW IF EXISTS view_3_tab4_179 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13550,13 +13550,13 @@ SELECT pk FROM tab0 WHERE col3 > 8
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_180
+DROP VIEW IF EXISTS view_1_tab0_180 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_180
+DROP VIEW IF EXISTS view_2_tab0_180 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_180
+DROP VIEW IF EXISTS view_3_tab0_180 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13645,13 +13645,13 @@ SELECT pk FROM tab1 WHERE col3 > 8
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_180
+DROP VIEW IF EXISTS view_1_tab1_180 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_180
+DROP VIEW IF EXISTS view_2_tab1_180 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_180
+DROP VIEW IF EXISTS view_3_tab1_180 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13740,13 +13740,13 @@ SELECT pk FROM tab2 WHERE col3 > 8
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_180
+DROP VIEW IF EXISTS view_1_tab2_180 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_180
+DROP VIEW IF EXISTS view_2_tab2_180 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_180
+DROP VIEW IF EXISTS view_3_tab2_180 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13835,13 +13835,13 @@ SELECT pk FROM tab3 WHERE col3 > 8
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_180
+DROP VIEW IF EXISTS view_1_tab3_180 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_180
+DROP VIEW IF EXISTS view_2_tab3_180 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_180
+DROP VIEW IF EXISTS view_3_tab3_180 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13930,13 +13930,13 @@ SELECT pk FROM tab4 WHERE col3 > 8
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_180
+DROP VIEW IF EXISTS view_1_tab4_180 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_180
+DROP VIEW IF EXISTS view_2_tab4_180 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_180
+DROP VIEW IF EXISTS view_3_tab4_180 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14039,13 +14039,13 @@ SELECT pk FROM tab0 WHERE (col4 > 38.90)
 8
 
 statement ok
-DROP VIEW view_1_tab0_181
+DROP VIEW IF EXISTS view_1_tab0_181 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_181
+DROP VIEW IF EXISTS view_2_tab0_181 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_181
+DROP VIEW IF EXISTS view_3_tab0_181 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14148,13 +14148,13 @@ SELECT pk FROM tab1 WHERE (col4 > 38.90)
 8
 
 statement ok
-DROP VIEW view_1_tab1_181
+DROP VIEW IF EXISTS view_1_tab1_181 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_181
+DROP VIEW IF EXISTS view_2_tab1_181 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_181
+DROP VIEW IF EXISTS view_3_tab1_181 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14257,13 +14257,13 @@ SELECT pk FROM tab2 WHERE (col4 > 38.90)
 8
 
 statement ok
-DROP VIEW view_1_tab2_181
+DROP VIEW IF EXISTS view_1_tab2_181 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_181
+DROP VIEW IF EXISTS view_2_tab2_181 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_181
+DROP VIEW IF EXISTS view_3_tab2_181 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14366,13 +14366,13 @@ SELECT pk FROM tab3 WHERE (col4 > 38.90)
 8
 
 statement ok
-DROP VIEW view_1_tab3_181
+DROP VIEW IF EXISTS view_1_tab3_181 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_181
+DROP VIEW IF EXISTS view_2_tab3_181 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_181
+DROP VIEW IF EXISTS view_3_tab3_181 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14475,13 +14475,13 @@ SELECT pk FROM tab4 WHERE (col4 > 38.90)
 8
 
 statement ok
-DROP VIEW view_1_tab4_181
+DROP VIEW IF EXISTS view_1_tab4_181 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_181
+DROP VIEW IF EXISTS view_2_tab4_181 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_181
+DROP VIEW IF EXISTS view_3_tab4_181 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14574,13 +14574,13 @@ SELECT pk FROM tab0 WHERE col1 <= 5.36 AND (col4 > 11.88 OR col3 >= 8)
 8
 
 statement ok
-DROP VIEW view_1_tab0_182
+DROP VIEW IF EXISTS view_1_tab0_182 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_182
+DROP VIEW IF EXISTS view_2_tab0_182 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_182
+DROP VIEW IF EXISTS view_3_tab0_182 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14673,13 +14673,13 @@ SELECT pk FROM tab1 WHERE col1 <= 5.36 AND (col4 > 11.88 OR col3 >= 8)
 8
 
 statement ok
-DROP VIEW view_1_tab1_182
+DROP VIEW IF EXISTS view_1_tab1_182 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_182
+DROP VIEW IF EXISTS view_2_tab1_182 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_182
+DROP VIEW IF EXISTS view_3_tab1_182 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14772,13 +14772,13 @@ SELECT pk FROM tab2 WHERE col1 <= 5.36 AND (col4 > 11.88 OR col3 >= 8)
 8
 
 statement ok
-DROP VIEW view_1_tab2_182
+DROP VIEW IF EXISTS view_1_tab2_182 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_182
+DROP VIEW IF EXISTS view_2_tab2_182 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_182
+DROP VIEW IF EXISTS view_3_tab2_182 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14871,13 +14871,13 @@ SELECT pk FROM tab3 WHERE col1 <= 5.36 AND (col4 > 11.88 OR col3 >= 8)
 8
 
 statement ok
-DROP VIEW view_1_tab3_182
+DROP VIEW IF EXISTS view_1_tab3_182 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_182
+DROP VIEW IF EXISTS view_2_tab3_182 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_182
+DROP VIEW IF EXISTS view_3_tab3_182 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14970,13 +14970,13 @@ SELECT pk FROM tab4 WHERE col1 <= 5.36 AND (col4 > 11.88 OR col3 >= 8)
 8
 
 statement ok
-DROP VIEW view_1_tab4_182
+DROP VIEW IF EXISTS view_1_tab4_182 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_182
+DROP VIEW IF EXISTS view_2_tab4_182 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_182
+DROP VIEW IF EXISTS view_3_tab4_182 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15069,13 +15069,13 @@ SELECT pk FROM tab0 WHERE ((col1 < 73.59 AND (col4 > 98.28 OR (col0 >= 41 AND co
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab0_183
+DROP VIEW IF EXISTS view_1_tab0_183 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_183
+DROP VIEW IF EXISTS view_2_tab0_183 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_183
+DROP VIEW IF EXISTS view_3_tab0_183 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15168,13 +15168,13 @@ SELECT pk FROM tab1 WHERE ((col1 < 73.59 AND (col4 > 98.28 OR (col0 >= 41 AND co
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab1_183
+DROP VIEW IF EXISTS view_1_tab1_183 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_183
+DROP VIEW IF EXISTS view_2_tab1_183 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_183
+DROP VIEW IF EXISTS view_3_tab1_183 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15267,13 +15267,13 @@ SELECT pk FROM tab2 WHERE ((col1 < 73.59 AND (col4 > 98.28 OR (col0 >= 41 AND co
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab2_183
+DROP VIEW IF EXISTS view_1_tab2_183 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_183
+DROP VIEW IF EXISTS view_2_tab2_183 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_183
+DROP VIEW IF EXISTS view_3_tab2_183 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15366,13 +15366,13 @@ SELECT pk FROM tab3 WHERE ((col1 < 73.59 AND (col4 > 98.28 OR (col0 >= 41 AND co
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab3_183
+DROP VIEW IF EXISTS view_1_tab3_183 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_183
+DROP VIEW IF EXISTS view_2_tab3_183 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_183
+DROP VIEW IF EXISTS view_3_tab3_183 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15465,13 +15465,13 @@ SELECT pk FROM tab4 WHERE ((col1 < 73.59 AND (col4 > 98.28 OR (col0 >= 41 AND co
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab4_183
+DROP VIEW IF EXISTS view_1_tab4_183 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_183
+DROP VIEW IF EXISTS view_2_tab4_183 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_183
+DROP VIEW IF EXISTS view_3_tab4_183 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15564,13 +15564,13 @@ SELECT pk FROM tab0 WHERE col1 >= 24.28
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab0_184
+DROP VIEW IF EXISTS view_1_tab0_184 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_184
+DROP VIEW IF EXISTS view_2_tab0_184 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_184
+DROP VIEW IF EXISTS view_3_tab0_184 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15663,13 +15663,13 @@ SELECT pk FROM tab1 WHERE col1 >= 24.28
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab1_184
+DROP VIEW IF EXISTS view_1_tab1_184 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_184
+DROP VIEW IF EXISTS view_2_tab1_184 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_184
+DROP VIEW IF EXISTS view_3_tab1_184 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15762,13 +15762,13 @@ SELECT pk FROM tab2 WHERE col1 >= 24.28
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab2_184
+DROP VIEW IF EXISTS view_1_tab2_184 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_184
+DROP VIEW IF EXISTS view_2_tab2_184 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_184
+DROP VIEW IF EXISTS view_3_tab2_184 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15861,13 +15861,13 @@ SELECT pk FROM tab3 WHERE col1 >= 24.28
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab3_184
+DROP VIEW IF EXISTS view_1_tab3_184 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_184
+DROP VIEW IF EXISTS view_2_tab3_184 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_184
+DROP VIEW IF EXISTS view_3_tab3_184 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15960,13 +15960,13 @@ SELECT pk FROM tab4 WHERE col1 >= 24.28
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab4_184
+DROP VIEW IF EXISTS view_1_tab4_184 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_184
+DROP VIEW IF EXISTS view_2_tab4_184 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_184
+DROP VIEW IF EXISTS view_3_tab4_184 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16069,13 +16069,13 @@ SELECT pk FROM tab0 WHERE col3 BETWEEN 32 AND 94 AND (col0 <= 62)
 8
 
 statement ok
-DROP VIEW view_1_tab0_185
+DROP VIEW IF EXISTS view_1_tab0_185 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_185
+DROP VIEW IF EXISTS view_2_tab0_185 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_185
+DROP VIEW IF EXISTS view_3_tab0_185 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16178,13 +16178,13 @@ SELECT pk FROM tab1 WHERE col3 BETWEEN 32 AND 94 AND (col0 <= 62)
 8
 
 statement ok
-DROP VIEW view_1_tab1_185
+DROP VIEW IF EXISTS view_1_tab1_185 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_185
+DROP VIEW IF EXISTS view_2_tab1_185 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_185
+DROP VIEW IF EXISTS view_3_tab1_185 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16287,13 +16287,13 @@ SELECT pk FROM tab2 WHERE col3 BETWEEN 32 AND 94 AND (col0 <= 62)
 8
 
 statement ok
-DROP VIEW view_1_tab2_185
+DROP VIEW IF EXISTS view_1_tab2_185 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_185
+DROP VIEW IF EXISTS view_2_tab2_185 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_185
+DROP VIEW IF EXISTS view_3_tab2_185 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16396,13 +16396,13 @@ SELECT pk FROM tab3 WHERE col3 BETWEEN 32 AND 94 AND (col0 <= 62)
 8
 
 statement ok
-DROP VIEW view_1_tab3_185
+DROP VIEW IF EXISTS view_1_tab3_185 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_185
+DROP VIEW IF EXISTS view_2_tab3_185 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_185
+DROP VIEW IF EXISTS view_3_tab3_185 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16505,13 +16505,13 @@ SELECT pk FROM tab4 WHERE col3 BETWEEN 32 AND 94 AND (col0 <= 62)
 8
 
 statement ok
-DROP VIEW view_1_tab4_185
+DROP VIEW IF EXISTS view_1_tab4_185 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_185
+DROP VIEW IF EXISTS view_2_tab4_185 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_185
+DROP VIEW IF EXISTS view_3_tab4_185 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16630,13 +16630,13 @@ SELECT pk FROM tab0 WHERE ((col4 >= 29.76))
 8
 
 statement ok
-DROP VIEW view_1_tab0_186
+DROP VIEW IF EXISTS view_1_tab0_186 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_186
+DROP VIEW IF EXISTS view_2_tab0_186 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_186
+DROP VIEW IF EXISTS view_3_tab0_186 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16755,13 +16755,13 @@ SELECT pk FROM tab1 WHERE ((col4 >= 29.76))
 8
 
 statement ok
-DROP VIEW view_1_tab1_186
+DROP VIEW IF EXISTS view_1_tab1_186 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_186
+DROP VIEW IF EXISTS view_2_tab1_186 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_186
+DROP VIEW IF EXISTS view_3_tab1_186 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16880,13 +16880,13 @@ SELECT pk FROM tab2 WHERE ((col4 >= 29.76))
 8
 
 statement ok
-DROP VIEW view_1_tab2_186
+DROP VIEW IF EXISTS view_1_tab2_186 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_186
+DROP VIEW IF EXISTS view_2_tab2_186 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_186
+DROP VIEW IF EXISTS view_3_tab2_186 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17005,13 +17005,13 @@ SELECT pk FROM tab3 WHERE ((col4 >= 29.76))
 8
 
 statement ok
-DROP VIEW view_1_tab3_186
+DROP VIEW IF EXISTS view_1_tab3_186 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_186
+DROP VIEW IF EXISTS view_2_tab3_186 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_186
+DROP VIEW IF EXISTS view_3_tab3_186 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17130,13 +17130,13 @@ SELECT pk FROM tab4 WHERE ((col4 >= 29.76))
 8
 
 statement ok
-DROP VIEW view_1_tab4_186
+DROP VIEW IF EXISTS view_1_tab4_186 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_186
+DROP VIEW IF EXISTS view_2_tab4_186 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_186
+DROP VIEW IF EXISTS view_3_tab4_186 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17239,13 +17239,13 @@ SELECT pk FROM tab0 WHERE ((col3 > 69))
 5
 
 statement ok
-DROP VIEW view_1_tab0_187
+DROP VIEW IF EXISTS view_1_tab0_187 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_187
+DROP VIEW IF EXISTS view_2_tab0_187 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_187
+DROP VIEW IF EXISTS view_3_tab0_187 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17348,13 +17348,13 @@ SELECT pk FROM tab1 WHERE ((col3 > 69))
 5
 
 statement ok
-DROP VIEW view_1_tab1_187
+DROP VIEW IF EXISTS view_1_tab1_187 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_187
+DROP VIEW IF EXISTS view_2_tab1_187 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_187
+DROP VIEW IF EXISTS view_3_tab1_187 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17457,13 +17457,13 @@ SELECT pk FROM tab2 WHERE ((col3 > 69))
 5
 
 statement ok
-DROP VIEW view_1_tab2_187
+DROP VIEW IF EXISTS view_1_tab2_187 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_187
+DROP VIEW IF EXISTS view_2_tab2_187 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_187
+DROP VIEW IF EXISTS view_3_tab2_187 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17566,13 +17566,13 @@ SELECT pk FROM tab3 WHERE ((col3 > 69))
 5
 
 statement ok
-DROP VIEW view_1_tab3_187
+DROP VIEW IF EXISTS view_1_tab3_187 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_187
+DROP VIEW IF EXISTS view_2_tab3_187 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_187
+DROP VIEW IF EXISTS view_3_tab3_187 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17675,13 +17675,13 @@ SELECT pk FROM tab4 WHERE ((col3 > 69))
 5
 
 statement ok
-DROP VIEW view_1_tab4_187
+DROP VIEW IF EXISTS view_1_tab4_187 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_187
+DROP VIEW IF EXISTS view_2_tab4_187 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_187
+DROP VIEW IF EXISTS view_3_tab4_187 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17767,13 +17767,13 @@ SELECT pk FROM tab0 WHERE col4 = 69.29
 ----
 
 statement ok
-DROP VIEW view_1_tab0_188
+DROP VIEW IF EXISTS view_1_tab0_188 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_188
+DROP VIEW IF EXISTS view_2_tab0_188 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_188
+DROP VIEW IF EXISTS view_3_tab0_188 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17859,13 +17859,13 @@ SELECT pk FROM tab1 WHERE col4 = 69.29
 ----
 
 statement ok
-DROP VIEW view_1_tab1_188
+DROP VIEW IF EXISTS view_1_tab1_188 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_188
+DROP VIEW IF EXISTS view_2_tab1_188 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_188
+DROP VIEW IF EXISTS view_3_tab1_188 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17951,13 +17951,13 @@ SELECT pk FROM tab2 WHERE col4 = 69.29
 ----
 
 statement ok
-DROP VIEW view_1_tab2_188
+DROP VIEW IF EXISTS view_1_tab2_188 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_188
+DROP VIEW IF EXISTS view_2_tab2_188 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_188
+DROP VIEW IF EXISTS view_3_tab2_188 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18043,13 +18043,13 @@ SELECT pk FROM tab3 WHERE col4 = 69.29
 ----
 
 statement ok
-DROP VIEW view_1_tab3_188
+DROP VIEW IF EXISTS view_1_tab3_188 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_188
+DROP VIEW IF EXISTS view_2_tab3_188 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_188
+DROP VIEW IF EXISTS view_3_tab3_188 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18135,13 +18135,13 @@ SELECT pk FROM tab4 WHERE col4 = 69.29
 ----
 
 statement ok
-DROP VIEW view_1_tab4_188
+DROP VIEW IF EXISTS view_1_tab4_188 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_188
+DROP VIEW IF EXISTS view_2_tab4_188 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_188
+DROP VIEW IF EXISTS view_3_tab4_188 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18241,13 +18241,13 @@ SELECT pk FROM tab0 WHERE (col0 < 73) AND (col0 > 18 AND col3 > 86) AND col3 > 8
 5
 
 statement ok
-DROP VIEW view_1_tab0_189
+DROP VIEW IF EXISTS view_1_tab0_189 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_189
+DROP VIEW IF EXISTS view_2_tab0_189 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_189
+DROP VIEW IF EXISTS view_3_tab0_189 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18347,13 +18347,13 @@ SELECT pk FROM tab1 WHERE (col0 < 73) AND (col0 > 18 AND col3 > 86) AND col3 > 8
 5
 
 statement ok
-DROP VIEW view_1_tab1_189
+DROP VIEW IF EXISTS view_1_tab1_189 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_189
+DROP VIEW IF EXISTS view_2_tab1_189 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_189
+DROP VIEW IF EXISTS view_3_tab1_189 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18453,13 +18453,13 @@ SELECT pk FROM tab2 WHERE (col0 < 73) AND (col0 > 18 AND col3 > 86) AND col3 > 8
 5
 
 statement ok
-DROP VIEW view_1_tab2_189
+DROP VIEW IF EXISTS view_1_tab2_189 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_189
+DROP VIEW IF EXISTS view_2_tab2_189 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_189
+DROP VIEW IF EXISTS view_3_tab2_189 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18559,13 +18559,13 @@ SELECT pk FROM tab3 WHERE (col0 < 73) AND (col0 > 18 AND col3 > 86) AND col3 > 8
 5
 
 statement ok
-DROP VIEW view_1_tab3_189
+DROP VIEW IF EXISTS view_1_tab3_189 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_189
+DROP VIEW IF EXISTS view_2_tab3_189 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_189
+DROP VIEW IF EXISTS view_3_tab3_189 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18665,13 +18665,13 @@ SELECT pk FROM tab4 WHERE (col0 < 73) AND (col0 > 18 AND col3 > 86) AND col3 > 8
 5
 
 statement ok
-DROP VIEW view_1_tab4_189
+DROP VIEW IF EXISTS view_1_tab4_189 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_189
+DROP VIEW IF EXISTS view_2_tab4_189 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_189
+DROP VIEW IF EXISTS view_3_tab4_189 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18764,13 +18764,13 @@ SELECT pk FROM tab0 WHERE col1 <= 32.53
 8
 
 statement ok
-DROP VIEW view_1_tab0_190
+DROP VIEW IF EXISTS view_1_tab0_190 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_190
+DROP VIEW IF EXISTS view_2_tab0_190 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_190
+DROP VIEW IF EXISTS view_3_tab0_190 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18863,13 +18863,13 @@ SELECT pk FROM tab1 WHERE col1 <= 32.53
 8
 
 statement ok
-DROP VIEW view_1_tab1_190
+DROP VIEW IF EXISTS view_1_tab1_190 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_190
+DROP VIEW IF EXISTS view_2_tab1_190 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_190
+DROP VIEW IF EXISTS view_3_tab1_190 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18962,13 +18962,13 @@ SELECT pk FROM tab2 WHERE col1 <= 32.53
 8
 
 statement ok
-DROP VIEW view_1_tab2_190
+DROP VIEW IF EXISTS view_1_tab2_190 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_190
+DROP VIEW IF EXISTS view_2_tab2_190 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_190
+DROP VIEW IF EXISTS view_3_tab2_190 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19061,13 +19061,13 @@ SELECT pk FROM tab3 WHERE col1 <= 32.53
 8
 
 statement ok
-DROP VIEW view_1_tab3_190
+DROP VIEW IF EXISTS view_1_tab3_190 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_190
+DROP VIEW IF EXISTS view_2_tab3_190 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_190
+DROP VIEW IF EXISTS view_3_tab3_190 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19160,13 +19160,13 @@ SELECT pk FROM tab4 WHERE col1 <= 32.53
 8
 
 statement ok
-DROP VIEW view_1_tab4_190
+DROP VIEW IF EXISTS view_1_tab4_190 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_190
+DROP VIEW IF EXISTS view_2_tab4_190 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_190
+DROP VIEW IF EXISTS view_3_tab4_190 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19284,13 +19284,13 @@ SELECT pk FROM tab0 WHERE col0 < 85
 8
 
 statement ok
-DROP VIEW view_1_tab0_191
+DROP VIEW IF EXISTS view_1_tab0_191 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_191
+DROP VIEW IF EXISTS view_2_tab0_191 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_191
+DROP VIEW IF EXISTS view_3_tab0_191 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19408,13 +19408,13 @@ SELECT pk FROM tab1 WHERE col0 < 85
 8
 
 statement ok
-DROP VIEW view_1_tab1_191
+DROP VIEW IF EXISTS view_1_tab1_191 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_191
+DROP VIEW IF EXISTS view_2_tab1_191 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_191
+DROP VIEW IF EXISTS view_3_tab1_191 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19532,13 +19532,13 @@ SELECT pk FROM tab2 WHERE col0 < 85
 8
 
 statement ok
-DROP VIEW view_1_tab2_191
+DROP VIEW IF EXISTS view_1_tab2_191 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_191
+DROP VIEW IF EXISTS view_2_tab2_191 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_191
+DROP VIEW IF EXISTS view_3_tab2_191 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19656,13 +19656,13 @@ SELECT pk FROM tab3 WHERE col0 < 85
 8
 
 statement ok
-DROP VIEW view_1_tab3_191
+DROP VIEW IF EXISTS view_1_tab3_191 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_191
+DROP VIEW IF EXISTS view_2_tab3_191 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_191
+DROP VIEW IF EXISTS view_3_tab3_191 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19780,13 +19780,13 @@ SELECT pk FROM tab4 WHERE col0 < 85
 8
 
 statement ok
-DROP VIEW view_1_tab4_191
+DROP VIEW IF EXISTS view_1_tab4_191 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_191
+DROP VIEW IF EXISTS view_2_tab4_191 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_191
+DROP VIEW IF EXISTS view_3_tab4_191 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19875,13 +19875,13 @@ SELECT pk FROM tab0 WHERE col0 IS NULL OR col3 <= 98
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_192
+DROP VIEW IF EXISTS view_1_tab0_192 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_192
+DROP VIEW IF EXISTS view_2_tab0_192 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_192
+DROP VIEW IF EXISTS view_3_tab0_192 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19970,13 +19970,13 @@ SELECT pk FROM tab1 WHERE col0 IS NULL OR col3 <= 98
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_192
+DROP VIEW IF EXISTS view_1_tab1_192 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_192
+DROP VIEW IF EXISTS view_2_tab1_192 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_192
+DROP VIEW IF EXISTS view_3_tab1_192 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20065,13 +20065,13 @@ SELECT pk FROM tab2 WHERE col0 IS NULL OR col3 <= 98
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_192
+DROP VIEW IF EXISTS view_1_tab2_192 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_192
+DROP VIEW IF EXISTS view_2_tab2_192 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_192
+DROP VIEW IF EXISTS view_3_tab2_192 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20160,13 +20160,13 @@ SELECT pk FROM tab3 WHERE col0 IS NULL OR col3 <= 98
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_192
+DROP VIEW IF EXISTS view_1_tab3_192 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_192
+DROP VIEW IF EXISTS view_2_tab3_192 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_192
+DROP VIEW IF EXISTS view_3_tab3_192 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20255,13 +20255,13 @@ SELECT pk FROM tab4 WHERE col0 IS NULL OR col3 <= 98
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_192
+DROP VIEW IF EXISTS view_1_tab4_192 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_192
+DROP VIEW IF EXISTS view_2_tab4_192 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_192
+DROP VIEW IF EXISTS view_3_tab4_192 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20361,13 +20361,13 @@ SELECT pk FROM tab0 WHERE col4 >= 70.6
 8
 
 statement ok
-DROP VIEW view_1_tab0_193
+DROP VIEW IF EXISTS view_1_tab0_193 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_193
+DROP VIEW IF EXISTS view_2_tab0_193 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_193
+DROP VIEW IF EXISTS view_3_tab0_193 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20467,13 +20467,13 @@ SELECT pk FROM tab1 WHERE col4 >= 70.6
 8
 
 statement ok
-DROP VIEW view_1_tab1_193
+DROP VIEW IF EXISTS view_1_tab1_193 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_193
+DROP VIEW IF EXISTS view_2_tab1_193 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_193
+DROP VIEW IF EXISTS view_3_tab1_193 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20573,13 +20573,13 @@ SELECT pk FROM tab2 WHERE col4 >= 70.6
 8
 
 statement ok
-DROP VIEW view_1_tab2_193
+DROP VIEW IF EXISTS view_1_tab2_193 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_193
+DROP VIEW IF EXISTS view_2_tab2_193 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_193
+DROP VIEW IF EXISTS view_3_tab2_193 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20679,13 +20679,13 @@ SELECT pk FROM tab3 WHERE col4 >= 70.6
 8
 
 statement ok
-DROP VIEW view_1_tab3_193
+DROP VIEW IF EXISTS view_1_tab3_193 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_193
+DROP VIEW IF EXISTS view_2_tab3_193 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_193
+DROP VIEW IF EXISTS view_3_tab3_193 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20785,13 +20785,13 @@ SELECT pk FROM tab4 WHERE col4 >= 70.6
 8
 
 statement ok
-DROP VIEW view_1_tab4_193
+DROP VIEW IF EXISTS view_1_tab4_193 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_193
+DROP VIEW IF EXISTS view_2_tab4_193 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_193
+DROP VIEW IF EXISTS view_3_tab4_193 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20884,13 +20884,13 @@ SELECT pk FROM tab0 WHERE (col0 >= 21)
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab0_194
+DROP VIEW IF EXISTS view_1_tab0_194 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_194
+DROP VIEW IF EXISTS view_2_tab0_194 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_194
+DROP VIEW IF EXISTS view_3_tab0_194 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20983,13 +20983,13 @@ SELECT pk FROM tab1 WHERE (col0 >= 21)
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab1_194
+DROP VIEW IF EXISTS view_1_tab1_194 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_194
+DROP VIEW IF EXISTS view_2_tab1_194 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_194
+DROP VIEW IF EXISTS view_3_tab1_194 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21082,13 +21082,13 @@ SELECT pk FROM tab2 WHERE (col0 >= 21)
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab2_194
+DROP VIEW IF EXISTS view_1_tab2_194 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_194
+DROP VIEW IF EXISTS view_2_tab2_194 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_194
+DROP VIEW IF EXISTS view_3_tab2_194 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21181,13 +21181,13 @@ SELECT pk FROM tab3 WHERE (col0 >= 21)
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab3_194
+DROP VIEW IF EXISTS view_1_tab3_194 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_194
+DROP VIEW IF EXISTS view_2_tab3_194 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_194
+DROP VIEW IF EXISTS view_3_tab3_194 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21280,13 +21280,13 @@ SELECT pk FROM tab4 WHERE (col0 >= 21)
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab4_194
+DROP VIEW IF EXISTS view_1_tab4_194 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_194
+DROP VIEW IF EXISTS view_2_tab4_194 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_194
+DROP VIEW IF EXISTS view_3_tab4_194 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21372,13 +21372,13 @@ SELECT pk FROM tab0 WHERE col4 = 27.89
 ----
 
 statement ok
-DROP VIEW view_1_tab0_195
+DROP VIEW IF EXISTS view_1_tab0_195 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_195
+DROP VIEW IF EXISTS view_2_tab0_195 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_195
+DROP VIEW IF EXISTS view_3_tab0_195 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21464,13 +21464,13 @@ SELECT pk FROM tab1 WHERE col4 = 27.89
 ----
 
 statement ok
-DROP VIEW view_1_tab1_195
+DROP VIEW IF EXISTS view_1_tab1_195 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_195
+DROP VIEW IF EXISTS view_2_tab1_195 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_195
+DROP VIEW IF EXISTS view_3_tab1_195 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21556,13 +21556,13 @@ SELECT pk FROM tab2 WHERE col4 = 27.89
 ----
 
 statement ok
-DROP VIEW view_1_tab2_195
+DROP VIEW IF EXISTS view_1_tab2_195 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_195
+DROP VIEW IF EXISTS view_2_tab2_195 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_195
+DROP VIEW IF EXISTS view_3_tab2_195 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21648,13 +21648,13 @@ SELECT pk FROM tab3 WHERE col4 = 27.89
 ----
 
 statement ok
-DROP VIEW view_1_tab3_195
+DROP VIEW IF EXISTS view_1_tab3_195 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_195
+DROP VIEW IF EXISTS view_2_tab3_195 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_195
+DROP VIEW IF EXISTS view_3_tab3_195 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21740,13 +21740,13 @@ SELECT pk FROM tab4 WHERE col4 = 27.89
 ----
 
 statement ok
-DROP VIEW view_1_tab4_195
+DROP VIEW IF EXISTS view_1_tab4_195 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_195
+DROP VIEW IF EXISTS view_2_tab4_195 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_195
+DROP VIEW IF EXISTS view_3_tab4_195 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21865,13 +21865,13 @@ SELECT pk FROM tab0 WHERE col0 > 34 AND ((col3 > 29) OR col4 > 73.13) AND (((col
 9
 
 statement ok
-DROP VIEW view_1_tab0_196
+DROP VIEW IF EXISTS view_1_tab0_196 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_196
+DROP VIEW IF EXISTS view_2_tab0_196 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_196
+DROP VIEW IF EXISTS view_3_tab0_196 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21990,13 +21990,13 @@ SELECT pk FROM tab1 WHERE col0 > 34 AND ((col3 > 29) OR col4 > 73.13) AND (((col
 9
 
 statement ok
-DROP VIEW view_1_tab1_196
+DROP VIEW IF EXISTS view_1_tab1_196 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_196
+DROP VIEW IF EXISTS view_2_tab1_196 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_196
+DROP VIEW IF EXISTS view_3_tab1_196 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22115,13 +22115,13 @@ SELECT pk FROM tab2 WHERE col0 > 34 AND ((col3 > 29) OR col4 > 73.13) AND (((col
 9
 
 statement ok
-DROP VIEW view_1_tab2_196
+DROP VIEW IF EXISTS view_1_tab2_196 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_196
+DROP VIEW IF EXISTS view_2_tab2_196 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_196
+DROP VIEW IF EXISTS view_3_tab2_196 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22240,13 +22240,13 @@ SELECT pk FROM tab3 WHERE col0 > 34 AND ((col3 > 29) OR col4 > 73.13) AND (((col
 9
 
 statement ok
-DROP VIEW view_1_tab3_196
+DROP VIEW IF EXISTS view_1_tab3_196 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_196
+DROP VIEW IF EXISTS view_2_tab3_196 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_196
+DROP VIEW IF EXISTS view_3_tab3_196 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22365,13 +22365,13 @@ SELECT pk FROM tab4 WHERE col0 > 34 AND ((col3 > 29) OR col4 > 73.13) AND (((col
 9
 
 statement ok
-DROP VIEW view_1_tab4_196
+DROP VIEW IF EXISTS view_1_tab4_196 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_196
+DROP VIEW IF EXISTS view_2_tab4_196 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_196
+DROP VIEW IF EXISTS view_3_tab4_196 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22457,13 +22457,13 @@ SELECT pk FROM tab0 WHERE col0 > 99
 ----
 
 statement ok
-DROP VIEW view_1_tab0_197
+DROP VIEW IF EXISTS view_1_tab0_197 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_197
+DROP VIEW IF EXISTS view_2_tab0_197 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_197
+DROP VIEW IF EXISTS view_3_tab0_197 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22549,13 +22549,13 @@ SELECT pk FROM tab1 WHERE col0 > 99
 ----
 
 statement ok
-DROP VIEW view_1_tab1_197
+DROP VIEW IF EXISTS view_1_tab1_197 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_197
+DROP VIEW IF EXISTS view_2_tab1_197 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_197
+DROP VIEW IF EXISTS view_3_tab1_197 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22641,13 +22641,13 @@ SELECT pk FROM tab2 WHERE col0 > 99
 ----
 
 statement ok
-DROP VIEW view_1_tab2_197
+DROP VIEW IF EXISTS view_1_tab2_197 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_197
+DROP VIEW IF EXISTS view_2_tab2_197 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_197
+DROP VIEW IF EXISTS view_3_tab2_197 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22733,13 +22733,13 @@ SELECT pk FROM tab3 WHERE col0 > 99
 ----
 
 statement ok
-DROP VIEW view_1_tab3_197
+DROP VIEW IF EXISTS view_1_tab3_197 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_197
+DROP VIEW IF EXISTS view_2_tab3_197 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_197
+DROP VIEW IF EXISTS view_3_tab3_197 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22825,13 +22825,13 @@ SELECT pk FROM tab4 WHERE col0 > 99
 ----
 
 statement ok
-DROP VIEW view_1_tab4_197
+DROP VIEW IF EXISTS view_1_tab4_197 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_197
+DROP VIEW IF EXISTS view_2_tab4_197 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_197
+DROP VIEW IF EXISTS view_3_tab4_197 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22917,13 +22917,13 @@ SELECT pk FROM tab0 WHERE col4 IN (72.21,41.70,5.75)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_198
+DROP VIEW IF EXISTS view_1_tab0_198 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_198
+DROP VIEW IF EXISTS view_2_tab0_198 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_198
+DROP VIEW IF EXISTS view_3_tab0_198 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23009,13 +23009,13 @@ SELECT pk FROM tab1 WHERE col4 IN (72.21,41.70,5.75)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_198
+DROP VIEW IF EXISTS view_1_tab1_198 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_198
+DROP VIEW IF EXISTS view_2_tab1_198 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_198
+DROP VIEW IF EXISTS view_3_tab1_198 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23101,13 +23101,13 @@ SELECT pk FROM tab2 WHERE col4 IN (72.21,41.70,5.75)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_198
+DROP VIEW IF EXISTS view_1_tab2_198 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_198
+DROP VIEW IF EXISTS view_2_tab2_198 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_198
+DROP VIEW IF EXISTS view_3_tab2_198 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23193,13 +23193,13 @@ SELECT pk FROM tab3 WHERE col4 IN (72.21,41.70,5.75)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_198
+DROP VIEW IF EXISTS view_1_tab3_198 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_198
+DROP VIEW IF EXISTS view_2_tab3_198 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_198
+DROP VIEW IF EXISTS view_3_tab3_198 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23285,13 +23285,13 @@ SELECT pk FROM tab4 WHERE col4 IN (72.21,41.70,5.75)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_198
+DROP VIEW IF EXISTS view_1_tab4_198 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_198
+DROP VIEW IF EXISTS view_2_tab4_198 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_198
+DROP VIEW IF EXISTS view_3_tab4_198 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23377,13 +23377,13 @@ SELECT pk FROM tab0 WHERE col3 IN (99,74,47,0,63) AND col3 < 45 AND (col4 <= 51.
 ----
 
 statement ok
-DROP VIEW view_1_tab0_199
+DROP VIEW IF EXISTS view_1_tab0_199 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_199
+DROP VIEW IF EXISTS view_2_tab0_199 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_199
+DROP VIEW IF EXISTS view_3_tab0_199 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23469,13 +23469,13 @@ SELECT pk FROM tab1 WHERE col3 IN (99,74,47,0,63) AND col3 < 45 AND (col4 <= 51.
 ----
 
 statement ok
-DROP VIEW view_1_tab1_199
+DROP VIEW IF EXISTS view_1_tab1_199 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_199
+DROP VIEW IF EXISTS view_2_tab1_199 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_199
+DROP VIEW IF EXISTS view_3_tab1_199 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23561,13 +23561,13 @@ SELECT pk FROM tab2 WHERE col3 IN (99,74,47,0,63) AND col3 < 45 AND (col4 <= 51.
 ----
 
 statement ok
-DROP VIEW view_1_tab2_199
+DROP VIEW IF EXISTS view_1_tab2_199 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_199
+DROP VIEW IF EXISTS view_2_tab2_199 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_199
+DROP VIEW IF EXISTS view_3_tab2_199 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23653,13 +23653,13 @@ SELECT pk FROM tab3 WHERE col3 IN (99,74,47,0,63) AND col3 < 45 AND (col4 <= 51.
 ----
 
 statement ok
-DROP VIEW view_1_tab3_199
+DROP VIEW IF EXISTS view_1_tab3_199 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_199
+DROP VIEW IF EXISTS view_2_tab3_199 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_199
+DROP VIEW IF EXISTS view_3_tab3_199 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23745,13 +23745,13 @@ SELECT pk FROM tab4 WHERE col3 IN (99,74,47,0,63) AND col3 < 45 AND (col4 <= 51.
 ----
 
 statement ok
-DROP VIEW view_1_tab4_199
+DROP VIEW IF EXISTS view_1_tab4_199 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_199
+DROP VIEW IF EXISTS view_2_tab4_199 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_199
+DROP VIEW IF EXISTS view_3_tab4_199 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23844,13 +23844,13 @@ SELECT pk FROM tab0 WHERE (col1 > 21.49)
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab0_200
+DROP VIEW IF EXISTS view_1_tab0_200 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_200
+DROP VIEW IF EXISTS view_2_tab0_200 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_200
+DROP VIEW IF EXISTS view_3_tab0_200 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23943,13 +23943,13 @@ SELECT pk FROM tab1 WHERE (col1 > 21.49)
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab1_200
+DROP VIEW IF EXISTS view_1_tab1_200 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_200
+DROP VIEW IF EXISTS view_2_tab1_200 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_200
+DROP VIEW IF EXISTS view_3_tab1_200 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24042,13 +24042,13 @@ SELECT pk FROM tab2 WHERE (col1 > 21.49)
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab2_200
+DROP VIEW IF EXISTS view_1_tab2_200 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_200
+DROP VIEW IF EXISTS view_2_tab2_200 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_200
+DROP VIEW IF EXISTS view_3_tab2_200 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24141,13 +24141,13 @@ SELECT pk FROM tab3 WHERE (col1 > 21.49)
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab3_200
+DROP VIEW IF EXISTS view_1_tab3_200 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_200
+DROP VIEW IF EXISTS view_2_tab3_200 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_200
+DROP VIEW IF EXISTS view_3_tab3_200 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24240,13 +24240,13 @@ SELECT pk FROM tab4 WHERE (col1 > 21.49)
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab4_200
+DROP VIEW IF EXISTS view_1_tab4_200 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_200
+DROP VIEW IF EXISTS view_2_tab4_200 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_200
+DROP VIEW IF EXISTS view_3_tab4_200 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24335,13 +24335,13 @@ SELECT pk FROM tab0 WHERE col3 > 3 OR (((col3 BETWEEN 22 AND 86) AND (col1 > 30.
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_201
+DROP VIEW IF EXISTS view_1_tab0_201 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_201
+DROP VIEW IF EXISTS view_2_tab0_201 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_201
+DROP VIEW IF EXISTS view_3_tab0_201 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24430,13 +24430,13 @@ SELECT pk FROM tab1 WHERE col3 > 3 OR (((col3 BETWEEN 22 AND 86) AND (col1 > 30.
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_201
+DROP VIEW IF EXISTS view_1_tab1_201 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_201
+DROP VIEW IF EXISTS view_2_tab1_201 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_201
+DROP VIEW IF EXISTS view_3_tab1_201 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24525,13 +24525,13 @@ SELECT pk FROM tab2 WHERE col3 > 3 OR (((col3 BETWEEN 22 AND 86) AND (col1 > 30.
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_201
+DROP VIEW IF EXISTS view_1_tab2_201 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_201
+DROP VIEW IF EXISTS view_2_tab2_201 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_201
+DROP VIEW IF EXISTS view_3_tab2_201 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24620,13 +24620,13 @@ SELECT pk FROM tab3 WHERE col3 > 3 OR (((col3 BETWEEN 22 AND 86) AND (col1 > 30.
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_201
+DROP VIEW IF EXISTS view_1_tab3_201 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_201
+DROP VIEW IF EXISTS view_2_tab3_201 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_201
+DROP VIEW IF EXISTS view_3_tab3_201 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24715,13 +24715,13 @@ SELECT pk FROM tab4 WHERE col3 > 3 OR (((col3 BETWEEN 22 AND 86) AND (col1 > 30.
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_201
+DROP VIEW IF EXISTS view_1_tab4_201 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_201
+DROP VIEW IF EXISTS view_2_tab4_201 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_201
+DROP VIEW IF EXISTS view_3_tab4_201 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24814,13 +24814,13 @@ SELECT pk FROM tab0 WHERE (col4 > 18.90 OR col0 <= 25)
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab0_202
+DROP VIEW IF EXISTS view_1_tab0_202 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_202
+DROP VIEW IF EXISTS view_2_tab0_202 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_202
+DROP VIEW IF EXISTS view_3_tab0_202 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24913,13 +24913,13 @@ SELECT pk FROM tab1 WHERE (col4 > 18.90 OR col0 <= 25)
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab1_202
+DROP VIEW IF EXISTS view_1_tab1_202 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_202
+DROP VIEW IF EXISTS view_2_tab1_202 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_202
+DROP VIEW IF EXISTS view_3_tab1_202 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25012,13 +25012,13 @@ SELECT pk FROM tab2 WHERE (col4 > 18.90 OR col0 <= 25)
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab2_202
+DROP VIEW IF EXISTS view_1_tab2_202 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_202
+DROP VIEW IF EXISTS view_2_tab2_202 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_202
+DROP VIEW IF EXISTS view_3_tab2_202 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25111,13 +25111,13 @@ SELECT pk FROM tab3 WHERE (col4 > 18.90 OR col0 <= 25)
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab3_202
+DROP VIEW IF EXISTS view_1_tab3_202 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_202
+DROP VIEW IF EXISTS view_2_tab3_202 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_202
+DROP VIEW IF EXISTS view_3_tab3_202 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25210,13 +25210,13 @@ SELECT pk FROM tab4 WHERE (col4 > 18.90 OR col0 <= 25)
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab4_202
+DROP VIEW IF EXISTS view_1_tab4_202 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_202
+DROP VIEW IF EXISTS view_2_tab4_202 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_202
+DROP VIEW IF EXISTS view_3_tab4_202 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25334,13 +25334,13 @@ SELECT pk FROM tab0 WHERE ((col3 IN (68,13,21,16,87) OR (col1 = 12.25) AND col1 
 8
 
 statement ok
-DROP VIEW view_1_tab0_203
+DROP VIEW IF EXISTS view_1_tab0_203 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_203
+DROP VIEW IF EXISTS view_2_tab0_203 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_203
+DROP VIEW IF EXISTS view_3_tab0_203 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25458,13 +25458,13 @@ SELECT pk FROM tab1 WHERE ((col3 IN (68,13,21,16,87) OR (col1 = 12.25) AND col1 
 8
 
 statement ok
-DROP VIEW view_1_tab1_203
+DROP VIEW IF EXISTS view_1_tab1_203 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_203
+DROP VIEW IF EXISTS view_2_tab1_203 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_203
+DROP VIEW IF EXISTS view_3_tab1_203 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25582,13 +25582,13 @@ SELECT pk FROM tab2 WHERE ((col3 IN (68,13,21,16,87) OR (col1 = 12.25) AND col1 
 8
 
 statement ok
-DROP VIEW view_1_tab2_203
+DROP VIEW IF EXISTS view_1_tab2_203 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_203
+DROP VIEW IF EXISTS view_2_tab2_203 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_203
+DROP VIEW IF EXISTS view_3_tab2_203 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25706,13 +25706,13 @@ SELECT pk FROM tab3 WHERE ((col3 IN (68,13,21,16,87) OR (col1 = 12.25) AND col1 
 8
 
 statement ok
-DROP VIEW view_1_tab3_203
+DROP VIEW IF EXISTS view_1_tab3_203 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_203
+DROP VIEW IF EXISTS view_2_tab3_203 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_203
+DROP VIEW IF EXISTS view_3_tab3_203 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25830,13 +25830,13 @@ SELECT pk FROM tab4 WHERE ((col3 IN (68,13,21,16,87) OR (col1 = 12.25) AND col1 
 8
 
 statement ok
-DROP VIEW view_1_tab4_203
+DROP VIEW IF EXISTS view_1_tab4_203 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_203
+DROP VIEW IF EXISTS view_2_tab4_203 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_203
+DROP VIEW IF EXISTS view_3_tab4_203 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25922,13 +25922,13 @@ SELECT pk FROM tab0 WHERE (((col3 < 34 AND (col3 > 22))) AND ((col0 > 52 AND col
 ----
 
 statement ok
-DROP VIEW view_1_tab0_205
+DROP VIEW IF EXISTS view_1_tab0_205 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_205
+DROP VIEW IF EXISTS view_2_tab0_205 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_205
+DROP VIEW IF EXISTS view_3_tab0_205 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26014,13 +26014,13 @@ SELECT pk FROM tab1 WHERE (((col3 < 34 AND (col3 > 22))) AND ((col0 > 52 AND col
 ----
 
 statement ok
-DROP VIEW view_1_tab1_205
+DROP VIEW IF EXISTS view_1_tab1_205 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_205
+DROP VIEW IF EXISTS view_2_tab1_205 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_205
+DROP VIEW IF EXISTS view_3_tab1_205 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26106,13 +26106,13 @@ SELECT pk FROM tab2 WHERE (((col3 < 34 AND (col3 > 22))) AND ((col0 > 52 AND col
 ----
 
 statement ok
-DROP VIEW view_1_tab2_205
+DROP VIEW IF EXISTS view_1_tab2_205 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_205
+DROP VIEW IF EXISTS view_2_tab2_205 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_205
+DROP VIEW IF EXISTS view_3_tab2_205 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26198,13 +26198,13 @@ SELECT pk FROM tab3 WHERE (((col3 < 34 AND (col3 > 22))) AND ((col0 > 52 AND col
 ----
 
 statement ok
-DROP VIEW view_1_tab3_205
+DROP VIEW IF EXISTS view_1_tab3_205 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_205
+DROP VIEW IF EXISTS view_2_tab3_205 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_205
+DROP VIEW IF EXISTS view_3_tab3_205 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26290,13 +26290,13 @@ SELECT pk FROM tab4 WHERE (((col3 < 34 AND (col3 > 22))) AND ((col0 > 52 AND col
 ----
 
 statement ok
-DROP VIEW view_1_tab4_205
+DROP VIEW IF EXISTS view_1_tab4_205 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_205
+DROP VIEW IF EXISTS view_2_tab4_205 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_205
+DROP VIEW IF EXISTS view_3_tab4_205 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26416,13 +26416,13 @@ SELECT pk FROM tab0 WHERE col1 > 54.2
 9
 
 statement ok
-DROP VIEW view_1_tab0_206
+DROP VIEW IF EXISTS view_1_tab0_206 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_206
+DROP VIEW IF EXISTS view_2_tab0_206 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_206
+DROP VIEW IF EXISTS view_3_tab0_206 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26542,13 +26542,13 @@ SELECT pk FROM tab1 WHERE col1 > 54.2
 9
 
 statement ok
-DROP VIEW view_1_tab1_206
+DROP VIEW IF EXISTS view_1_tab1_206 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_206
+DROP VIEW IF EXISTS view_2_tab1_206 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_206
+DROP VIEW IF EXISTS view_3_tab1_206 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26668,13 +26668,13 @@ SELECT pk FROM tab2 WHERE col1 > 54.2
 9
 
 statement ok
-DROP VIEW view_1_tab2_206
+DROP VIEW IF EXISTS view_1_tab2_206 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_206
+DROP VIEW IF EXISTS view_2_tab2_206 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_206
+DROP VIEW IF EXISTS view_3_tab2_206 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26794,13 +26794,13 @@ SELECT pk FROM tab3 WHERE col1 > 54.2
 9
 
 statement ok
-DROP VIEW view_1_tab3_206
+DROP VIEW IF EXISTS view_1_tab3_206 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_206
+DROP VIEW IF EXISTS view_2_tab3_206 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_206
+DROP VIEW IF EXISTS view_3_tab3_206 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26920,13 +26920,13 @@ SELECT pk FROM tab4 WHERE col1 > 54.2
 9
 
 statement ok
-DROP VIEW view_1_tab4_206
+DROP VIEW IF EXISTS view_1_tab4_206 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_206
+DROP VIEW IF EXISTS view_2_tab4_206 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_206
+DROP VIEW IF EXISTS view_3_tab4_206 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27012,13 +27012,13 @@ SELECT pk FROM tab0 WHERE col0 <= 29 AND ((col3 < 44)) AND (col0 >= 26)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_207
+DROP VIEW IF EXISTS view_1_tab0_207 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_207
+DROP VIEW IF EXISTS view_2_tab0_207 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_207
+DROP VIEW IF EXISTS view_3_tab0_207 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27104,13 +27104,13 @@ SELECT pk FROM tab1 WHERE col0 <= 29 AND ((col3 < 44)) AND (col0 >= 26)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_207
+DROP VIEW IF EXISTS view_1_tab1_207 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_207
+DROP VIEW IF EXISTS view_2_tab1_207 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_207
+DROP VIEW IF EXISTS view_3_tab1_207 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27196,13 +27196,13 @@ SELECT pk FROM tab2 WHERE col0 <= 29 AND ((col3 < 44)) AND (col0 >= 26)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_207
+DROP VIEW IF EXISTS view_1_tab2_207 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_207
+DROP VIEW IF EXISTS view_2_tab2_207 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_207
+DROP VIEW IF EXISTS view_3_tab2_207 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27288,13 +27288,13 @@ SELECT pk FROM tab3 WHERE col0 <= 29 AND ((col3 < 44)) AND (col0 >= 26)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_207
+DROP VIEW IF EXISTS view_1_tab3_207 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_207
+DROP VIEW IF EXISTS view_2_tab3_207 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_207
+DROP VIEW IF EXISTS view_3_tab3_207 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27380,13 +27380,13 @@ SELECT pk FROM tab4 WHERE col0 <= 29 AND ((col3 < 44)) AND (col0 >= 26)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_207
+DROP VIEW IF EXISTS view_1_tab4_207 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_207
+DROP VIEW IF EXISTS view_2_tab4_207 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_207
+DROP VIEW IF EXISTS view_3_tab4_207 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27472,13 +27472,13 @@ SELECT pk FROM tab0 WHERE col0 = 59
 ----
 
 statement ok
-DROP VIEW view_1_tab0_208
+DROP VIEW IF EXISTS view_1_tab0_208 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_208
+DROP VIEW IF EXISTS view_2_tab0_208 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_208
+DROP VIEW IF EXISTS view_3_tab0_208 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27564,13 +27564,13 @@ SELECT pk FROM tab1 WHERE col0 = 59
 ----
 
 statement ok
-DROP VIEW view_1_tab1_208
+DROP VIEW IF EXISTS view_1_tab1_208 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_208
+DROP VIEW IF EXISTS view_2_tab1_208 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_208
+DROP VIEW IF EXISTS view_3_tab1_208 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27656,13 +27656,13 @@ SELECT pk FROM tab2 WHERE col0 = 59
 ----
 
 statement ok
-DROP VIEW view_1_tab2_208
+DROP VIEW IF EXISTS view_1_tab2_208 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_208
+DROP VIEW IF EXISTS view_2_tab2_208 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_208
+DROP VIEW IF EXISTS view_3_tab2_208 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27748,13 +27748,13 @@ SELECT pk FROM tab3 WHERE col0 = 59
 ----
 
 statement ok
-DROP VIEW view_1_tab3_208
+DROP VIEW IF EXISTS view_1_tab3_208 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_208
+DROP VIEW IF EXISTS view_2_tab3_208 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_208
+DROP VIEW IF EXISTS view_3_tab3_208 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27840,13 +27840,13 @@ SELECT pk FROM tab4 WHERE col0 = 59
 ----
 
 statement ok
-DROP VIEW view_1_tab4_208
+DROP VIEW IF EXISTS view_1_tab4_208 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_208
+DROP VIEW IF EXISTS view_2_tab4_208 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_208
+DROP VIEW IF EXISTS view_3_tab4_208 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27964,13 +27964,13 @@ SELECT pk FROM tab0 WHERE col4 > 11.79
 9
 
 statement ok
-DROP VIEW view_1_tab0_209
+DROP VIEW IF EXISTS view_1_tab0_209 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_209
+DROP VIEW IF EXISTS view_2_tab0_209 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_209
+DROP VIEW IF EXISTS view_3_tab0_209 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28088,13 +28088,13 @@ SELECT pk FROM tab1 WHERE col4 > 11.79
 9
 
 statement ok
-DROP VIEW view_1_tab1_209
+DROP VIEW IF EXISTS view_1_tab1_209 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_209
+DROP VIEW IF EXISTS view_2_tab1_209 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_209
+DROP VIEW IF EXISTS view_3_tab1_209 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28212,13 +28212,13 @@ SELECT pk FROM tab2 WHERE col4 > 11.79
 9
 
 statement ok
-DROP VIEW view_1_tab2_209
+DROP VIEW IF EXISTS view_1_tab2_209 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_209
+DROP VIEW IF EXISTS view_2_tab2_209 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_209
+DROP VIEW IF EXISTS view_3_tab2_209 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28336,13 +28336,13 @@ SELECT pk FROM tab3 WHERE col4 > 11.79
 9
 
 statement ok
-DROP VIEW view_1_tab3_209
+DROP VIEW IF EXISTS view_1_tab3_209 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_209
+DROP VIEW IF EXISTS view_2_tab3_209 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_209
+DROP VIEW IF EXISTS view_3_tab3_209 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28460,13 +28460,13 @@ SELECT pk FROM tab4 WHERE col4 > 11.79
 9
 
 statement ok
-DROP VIEW view_1_tab4_209
+DROP VIEW IF EXISTS view_1_tab4_209 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_209
+DROP VIEW IF EXISTS view_2_tab4_209 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_209
+DROP VIEW IF EXISTS view_3_tab4_209 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28559,13 +28559,13 @@ SELECT pk FROM tab0 WHERE col0 > 3
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab0_210
+DROP VIEW IF EXISTS view_1_tab0_210 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_210
+DROP VIEW IF EXISTS view_2_tab0_210 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_210
+DROP VIEW IF EXISTS view_3_tab0_210 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28658,13 +28658,13 @@ SELECT pk FROM tab1 WHERE col0 > 3
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab1_210
+DROP VIEW IF EXISTS view_1_tab1_210 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_210
+DROP VIEW IF EXISTS view_2_tab1_210 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_210
+DROP VIEW IF EXISTS view_3_tab1_210 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28757,13 +28757,13 @@ SELECT pk FROM tab2 WHERE col0 > 3
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab2_210
+DROP VIEW IF EXISTS view_1_tab2_210 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_210
+DROP VIEW IF EXISTS view_2_tab2_210 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_210
+DROP VIEW IF EXISTS view_3_tab2_210 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28856,13 +28856,13 @@ SELECT pk FROM tab3 WHERE col0 > 3
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab3_210
+DROP VIEW IF EXISTS view_1_tab3_210 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_210
+DROP VIEW IF EXISTS view_2_tab3_210 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_210
+DROP VIEW IF EXISTS view_3_tab3_210 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28955,13 +28955,13 @@ SELECT pk FROM tab4 WHERE col0 > 3
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab4_210
+DROP VIEW IF EXISTS view_1_tab4_210 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_210
+DROP VIEW IF EXISTS view_2_tab4_210 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_210
+DROP VIEW IF EXISTS view_3_tab4_210 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29054,13 +29054,13 @@ SELECT pk FROM tab0 WHERE col3 >= 44
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab0_211
+DROP VIEW IF EXISTS view_1_tab0_211 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_211
+DROP VIEW IF EXISTS view_2_tab0_211 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_211
+DROP VIEW IF EXISTS view_3_tab0_211 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29153,13 +29153,13 @@ SELECT pk FROM tab1 WHERE col3 >= 44
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab1_211
+DROP VIEW IF EXISTS view_1_tab1_211 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_211
+DROP VIEW IF EXISTS view_2_tab1_211 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_211
+DROP VIEW IF EXISTS view_3_tab1_211 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29252,13 +29252,13 @@ SELECT pk FROM tab2 WHERE col3 >= 44
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab2_211
+DROP VIEW IF EXISTS view_1_tab2_211 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_211
+DROP VIEW IF EXISTS view_2_tab2_211 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_211
+DROP VIEW IF EXISTS view_3_tab2_211 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29351,13 +29351,13 @@ SELECT pk FROM tab3 WHERE col3 >= 44
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab3_211
+DROP VIEW IF EXISTS view_1_tab3_211 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_211
+DROP VIEW IF EXISTS view_2_tab3_211 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_211
+DROP VIEW IF EXISTS view_3_tab3_211 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29450,13 +29450,13 @@ SELECT pk FROM tab4 WHERE col3 >= 44
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab4_211
+DROP VIEW IF EXISTS view_1_tab4_211 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_211
+DROP VIEW IF EXISTS view_2_tab4_211 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_211
+DROP VIEW IF EXISTS view_3_tab4_211 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29545,13 +29545,13 @@ SELECT pk FROM tab0 WHERE (col3 > 9)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_212
+DROP VIEW IF EXISTS view_1_tab0_212 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_212
+DROP VIEW IF EXISTS view_2_tab0_212 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_212
+DROP VIEW IF EXISTS view_3_tab0_212 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29640,13 +29640,13 @@ SELECT pk FROM tab1 WHERE (col3 > 9)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_212
+DROP VIEW IF EXISTS view_1_tab1_212 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_212
+DROP VIEW IF EXISTS view_2_tab1_212 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_212
+DROP VIEW IF EXISTS view_3_tab1_212 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29735,13 +29735,13 @@ SELECT pk FROM tab2 WHERE (col3 > 9)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_212
+DROP VIEW IF EXISTS view_1_tab2_212 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_212
+DROP VIEW IF EXISTS view_2_tab2_212 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_212
+DROP VIEW IF EXISTS view_3_tab2_212 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29830,13 +29830,13 @@ SELECT pk FROM tab3 WHERE (col3 > 9)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_212
+DROP VIEW IF EXISTS view_1_tab3_212 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_212
+DROP VIEW IF EXISTS view_2_tab3_212 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_212
+DROP VIEW IF EXISTS view_3_tab3_212 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29925,13 +29925,13 @@ SELECT pk FROM tab4 WHERE (col3 > 9)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_212
+DROP VIEW IF EXISTS view_1_tab4_212 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_212
+DROP VIEW IF EXISTS view_2_tab4_212 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_212
+DROP VIEW IF EXISTS view_3_tab4_212 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30024,13 +30024,13 @@ SELECT pk FROM tab0 WHERE (col0 < 7)
 6
 
 statement ok
-DROP VIEW view_1_tab0_213
+DROP VIEW IF EXISTS view_1_tab0_213 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_213
+DROP VIEW IF EXISTS view_2_tab0_213 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_213
+DROP VIEW IF EXISTS view_3_tab0_213 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30123,13 +30123,13 @@ SELECT pk FROM tab1 WHERE (col0 < 7)
 6
 
 statement ok
-DROP VIEW view_1_tab1_213
+DROP VIEW IF EXISTS view_1_tab1_213 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_213
+DROP VIEW IF EXISTS view_2_tab1_213 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_213
+DROP VIEW IF EXISTS view_3_tab1_213 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30222,13 +30222,13 @@ SELECT pk FROM tab2 WHERE (col0 < 7)
 6
 
 statement ok
-DROP VIEW view_1_tab2_213
+DROP VIEW IF EXISTS view_1_tab2_213 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_213
+DROP VIEW IF EXISTS view_2_tab2_213 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_213
+DROP VIEW IF EXISTS view_3_tab2_213 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30321,13 +30321,13 @@ SELECT pk FROM tab3 WHERE (col0 < 7)
 6
 
 statement ok
-DROP VIEW view_1_tab3_213
+DROP VIEW IF EXISTS view_1_tab3_213 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_213
+DROP VIEW IF EXISTS view_2_tab3_213 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_213
+DROP VIEW IF EXISTS view_3_tab3_213 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30420,13 +30420,13 @@ SELECT pk FROM tab4 WHERE (col0 < 7)
 6
 
 statement ok
-DROP VIEW view_1_tab4_213
+DROP VIEW IF EXISTS view_1_tab4_213 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_213
+DROP VIEW IF EXISTS view_2_tab4_213 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_213
+DROP VIEW IF EXISTS view_3_tab4_213 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30519,13 +30519,13 @@ SELECT pk FROM tab0 WHERE col0 > 18
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab0_214
+DROP VIEW IF EXISTS view_1_tab0_214 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_214
+DROP VIEW IF EXISTS view_2_tab0_214 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_214
+DROP VIEW IF EXISTS view_3_tab0_214 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30618,13 +30618,13 @@ SELECT pk FROM tab1 WHERE col0 > 18
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab1_214
+DROP VIEW IF EXISTS view_1_tab1_214 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_214
+DROP VIEW IF EXISTS view_2_tab1_214 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_214
+DROP VIEW IF EXISTS view_3_tab1_214 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30717,13 +30717,13 @@ SELECT pk FROM tab2 WHERE col0 > 18
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab2_214
+DROP VIEW IF EXISTS view_1_tab2_214 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_214
+DROP VIEW IF EXISTS view_2_tab2_214 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_214
+DROP VIEW IF EXISTS view_3_tab2_214 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30816,13 +30816,13 @@ SELECT pk FROM tab3 WHERE col0 > 18
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab3_214
+DROP VIEW IF EXISTS view_1_tab3_214 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_214
+DROP VIEW IF EXISTS view_2_tab3_214 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_214
+DROP VIEW IF EXISTS view_3_tab3_214 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30915,13 +30915,13 @@ SELECT pk FROM tab4 WHERE col0 > 18
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab4_214
+DROP VIEW IF EXISTS view_1_tab4_214 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_214
+DROP VIEW IF EXISTS view_2_tab4_214 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_214
+DROP VIEW IF EXISTS view_3_tab4_214 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31007,13 +31007,13 @@ SELECT pk FROM tab0 WHERE col0 = 15
 ----
 
 statement ok
-DROP VIEW view_1_tab0_215
+DROP VIEW IF EXISTS view_1_tab0_215 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_215
+DROP VIEW IF EXISTS view_2_tab0_215 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_215
+DROP VIEW IF EXISTS view_3_tab0_215 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31099,13 +31099,13 @@ SELECT pk FROM tab1 WHERE col0 = 15
 ----
 
 statement ok
-DROP VIEW view_1_tab1_215
+DROP VIEW IF EXISTS view_1_tab1_215 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_215
+DROP VIEW IF EXISTS view_2_tab1_215 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_215
+DROP VIEW IF EXISTS view_3_tab1_215 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31191,13 +31191,13 @@ SELECT pk FROM tab2 WHERE col0 = 15
 ----
 
 statement ok
-DROP VIEW view_1_tab2_215
+DROP VIEW IF EXISTS view_1_tab2_215 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_215
+DROP VIEW IF EXISTS view_2_tab2_215 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_215
+DROP VIEW IF EXISTS view_3_tab2_215 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31283,13 +31283,13 @@ SELECT pk FROM tab3 WHERE col0 = 15
 ----
 
 statement ok
-DROP VIEW view_1_tab3_215
+DROP VIEW IF EXISTS view_1_tab3_215 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_215
+DROP VIEW IF EXISTS view_2_tab3_215 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_215
+DROP VIEW IF EXISTS view_3_tab3_215 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31375,13 +31375,13 @@ SELECT pk FROM tab4 WHERE col0 = 15
 ----
 
 statement ok
-DROP VIEW view_1_tab4_215
+DROP VIEW IF EXISTS view_1_tab4_215 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_215
+DROP VIEW IF EXISTS view_2_tab4_215 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_215
+DROP VIEW IF EXISTS view_3_tab4_215 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31474,13 +31474,13 @@ SELECT pk FROM tab0 WHERE ((col3 >= 40) OR col3 > 65 OR col3 >= 21 AND col4 > 41
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab0_216
+DROP VIEW IF EXISTS view_1_tab0_216 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_216
+DROP VIEW IF EXISTS view_2_tab0_216 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_216
+DROP VIEW IF EXISTS view_3_tab0_216 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31573,13 +31573,13 @@ SELECT pk FROM tab1 WHERE ((col3 >= 40) OR col3 > 65 OR col3 >= 21 AND col4 > 41
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab1_216
+DROP VIEW IF EXISTS view_1_tab1_216 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_216
+DROP VIEW IF EXISTS view_2_tab1_216 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_216
+DROP VIEW IF EXISTS view_3_tab1_216 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31672,13 +31672,13 @@ SELECT pk FROM tab2 WHERE ((col3 >= 40) OR col3 > 65 OR col3 >= 21 AND col4 > 41
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab2_216
+DROP VIEW IF EXISTS view_1_tab2_216 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_216
+DROP VIEW IF EXISTS view_2_tab2_216 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_216
+DROP VIEW IF EXISTS view_3_tab2_216 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31771,13 +31771,13 @@ SELECT pk FROM tab3 WHERE ((col3 >= 40) OR col3 > 65 OR col3 >= 21 AND col4 > 41
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab3_216
+DROP VIEW IF EXISTS view_1_tab3_216 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_216
+DROP VIEW IF EXISTS view_2_tab3_216 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_216
+DROP VIEW IF EXISTS view_3_tab3_216 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31870,13 +31870,13 @@ SELECT pk FROM tab4 WHERE ((col3 >= 40) OR col3 > 65 OR col3 >= 21 AND col4 > 41
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab4_216
+DROP VIEW IF EXISTS view_1_tab4_216 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_216
+DROP VIEW IF EXISTS view_2_tab4_216 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_216
+DROP VIEW IF EXISTS view_3_tab4_216 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31994,13 +31994,13 @@ SELECT pk FROM tab0 WHERE col3 < 53 OR (col3 < 53 AND col4 > 90.43 AND col4 <= 4
 8
 
 statement ok
-DROP VIEW view_1_tab0_217
+DROP VIEW IF EXISTS view_1_tab0_217 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_217
+DROP VIEW IF EXISTS view_2_tab0_217 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_217
+DROP VIEW IF EXISTS view_3_tab0_217 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32118,13 +32118,13 @@ SELECT pk FROM tab1 WHERE col3 < 53 OR (col3 < 53 AND col4 > 90.43 AND col4 <= 4
 8
 
 statement ok
-DROP VIEW view_1_tab1_217
+DROP VIEW IF EXISTS view_1_tab1_217 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_217
+DROP VIEW IF EXISTS view_2_tab1_217 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_217
+DROP VIEW IF EXISTS view_3_tab1_217 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32242,13 +32242,13 @@ SELECT pk FROM tab2 WHERE col3 < 53 OR (col3 < 53 AND col4 > 90.43 AND col4 <= 4
 8
 
 statement ok
-DROP VIEW view_1_tab2_217
+DROP VIEW IF EXISTS view_1_tab2_217 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_217
+DROP VIEW IF EXISTS view_2_tab2_217 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_217
+DROP VIEW IF EXISTS view_3_tab2_217 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32366,13 +32366,13 @@ SELECT pk FROM tab3 WHERE col3 < 53 OR (col3 < 53 AND col4 > 90.43 AND col4 <= 4
 8
 
 statement ok
-DROP VIEW view_1_tab3_217
+DROP VIEW IF EXISTS view_1_tab3_217 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_217
+DROP VIEW IF EXISTS view_2_tab3_217 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_217
+DROP VIEW IF EXISTS view_3_tab3_217 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32490,13 +32490,13 @@ SELECT pk FROM tab4 WHERE col3 < 53 OR (col3 < 53 AND col4 > 90.43 AND col4 <= 4
 8
 
 statement ok
-DROP VIEW view_1_tab4_217
+DROP VIEW IF EXISTS view_1_tab4_217 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_217
+DROP VIEW IF EXISTS view_2_tab4_217 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_217
+DROP VIEW IF EXISTS view_3_tab4_217 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32615,13 +32615,13 @@ SELECT pk FROM tab0 WHERE (((col1 > 48.37)))
 9
 
 statement ok
-DROP VIEW view_1_tab0_218
+DROP VIEW IF EXISTS view_1_tab0_218 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_218
+DROP VIEW IF EXISTS view_2_tab0_218 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_218
+DROP VIEW IF EXISTS view_3_tab0_218 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32740,13 +32740,13 @@ SELECT pk FROM tab1 WHERE (((col1 > 48.37)))
 9
 
 statement ok
-DROP VIEW view_1_tab1_218
+DROP VIEW IF EXISTS view_1_tab1_218 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_218
+DROP VIEW IF EXISTS view_2_tab1_218 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_218
+DROP VIEW IF EXISTS view_3_tab1_218 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32865,13 +32865,13 @@ SELECT pk FROM tab2 WHERE (((col1 > 48.37)))
 9
 
 statement ok
-DROP VIEW view_1_tab2_218
+DROP VIEW IF EXISTS view_1_tab2_218 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_218
+DROP VIEW IF EXISTS view_2_tab2_218 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_218
+DROP VIEW IF EXISTS view_3_tab2_218 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32990,13 +32990,13 @@ SELECT pk FROM tab3 WHERE (((col1 > 48.37)))
 9
 
 statement ok
-DROP VIEW view_1_tab3_218
+DROP VIEW IF EXISTS view_1_tab3_218 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_218
+DROP VIEW IF EXISTS view_2_tab3_218 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_218
+DROP VIEW IF EXISTS view_3_tab3_218 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33115,13 +33115,13 @@ SELECT pk FROM tab4 WHERE (((col1 > 48.37)))
 9
 
 statement ok
-DROP VIEW view_1_tab4_218
+DROP VIEW IF EXISTS view_1_tab4_218 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_218
+DROP VIEW IF EXISTS view_2_tab4_218 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_218
+DROP VIEW IF EXISTS view_3_tab4_218 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33240,13 +33240,13 @@ SELECT pk FROM tab0 WHERE col0 > 34
 9
 
 statement ok
-DROP VIEW view_1_tab0_219
+DROP VIEW IF EXISTS view_1_tab0_219 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_219
+DROP VIEW IF EXISTS view_2_tab0_219 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_219
+DROP VIEW IF EXISTS view_3_tab0_219 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33365,13 +33365,13 @@ SELECT pk FROM tab1 WHERE col0 > 34
 9
 
 statement ok
-DROP VIEW view_1_tab1_219
+DROP VIEW IF EXISTS view_1_tab1_219 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_219
+DROP VIEW IF EXISTS view_2_tab1_219 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_219
+DROP VIEW IF EXISTS view_3_tab1_219 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33490,13 +33490,13 @@ SELECT pk FROM tab2 WHERE col0 > 34
 9
 
 statement ok
-DROP VIEW view_1_tab2_219
+DROP VIEW IF EXISTS view_1_tab2_219 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_219
+DROP VIEW IF EXISTS view_2_tab2_219 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_219
+DROP VIEW IF EXISTS view_3_tab2_219 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33615,13 +33615,13 @@ SELECT pk FROM tab3 WHERE col0 > 34
 9
 
 statement ok
-DROP VIEW view_1_tab3_219
+DROP VIEW IF EXISTS view_1_tab3_219 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_219
+DROP VIEW IF EXISTS view_2_tab3_219 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_219
+DROP VIEW IF EXISTS view_3_tab3_219 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33740,13 +33740,13 @@ SELECT pk FROM tab4 WHERE col0 > 34
 9
 
 statement ok
-DROP VIEW view_1_tab4_219
+DROP VIEW IF EXISTS view_1_tab4_219 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_219
+DROP VIEW IF EXISTS view_2_tab4_219 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_219
+DROP VIEW IF EXISTS view_3_tab4_219 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33849,13 +33849,13 @@ SELECT pk FROM tab0 WHERE col0 > 53
 9
 
 statement ok
-DROP VIEW view_1_tab0_220
+DROP VIEW IF EXISTS view_1_tab0_220 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_220
+DROP VIEW IF EXISTS view_2_tab0_220 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_220
+DROP VIEW IF EXISTS view_3_tab0_220 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33958,13 +33958,13 @@ SELECT pk FROM tab1 WHERE col0 > 53
 9
 
 statement ok
-DROP VIEW view_1_tab1_220
+DROP VIEW IF EXISTS view_1_tab1_220 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_220
+DROP VIEW IF EXISTS view_2_tab1_220 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_220
+DROP VIEW IF EXISTS view_3_tab1_220 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34067,13 +34067,13 @@ SELECT pk FROM tab2 WHERE col0 > 53
 9
 
 statement ok
-DROP VIEW view_1_tab2_220
+DROP VIEW IF EXISTS view_1_tab2_220 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_220
+DROP VIEW IF EXISTS view_2_tab2_220 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_220
+DROP VIEW IF EXISTS view_3_tab2_220 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34176,13 +34176,13 @@ SELECT pk FROM tab3 WHERE col0 > 53
 9
 
 statement ok
-DROP VIEW view_1_tab3_220
+DROP VIEW IF EXISTS view_1_tab3_220 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_220
+DROP VIEW IF EXISTS view_2_tab3_220 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_220
+DROP VIEW IF EXISTS view_3_tab3_220 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34285,13 +34285,13 @@ SELECT pk FROM tab4 WHERE col0 > 53
 9
 
 statement ok
-DROP VIEW view_1_tab4_220
+DROP VIEW IF EXISTS view_1_tab4_220 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_220
+DROP VIEW IF EXISTS view_2_tab4_220 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_220
+DROP VIEW IF EXISTS view_3_tab4_220 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34410,13 +34410,13 @@ SELECT pk FROM tab0 WHERE col0 < 80
 8
 
 statement ok
-DROP VIEW view_1_tab0_221
+DROP VIEW IF EXISTS view_1_tab0_221 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_221
+DROP VIEW IF EXISTS view_2_tab0_221 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_221
+DROP VIEW IF EXISTS view_3_tab0_221 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34535,13 +34535,13 @@ SELECT pk FROM tab1 WHERE col0 < 80
 8
 
 statement ok
-DROP VIEW view_1_tab1_221
+DROP VIEW IF EXISTS view_1_tab1_221 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_221
+DROP VIEW IF EXISTS view_2_tab1_221 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_221
+DROP VIEW IF EXISTS view_3_tab1_221 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34660,13 +34660,13 @@ SELECT pk FROM tab2 WHERE col0 < 80
 8
 
 statement ok
-DROP VIEW view_1_tab2_221
+DROP VIEW IF EXISTS view_1_tab2_221 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_221
+DROP VIEW IF EXISTS view_2_tab2_221 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_221
+DROP VIEW IF EXISTS view_3_tab2_221 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34785,13 +34785,13 @@ SELECT pk FROM tab3 WHERE col0 < 80
 8
 
 statement ok
-DROP VIEW view_1_tab3_221
+DROP VIEW IF EXISTS view_1_tab3_221 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_221
+DROP VIEW IF EXISTS view_2_tab3_221 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_221
+DROP VIEW IF EXISTS view_3_tab3_221 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34910,13 +34910,13 @@ SELECT pk FROM tab4 WHERE col0 < 80
 8
 
 statement ok
-DROP VIEW view_1_tab4_221
+DROP VIEW IF EXISTS view_1_tab4_221 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_221
+DROP VIEW IF EXISTS view_2_tab4_221 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_221
+DROP VIEW IF EXISTS view_3_tab4_221 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35030,13 +35030,13 @@ SELECT pk FROM tab0 WHERE col4 > 44.18
 8
 
 statement ok
-DROP VIEW view_1_tab0_222
+DROP VIEW IF EXISTS view_1_tab0_222 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_222
+DROP VIEW IF EXISTS view_2_tab0_222 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_222
+DROP VIEW IF EXISTS view_3_tab0_222 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35150,13 +35150,13 @@ SELECT pk FROM tab1 WHERE col4 > 44.18
 8
 
 statement ok
-DROP VIEW view_1_tab1_222
+DROP VIEW IF EXISTS view_1_tab1_222 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_222
+DROP VIEW IF EXISTS view_2_tab1_222 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_222
+DROP VIEW IF EXISTS view_3_tab1_222 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35270,13 +35270,13 @@ SELECT pk FROM tab2 WHERE col4 > 44.18
 8
 
 statement ok
-DROP VIEW view_1_tab2_222
+DROP VIEW IF EXISTS view_1_tab2_222 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_222
+DROP VIEW IF EXISTS view_2_tab2_222 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_222
+DROP VIEW IF EXISTS view_3_tab2_222 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35390,13 +35390,13 @@ SELECT pk FROM tab3 WHERE col4 > 44.18
 8
 
 statement ok
-DROP VIEW view_1_tab3_222
+DROP VIEW IF EXISTS view_1_tab3_222 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_222
+DROP VIEW IF EXISTS view_2_tab3_222 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_222
+DROP VIEW IF EXISTS view_3_tab3_222 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35510,13 +35510,13 @@ SELECT pk FROM tab4 WHERE col4 > 44.18
 8
 
 statement ok
-DROP VIEW view_1_tab4_222
+DROP VIEW IF EXISTS view_1_tab4_222 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_222
+DROP VIEW IF EXISTS view_2_tab4_222 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_222
+DROP VIEW IF EXISTS view_3_tab4_222 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35623,13 +35623,13 @@ SELECT pk FROM tab0 WHERE col1 <= 48.75
 8
 
 statement ok
-DROP VIEW view_1_tab0_223
+DROP VIEW IF EXISTS view_1_tab0_223 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_223
+DROP VIEW IF EXISTS view_2_tab0_223 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_223
+DROP VIEW IF EXISTS view_3_tab0_223 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35736,13 +35736,13 @@ SELECT pk FROM tab1 WHERE col1 <= 48.75
 8
 
 statement ok
-DROP VIEW view_1_tab1_223
+DROP VIEW IF EXISTS view_1_tab1_223 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_223
+DROP VIEW IF EXISTS view_2_tab1_223 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_223
+DROP VIEW IF EXISTS view_3_tab1_223 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35849,13 +35849,13 @@ SELECT pk FROM tab2 WHERE col1 <= 48.75
 8
 
 statement ok
-DROP VIEW view_1_tab2_223
+DROP VIEW IF EXISTS view_1_tab2_223 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_223
+DROP VIEW IF EXISTS view_2_tab2_223 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_223
+DROP VIEW IF EXISTS view_3_tab2_223 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35962,13 +35962,13 @@ SELECT pk FROM tab3 WHERE col1 <= 48.75
 8
 
 statement ok
-DROP VIEW view_1_tab3_223
+DROP VIEW IF EXISTS view_1_tab3_223 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_223
+DROP VIEW IF EXISTS view_2_tab3_223 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_223
+DROP VIEW IF EXISTS view_3_tab3_223 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36075,13 +36075,13 @@ SELECT pk FROM tab4 WHERE col1 <= 48.75
 8
 
 statement ok
-DROP VIEW view_1_tab4_223
+DROP VIEW IF EXISTS view_1_tab4_223 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_223
+DROP VIEW IF EXISTS view_2_tab4_223 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_223
+DROP VIEW IF EXISTS view_3_tab4_223 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36199,13 +36199,13 @@ SELECT pk FROM tab0 WHERE col0 IS NULL OR col3 <= 94
 9
 
 statement ok
-DROP VIEW view_1_tab0_224
+DROP VIEW IF EXISTS view_1_tab0_224 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_224
+DROP VIEW IF EXISTS view_2_tab0_224 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_224
+DROP VIEW IF EXISTS view_3_tab0_224 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36323,13 +36323,13 @@ SELECT pk FROM tab1 WHERE col0 IS NULL OR col3 <= 94
 9
 
 statement ok
-DROP VIEW view_1_tab1_224
+DROP VIEW IF EXISTS view_1_tab1_224 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_224
+DROP VIEW IF EXISTS view_2_tab1_224 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_224
+DROP VIEW IF EXISTS view_3_tab1_224 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36447,13 +36447,13 @@ SELECT pk FROM tab2 WHERE col0 IS NULL OR col3 <= 94
 9
 
 statement ok
-DROP VIEW view_1_tab2_224
+DROP VIEW IF EXISTS view_1_tab2_224 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_224
+DROP VIEW IF EXISTS view_2_tab2_224 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_224
+DROP VIEW IF EXISTS view_3_tab2_224 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36571,13 +36571,13 @@ SELECT pk FROM tab3 WHERE col0 IS NULL OR col3 <= 94
 9
 
 statement ok
-DROP VIEW view_1_tab3_224
+DROP VIEW IF EXISTS view_1_tab3_224 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_224
+DROP VIEW IF EXISTS view_2_tab3_224 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_224
+DROP VIEW IF EXISTS view_3_tab3_224 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36695,13 +36695,13 @@ SELECT pk FROM tab4 WHERE col0 IS NULL OR col3 <= 94
 9
 
 statement ok
-DROP VIEW view_1_tab4_224
+DROP VIEW IF EXISTS view_1_tab4_224 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_224
+DROP VIEW IF EXISTS view_2_tab4_224 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_224
+DROP VIEW IF EXISTS view_3_tab4_224 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36787,13 +36787,13 @@ SELECT pk FROM tab0 WHERE (col4 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_225
+DROP VIEW IF EXISTS view_1_tab0_225 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_225
+DROP VIEW IF EXISTS view_2_tab0_225 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_225
+DROP VIEW IF EXISTS view_3_tab0_225 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36879,13 +36879,13 @@ SELECT pk FROM tab1 WHERE (col4 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_225
+DROP VIEW IF EXISTS view_1_tab1_225 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_225
+DROP VIEW IF EXISTS view_2_tab1_225 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_225
+DROP VIEW IF EXISTS view_3_tab1_225 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36971,13 +36971,13 @@ SELECT pk FROM tab2 WHERE (col4 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_225
+DROP VIEW IF EXISTS view_1_tab2_225 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_225
+DROP VIEW IF EXISTS view_2_tab2_225 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_225
+DROP VIEW IF EXISTS view_3_tab2_225 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37063,13 +37063,13 @@ SELECT pk FROM tab3 WHERE (col4 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_225
+DROP VIEW IF EXISTS view_1_tab3_225 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_225
+DROP VIEW IF EXISTS view_2_tab3_225 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_225
+DROP VIEW IF EXISTS view_3_tab3_225 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37155,11 +37155,11 @@ SELECT pk FROM tab4 WHERE (col4 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_225
+DROP VIEW IF EXISTS view_1_tab4_225 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_225
+DROP VIEW IF EXISTS view_2_tab4_225 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_225
+DROP VIEW IF EXISTS view_3_tab4_225 CASCADE
 

--- a/test/index/view/10/slt_good_2.test
+++ b/test/index/view/10/slt_good_2.test
@@ -218,13 +218,13 @@ SELECT pk FROM tab0 WHERE col3 < 84
 9
 
 statement ok
-DROP VIEW view_1_tab0_302
+DROP VIEW IF EXISTS view_1_tab0_302 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_302
+DROP VIEW IF EXISTS view_2_tab0_302 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_302
+DROP VIEW IF EXISTS view_3_tab0_302 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -342,13 +342,13 @@ SELECT pk FROM tab1 WHERE col3 < 84
 9
 
 statement ok
-DROP VIEW view_1_tab1_302
+DROP VIEW IF EXISTS view_1_tab1_302 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_302
+DROP VIEW IF EXISTS view_2_tab1_302 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_302
+DROP VIEW IF EXISTS view_3_tab1_302 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -466,13 +466,13 @@ SELECT pk FROM tab2 WHERE col3 < 84
 9
 
 statement ok
-DROP VIEW view_1_tab2_302
+DROP VIEW IF EXISTS view_1_tab2_302 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_302
+DROP VIEW IF EXISTS view_2_tab2_302 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_302
+DROP VIEW IF EXISTS view_3_tab2_302 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -590,13 +590,13 @@ SELECT pk FROM tab3 WHERE col3 < 84
 9
 
 statement ok
-DROP VIEW view_1_tab3_302
+DROP VIEW IF EXISTS view_1_tab3_302 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_302
+DROP VIEW IF EXISTS view_2_tab3_302 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_302
+DROP VIEW IF EXISTS view_3_tab3_302 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -714,13 +714,13 @@ SELECT pk FROM tab4 WHERE col3 < 84
 9
 
 statement ok
-DROP VIEW view_1_tab4_302
+DROP VIEW IF EXISTS view_1_tab4_302 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_302
+DROP VIEW IF EXISTS view_2_tab4_302 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_302
+DROP VIEW IF EXISTS view_3_tab4_302 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -806,13 +806,13 @@ SELECT pk FROM tab0 WHERE col4 < 22.92 AND (col3 = 16)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_303
+DROP VIEW IF EXISTS view_1_tab0_303 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_303
+DROP VIEW IF EXISTS view_2_tab0_303 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_303
+DROP VIEW IF EXISTS view_3_tab0_303 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -898,13 +898,13 @@ SELECT pk FROM tab1 WHERE col4 < 22.92 AND (col3 = 16)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_303
+DROP VIEW IF EXISTS view_1_tab1_303 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_303
+DROP VIEW IF EXISTS view_2_tab1_303 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_303
+DROP VIEW IF EXISTS view_3_tab1_303 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -990,13 +990,13 @@ SELECT pk FROM tab2 WHERE col4 < 22.92 AND (col3 = 16)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_303
+DROP VIEW IF EXISTS view_1_tab2_303 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_303
+DROP VIEW IF EXISTS view_2_tab2_303 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_303
+DROP VIEW IF EXISTS view_3_tab2_303 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1082,13 +1082,13 @@ SELECT pk FROM tab3 WHERE col4 < 22.92 AND (col3 = 16)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_303
+DROP VIEW IF EXISTS view_1_tab3_303 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_303
+DROP VIEW IF EXISTS view_2_tab3_303 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_303
+DROP VIEW IF EXISTS view_3_tab3_303 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1174,13 +1174,13 @@ SELECT pk FROM tab4 WHERE col4 < 22.92 AND (col3 = 16)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_303
+DROP VIEW IF EXISTS view_1_tab4_303 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_303
+DROP VIEW IF EXISTS view_2_tab4_303 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_303
+DROP VIEW IF EXISTS view_3_tab4_303 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1298,13 +1298,13 @@ SELECT pk FROM tab0 WHERE (col4 >= 5.32) AND col0 < 74
 9
 
 statement ok
-DROP VIEW view_1_tab0_304
+DROP VIEW IF EXISTS view_1_tab0_304 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_304
+DROP VIEW IF EXISTS view_2_tab0_304 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_304
+DROP VIEW IF EXISTS view_3_tab0_304 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1422,13 +1422,13 @@ SELECT pk FROM tab1 WHERE (col4 >= 5.32) AND col0 < 74
 9
 
 statement ok
-DROP VIEW view_1_tab1_304
+DROP VIEW IF EXISTS view_1_tab1_304 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_304
+DROP VIEW IF EXISTS view_2_tab1_304 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_304
+DROP VIEW IF EXISTS view_3_tab1_304 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1546,13 +1546,13 @@ SELECT pk FROM tab2 WHERE (col4 >= 5.32) AND col0 < 74
 9
 
 statement ok
-DROP VIEW view_1_tab2_304
+DROP VIEW IF EXISTS view_1_tab2_304 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_304
+DROP VIEW IF EXISTS view_2_tab2_304 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_304
+DROP VIEW IF EXISTS view_3_tab2_304 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1670,13 +1670,13 @@ SELECT pk FROM tab3 WHERE (col4 >= 5.32) AND col0 < 74
 9
 
 statement ok
-DROP VIEW view_1_tab3_304
+DROP VIEW IF EXISTS view_1_tab3_304 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_304
+DROP VIEW IF EXISTS view_2_tab3_304 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_304
+DROP VIEW IF EXISTS view_3_tab3_304 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1794,13 +1794,13 @@ SELECT pk FROM tab4 WHERE (col4 >= 5.32) AND col0 < 74
 9
 
 statement ok
-DROP VIEW view_1_tab4_304
+DROP VIEW IF EXISTS view_1_tab4_304 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_304
+DROP VIEW IF EXISTS view_2_tab4_304 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_304
+DROP VIEW IF EXISTS view_3_tab4_304 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1919,13 +1919,13 @@ SELECT pk FROM tab0 WHERE col0 < 41 OR (col1 < 93.66) AND col3 >= 21 AND col1 = 
 9
 
 statement ok
-DROP VIEW view_1_tab0_305
+DROP VIEW IF EXISTS view_1_tab0_305 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_305
+DROP VIEW IF EXISTS view_2_tab0_305 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_305
+DROP VIEW IF EXISTS view_3_tab0_305 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2044,13 +2044,13 @@ SELECT pk FROM tab1 WHERE col0 < 41 OR (col1 < 93.66) AND col3 >= 21 AND col1 = 
 9
 
 statement ok
-DROP VIEW view_1_tab1_305
+DROP VIEW IF EXISTS view_1_tab1_305 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_305
+DROP VIEW IF EXISTS view_2_tab1_305 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_305
+DROP VIEW IF EXISTS view_3_tab1_305 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2169,13 +2169,13 @@ SELECT pk FROM tab2 WHERE col0 < 41 OR (col1 < 93.66) AND col3 >= 21 AND col1 = 
 9
 
 statement ok
-DROP VIEW view_1_tab2_305
+DROP VIEW IF EXISTS view_1_tab2_305 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_305
+DROP VIEW IF EXISTS view_2_tab2_305 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_305
+DROP VIEW IF EXISTS view_3_tab2_305 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2294,13 +2294,13 @@ SELECT pk FROM tab3 WHERE col0 < 41 OR (col1 < 93.66) AND col3 >= 21 AND col1 = 
 9
 
 statement ok
-DROP VIEW view_1_tab3_305
+DROP VIEW IF EXISTS view_1_tab3_305 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_305
+DROP VIEW IF EXISTS view_2_tab3_305 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_305
+DROP VIEW IF EXISTS view_3_tab3_305 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2419,13 +2419,13 @@ SELECT pk FROM tab4 WHERE col0 < 41 OR (col1 < 93.66) AND col3 >= 21 AND col1 = 
 9
 
 statement ok
-DROP VIEW view_1_tab4_305
+DROP VIEW IF EXISTS view_1_tab4_305 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_305
+DROP VIEW IF EXISTS view_2_tab4_305 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_305
+DROP VIEW IF EXISTS view_3_tab4_305 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2518,13 +2518,13 @@ SELECT pk FROM tab0 WHERE col4 >= 36.7 AND col3 >= 6
 9 values hashing to 4290bd41ca7ca69dc280e33882d8e9de
 
 statement ok
-DROP VIEW view_1_tab0_306
+DROP VIEW IF EXISTS view_1_tab0_306 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_306
+DROP VIEW IF EXISTS view_2_tab0_306 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_306
+DROP VIEW IF EXISTS view_3_tab0_306 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2617,13 +2617,13 @@ SELECT pk FROM tab1 WHERE col4 >= 36.7 AND col3 >= 6
 9 values hashing to 4290bd41ca7ca69dc280e33882d8e9de
 
 statement ok
-DROP VIEW view_1_tab1_306
+DROP VIEW IF EXISTS view_1_tab1_306 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_306
+DROP VIEW IF EXISTS view_2_tab1_306 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_306
+DROP VIEW IF EXISTS view_3_tab1_306 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2716,13 +2716,13 @@ SELECT pk FROM tab2 WHERE col4 >= 36.7 AND col3 >= 6
 9 values hashing to 4290bd41ca7ca69dc280e33882d8e9de
 
 statement ok
-DROP VIEW view_1_tab2_306
+DROP VIEW IF EXISTS view_1_tab2_306 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_306
+DROP VIEW IF EXISTS view_2_tab2_306 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_306
+DROP VIEW IF EXISTS view_3_tab2_306 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2815,13 +2815,13 @@ SELECT pk FROM tab3 WHERE col4 >= 36.7 AND col3 >= 6
 9 values hashing to 4290bd41ca7ca69dc280e33882d8e9de
 
 statement ok
-DROP VIEW view_1_tab3_306
+DROP VIEW IF EXISTS view_1_tab3_306 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_306
+DROP VIEW IF EXISTS view_2_tab3_306 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_306
+DROP VIEW IF EXISTS view_3_tab3_306 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2914,13 +2914,13 @@ SELECT pk FROM tab4 WHERE col4 >= 36.7 AND col3 >= 6
 9 values hashing to 4290bd41ca7ca69dc280e33882d8e9de
 
 statement ok
-DROP VIEW view_1_tab4_306
+DROP VIEW IF EXISTS view_1_tab4_306 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_306
+DROP VIEW IF EXISTS view_2_tab4_306 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_306
+DROP VIEW IF EXISTS view_3_tab4_306 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3039,13 +3039,13 @@ SELECT pk FROM tab0 WHERE (col0 > 9)
 9
 
 statement ok
-DROP VIEW view_1_tab0_307
+DROP VIEW IF EXISTS view_1_tab0_307 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_307
+DROP VIEW IF EXISTS view_2_tab0_307 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_307
+DROP VIEW IF EXISTS view_3_tab0_307 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3164,13 +3164,13 @@ SELECT pk FROM tab1 WHERE (col0 > 9)
 9
 
 statement ok
-DROP VIEW view_1_tab1_307
+DROP VIEW IF EXISTS view_1_tab1_307 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_307
+DROP VIEW IF EXISTS view_2_tab1_307 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_307
+DROP VIEW IF EXISTS view_3_tab1_307 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3289,13 +3289,13 @@ SELECT pk FROM tab2 WHERE (col0 > 9)
 9
 
 statement ok
-DROP VIEW view_1_tab2_307
+DROP VIEW IF EXISTS view_1_tab2_307 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_307
+DROP VIEW IF EXISTS view_2_tab2_307 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_307
+DROP VIEW IF EXISTS view_3_tab2_307 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3414,13 +3414,13 @@ SELECT pk FROM tab3 WHERE (col0 > 9)
 9
 
 statement ok
-DROP VIEW view_1_tab3_307
+DROP VIEW IF EXISTS view_1_tab3_307 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_307
+DROP VIEW IF EXISTS view_2_tab3_307 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_307
+DROP VIEW IF EXISTS view_3_tab3_307 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3539,13 +3539,13 @@ SELECT pk FROM tab4 WHERE (col0 > 9)
 9
 
 statement ok
-DROP VIEW view_1_tab4_307
+DROP VIEW IF EXISTS view_1_tab4_307 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_307
+DROP VIEW IF EXISTS view_2_tab4_307 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_307
+DROP VIEW IF EXISTS view_3_tab4_307 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3648,13 +3648,13 @@ SELECT pk FROM tab0 WHERE col1 > 17.28 AND (col3 < 43)
 9
 
 statement ok
-DROP VIEW view_1_tab0_308
+DROP VIEW IF EXISTS view_1_tab0_308 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_308
+DROP VIEW IF EXISTS view_2_tab0_308 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_308
+DROP VIEW IF EXISTS view_3_tab0_308 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3757,13 +3757,13 @@ SELECT pk FROM tab1 WHERE col1 > 17.28 AND (col3 < 43)
 9
 
 statement ok
-DROP VIEW view_1_tab1_308
+DROP VIEW IF EXISTS view_1_tab1_308 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_308
+DROP VIEW IF EXISTS view_2_tab1_308 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_308
+DROP VIEW IF EXISTS view_3_tab1_308 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3866,13 +3866,13 @@ SELECT pk FROM tab2 WHERE col1 > 17.28 AND (col3 < 43)
 9
 
 statement ok
-DROP VIEW view_1_tab2_308
+DROP VIEW IF EXISTS view_1_tab2_308 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_308
+DROP VIEW IF EXISTS view_2_tab2_308 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_308
+DROP VIEW IF EXISTS view_3_tab2_308 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3975,13 +3975,13 @@ SELECT pk FROM tab3 WHERE col1 > 17.28 AND (col3 < 43)
 9
 
 statement ok
-DROP VIEW view_1_tab3_308
+DROP VIEW IF EXISTS view_1_tab3_308 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_308
+DROP VIEW IF EXISTS view_2_tab3_308 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_308
+DROP VIEW IF EXISTS view_3_tab3_308 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4084,13 +4084,13 @@ SELECT pk FROM tab4 WHERE col1 > 17.28 AND (col3 < 43)
 9
 
 statement ok
-DROP VIEW view_1_tab4_308
+DROP VIEW IF EXISTS view_1_tab4_308 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_308
+DROP VIEW IF EXISTS view_2_tab4_308 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_308
+DROP VIEW IF EXISTS view_3_tab4_308 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4176,13 +4176,13 @@ SELECT pk FROM tab0 WHERE (col0 IS NULL AND (col4 IS NULL AND (col3 > 54) AND co
 ----
 
 statement ok
-DROP VIEW view_1_tab0_309
+DROP VIEW IF EXISTS view_1_tab0_309 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_309
+DROP VIEW IF EXISTS view_2_tab0_309 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_309
+DROP VIEW IF EXISTS view_3_tab0_309 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4268,13 +4268,13 @@ SELECT pk FROM tab1 WHERE (col0 IS NULL AND (col4 IS NULL AND (col3 > 54) AND co
 ----
 
 statement ok
-DROP VIEW view_1_tab1_309
+DROP VIEW IF EXISTS view_1_tab1_309 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_309
+DROP VIEW IF EXISTS view_2_tab1_309 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_309
+DROP VIEW IF EXISTS view_3_tab1_309 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4360,13 +4360,13 @@ SELECT pk FROM tab2 WHERE (col0 IS NULL AND (col4 IS NULL AND (col3 > 54) AND co
 ----
 
 statement ok
-DROP VIEW view_1_tab2_309
+DROP VIEW IF EXISTS view_1_tab2_309 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_309
+DROP VIEW IF EXISTS view_2_tab2_309 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_309
+DROP VIEW IF EXISTS view_3_tab2_309 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4452,13 +4452,13 @@ SELECT pk FROM tab3 WHERE (col0 IS NULL AND (col4 IS NULL AND (col3 > 54) AND co
 ----
 
 statement ok
-DROP VIEW view_1_tab3_309
+DROP VIEW IF EXISTS view_1_tab3_309 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_309
+DROP VIEW IF EXISTS view_2_tab3_309 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_309
+DROP VIEW IF EXISTS view_3_tab3_309 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4544,13 +4544,13 @@ SELECT pk FROM tab4 WHERE (col0 IS NULL AND (col4 IS NULL AND (col3 > 54) AND co
 ----
 
 statement ok
-DROP VIEW view_1_tab4_309
+DROP VIEW IF EXISTS view_1_tab4_309 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_309
+DROP VIEW IF EXISTS view_2_tab4_309 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_309
+DROP VIEW IF EXISTS view_3_tab4_309 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4639,13 +4639,13 @@ SELECT pk FROM tab0 WHERE col3 = 5 OR ((col0 <= 93 AND ((col4 = 42.93))) AND col
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_310
+DROP VIEW IF EXISTS view_1_tab0_310 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_310
+DROP VIEW IF EXISTS view_2_tab0_310 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_310
+DROP VIEW IF EXISTS view_3_tab0_310 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4734,13 +4734,13 @@ SELECT pk FROM tab1 WHERE col3 = 5 OR ((col0 <= 93 AND ((col4 = 42.93))) AND col
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_310
+DROP VIEW IF EXISTS view_1_tab1_310 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_310
+DROP VIEW IF EXISTS view_2_tab1_310 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_310
+DROP VIEW IF EXISTS view_3_tab1_310 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4829,13 +4829,13 @@ SELECT pk FROM tab2 WHERE col3 = 5 OR ((col0 <= 93 AND ((col4 = 42.93))) AND col
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_310
+DROP VIEW IF EXISTS view_1_tab2_310 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_310
+DROP VIEW IF EXISTS view_2_tab2_310 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_310
+DROP VIEW IF EXISTS view_3_tab2_310 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4924,13 +4924,13 @@ SELECT pk FROM tab3 WHERE col3 = 5 OR ((col0 <= 93 AND ((col4 = 42.93))) AND col
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_310
+DROP VIEW IF EXISTS view_1_tab3_310 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_310
+DROP VIEW IF EXISTS view_2_tab3_310 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_310
+DROP VIEW IF EXISTS view_3_tab3_310 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5019,13 +5019,13 @@ SELECT pk FROM tab4 WHERE col3 = 5 OR ((col0 <= 93 AND ((col4 = 42.93))) AND col
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_310
+DROP VIEW IF EXISTS view_1_tab4_310 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_310
+DROP VIEW IF EXISTS view_2_tab4_310 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_310
+DROP VIEW IF EXISTS view_3_tab4_310 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5111,13 +5111,13 @@ SELECT pk FROM tab0 WHERE col0 BETWEEN 35 AND 12
 ----
 
 statement ok
-DROP VIEW view_1_tab0_311
+DROP VIEW IF EXISTS view_1_tab0_311 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_311
+DROP VIEW IF EXISTS view_2_tab0_311 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_311
+DROP VIEW IF EXISTS view_3_tab0_311 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5203,13 +5203,13 @@ SELECT pk FROM tab1 WHERE col0 BETWEEN 35 AND 12
 ----
 
 statement ok
-DROP VIEW view_1_tab1_311
+DROP VIEW IF EXISTS view_1_tab1_311 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_311
+DROP VIEW IF EXISTS view_2_tab1_311 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_311
+DROP VIEW IF EXISTS view_3_tab1_311 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5295,13 +5295,13 @@ SELECT pk FROM tab2 WHERE col0 BETWEEN 35 AND 12
 ----
 
 statement ok
-DROP VIEW view_1_tab2_311
+DROP VIEW IF EXISTS view_1_tab2_311 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_311
+DROP VIEW IF EXISTS view_2_tab2_311 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_311
+DROP VIEW IF EXISTS view_3_tab2_311 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5387,13 +5387,13 @@ SELECT pk FROM tab3 WHERE col0 BETWEEN 35 AND 12
 ----
 
 statement ok
-DROP VIEW view_1_tab3_311
+DROP VIEW IF EXISTS view_1_tab3_311 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_311
+DROP VIEW IF EXISTS view_2_tab3_311 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_311
+DROP VIEW IF EXISTS view_3_tab3_311 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5479,13 +5479,13 @@ SELECT pk FROM tab4 WHERE col0 BETWEEN 35 AND 12
 ----
 
 statement ok
-DROP VIEW view_1_tab4_311
+DROP VIEW IF EXISTS view_1_tab4_311 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_311
+DROP VIEW IF EXISTS view_2_tab4_311 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_311
+DROP VIEW IF EXISTS view_3_tab4_311 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5578,13 +5578,13 @@ SELECT pk FROM tab0 WHERE (col3 <= 3) AND col3 > 38 OR col1 BETWEEN 15.33 AND 89
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab0_312
+DROP VIEW IF EXISTS view_1_tab0_312 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_312
+DROP VIEW IF EXISTS view_2_tab0_312 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_312
+DROP VIEW IF EXISTS view_3_tab0_312 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5677,13 +5677,13 @@ SELECT pk FROM tab1 WHERE (col3 <= 3) AND col3 > 38 OR col1 BETWEEN 15.33 AND 89
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab1_312
+DROP VIEW IF EXISTS view_1_tab1_312 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_312
+DROP VIEW IF EXISTS view_2_tab1_312 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_312
+DROP VIEW IF EXISTS view_3_tab1_312 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5776,13 +5776,13 @@ SELECT pk FROM tab2 WHERE (col3 <= 3) AND col3 > 38 OR col1 BETWEEN 15.33 AND 89
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab2_312
+DROP VIEW IF EXISTS view_1_tab2_312 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_312
+DROP VIEW IF EXISTS view_2_tab2_312 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_312
+DROP VIEW IF EXISTS view_3_tab2_312 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5875,13 +5875,13 @@ SELECT pk FROM tab3 WHERE (col3 <= 3) AND col3 > 38 OR col1 BETWEEN 15.33 AND 89
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab3_312
+DROP VIEW IF EXISTS view_1_tab3_312 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_312
+DROP VIEW IF EXISTS view_2_tab3_312 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_312
+DROP VIEW IF EXISTS view_3_tab3_312 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5974,13 +5974,13 @@ SELECT pk FROM tab4 WHERE (col3 <= 3) AND col3 > 38 OR col1 BETWEEN 15.33 AND 89
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab4_312
+DROP VIEW IF EXISTS view_1_tab4_312 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_312
+DROP VIEW IF EXISTS view_2_tab4_312 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_312
+DROP VIEW IF EXISTS view_3_tab4_312 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6080,13 +6080,13 @@ SELECT pk FROM tab0 WHERE (((col0 > 37 OR col4 = 0.26) AND col1 > 47.56 AND col3
 6
 
 statement ok
-DROP VIEW view_1_tab0_313
+DROP VIEW IF EXISTS view_1_tab0_313 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_313
+DROP VIEW IF EXISTS view_2_tab0_313 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_313
+DROP VIEW IF EXISTS view_3_tab0_313 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6186,13 +6186,13 @@ SELECT pk FROM tab1 WHERE (((col0 > 37 OR col4 = 0.26) AND col1 > 47.56 AND col3
 6
 
 statement ok
-DROP VIEW view_1_tab1_313
+DROP VIEW IF EXISTS view_1_tab1_313 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_313
+DROP VIEW IF EXISTS view_2_tab1_313 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_313
+DROP VIEW IF EXISTS view_3_tab1_313 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6292,13 +6292,13 @@ SELECT pk FROM tab2 WHERE (((col0 > 37 OR col4 = 0.26) AND col1 > 47.56 AND col3
 6
 
 statement ok
-DROP VIEW view_1_tab2_313
+DROP VIEW IF EXISTS view_1_tab2_313 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_313
+DROP VIEW IF EXISTS view_2_tab2_313 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_313
+DROP VIEW IF EXISTS view_3_tab2_313 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6398,13 +6398,13 @@ SELECT pk FROM tab3 WHERE (((col0 > 37 OR col4 = 0.26) AND col1 > 47.56 AND col3
 6
 
 statement ok
-DROP VIEW view_1_tab3_313
+DROP VIEW IF EXISTS view_1_tab3_313 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_313
+DROP VIEW IF EXISTS view_2_tab3_313 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_313
+DROP VIEW IF EXISTS view_3_tab3_313 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6504,13 +6504,13 @@ SELECT pk FROM tab4 WHERE (((col0 > 37 OR col4 = 0.26) AND col1 > 47.56 AND col3
 6
 
 statement ok
-DROP VIEW view_1_tab4_313
+DROP VIEW IF EXISTS view_1_tab4_313 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_313
+DROP VIEW IF EXISTS view_2_tab4_313 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_313
+DROP VIEW IF EXISTS view_3_tab4_313 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6599,13 +6599,13 @@ SELECT pk FROM tab0 WHERE col0 >= 62 OR col4 >= 33.38 OR col4 <= 13.37 AND col1 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_314
+DROP VIEW IF EXISTS view_1_tab0_314 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_314
+DROP VIEW IF EXISTS view_2_tab0_314 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_314
+DROP VIEW IF EXISTS view_3_tab0_314 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6694,13 +6694,13 @@ SELECT pk FROM tab1 WHERE col0 >= 62 OR col4 >= 33.38 OR col4 <= 13.37 AND col1 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_314
+DROP VIEW IF EXISTS view_1_tab1_314 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_314
+DROP VIEW IF EXISTS view_2_tab1_314 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_314
+DROP VIEW IF EXISTS view_3_tab1_314 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6789,13 +6789,13 @@ SELECT pk FROM tab2 WHERE col0 >= 62 OR col4 >= 33.38 OR col4 <= 13.37 AND col1 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_314
+DROP VIEW IF EXISTS view_1_tab2_314 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_314
+DROP VIEW IF EXISTS view_2_tab2_314 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_314
+DROP VIEW IF EXISTS view_3_tab2_314 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6884,13 +6884,13 @@ SELECT pk FROM tab3 WHERE col0 >= 62 OR col4 >= 33.38 OR col4 <= 13.37 AND col1 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_314
+DROP VIEW IF EXISTS view_1_tab3_314 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_314
+DROP VIEW IF EXISTS view_2_tab3_314 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_314
+DROP VIEW IF EXISTS view_3_tab3_314 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6979,13 +6979,13 @@ SELECT pk FROM tab4 WHERE col0 >= 62 OR col4 >= 33.38 OR col4 <= 13.37 AND col1 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_314
+DROP VIEW IF EXISTS view_1_tab4_314 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_314
+DROP VIEW IF EXISTS view_2_tab4_314 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_314
+DROP VIEW IF EXISTS view_3_tab4_314 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7071,13 +7071,13 @@ SELECT pk FROM tab0 WHERE (col0 = 85)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_315
+DROP VIEW IF EXISTS view_1_tab0_315 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_315
+DROP VIEW IF EXISTS view_2_tab0_315 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_315
+DROP VIEW IF EXISTS view_3_tab0_315 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7163,13 +7163,13 @@ SELECT pk FROM tab1 WHERE (col0 = 85)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_315
+DROP VIEW IF EXISTS view_1_tab1_315 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_315
+DROP VIEW IF EXISTS view_2_tab1_315 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_315
+DROP VIEW IF EXISTS view_3_tab1_315 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7255,13 +7255,13 @@ SELECT pk FROM tab2 WHERE (col0 = 85)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_315
+DROP VIEW IF EXISTS view_1_tab2_315 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_315
+DROP VIEW IF EXISTS view_2_tab2_315 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_315
+DROP VIEW IF EXISTS view_3_tab2_315 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7347,13 +7347,13 @@ SELECT pk FROM tab3 WHERE (col0 = 85)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_315
+DROP VIEW IF EXISTS view_1_tab3_315 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_315
+DROP VIEW IF EXISTS view_2_tab3_315 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_315
+DROP VIEW IF EXISTS view_3_tab3_315 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7439,13 +7439,13 @@ SELECT pk FROM tab4 WHERE (col0 = 85)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_315
+DROP VIEW IF EXISTS view_1_tab4_315 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_315
+DROP VIEW IF EXISTS view_2_tab4_315 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_315
+DROP VIEW IF EXISTS view_3_tab4_315 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7552,13 +7552,13 @@ SELECT pk FROM tab0 WHERE (col4 >= 70.98)
 8
 
 statement ok
-DROP VIEW view_1_tab0_316
+DROP VIEW IF EXISTS view_1_tab0_316 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_316
+DROP VIEW IF EXISTS view_2_tab0_316 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_316
+DROP VIEW IF EXISTS view_3_tab0_316 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7665,13 +7665,13 @@ SELECT pk FROM tab1 WHERE (col4 >= 70.98)
 8
 
 statement ok
-DROP VIEW view_1_tab1_316
+DROP VIEW IF EXISTS view_1_tab1_316 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_316
+DROP VIEW IF EXISTS view_2_tab1_316 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_316
+DROP VIEW IF EXISTS view_3_tab1_316 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7778,13 +7778,13 @@ SELECT pk FROM tab2 WHERE (col4 >= 70.98)
 8
 
 statement ok
-DROP VIEW view_1_tab2_316
+DROP VIEW IF EXISTS view_1_tab2_316 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_316
+DROP VIEW IF EXISTS view_2_tab2_316 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_316
+DROP VIEW IF EXISTS view_3_tab2_316 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7891,13 +7891,13 @@ SELECT pk FROM tab3 WHERE (col4 >= 70.98)
 8
 
 statement ok
-DROP VIEW view_1_tab3_316
+DROP VIEW IF EXISTS view_1_tab3_316 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_316
+DROP VIEW IF EXISTS view_2_tab3_316 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_316
+DROP VIEW IF EXISTS view_3_tab3_316 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8004,13 +8004,13 @@ SELECT pk FROM tab4 WHERE (col4 >= 70.98)
 8
 
 statement ok
-DROP VIEW view_1_tab4_316
+DROP VIEW IF EXISTS view_1_tab4_316 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_316
+DROP VIEW IF EXISTS view_2_tab4_316 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_316
+DROP VIEW IF EXISTS view_3_tab4_316 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8099,13 +8099,13 @@ SELECT pk FROM tab0 WHERE col0 < 89 OR col1 < 1.95 AND col4 >= 75.40 OR col0 >= 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_318
+DROP VIEW IF EXISTS view_1_tab0_318 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_318
+DROP VIEW IF EXISTS view_2_tab0_318 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_318
+DROP VIEW IF EXISTS view_3_tab0_318 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8194,13 +8194,13 @@ SELECT pk FROM tab1 WHERE col0 < 89 OR col1 < 1.95 AND col4 >= 75.40 OR col0 >= 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_318
+DROP VIEW IF EXISTS view_1_tab1_318 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_318
+DROP VIEW IF EXISTS view_2_tab1_318 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_318
+DROP VIEW IF EXISTS view_3_tab1_318 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8289,13 +8289,13 @@ SELECT pk FROM tab2 WHERE col0 < 89 OR col1 < 1.95 AND col4 >= 75.40 OR col0 >= 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_318
+DROP VIEW IF EXISTS view_1_tab2_318 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_318
+DROP VIEW IF EXISTS view_2_tab2_318 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_318
+DROP VIEW IF EXISTS view_3_tab2_318 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8384,13 +8384,13 @@ SELECT pk FROM tab3 WHERE col0 < 89 OR col1 < 1.95 AND col4 >= 75.40 OR col0 >= 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_318
+DROP VIEW IF EXISTS view_1_tab3_318 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_318
+DROP VIEW IF EXISTS view_2_tab3_318 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_318
+DROP VIEW IF EXISTS view_3_tab3_318 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8479,13 +8479,13 @@ SELECT pk FROM tab4 WHERE col0 < 89 OR col1 < 1.95 AND col4 >= 75.40 OR col0 >= 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_318
+DROP VIEW IF EXISTS view_1_tab4_318 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_318
+DROP VIEW IF EXISTS view_2_tab4_318 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_318
+DROP VIEW IF EXISTS view_3_tab4_318 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8571,13 +8571,13 @@ SELECT pk FROM tab0 WHERE (((col3 IS NULL)) AND col3 = 63)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_319
+DROP VIEW IF EXISTS view_1_tab0_319 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_319
+DROP VIEW IF EXISTS view_2_tab0_319 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_319
+DROP VIEW IF EXISTS view_3_tab0_319 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8663,13 +8663,13 @@ SELECT pk FROM tab1 WHERE (((col3 IS NULL)) AND col3 = 63)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_319
+DROP VIEW IF EXISTS view_1_tab1_319 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_319
+DROP VIEW IF EXISTS view_2_tab1_319 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_319
+DROP VIEW IF EXISTS view_3_tab1_319 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8755,13 +8755,13 @@ SELECT pk FROM tab2 WHERE (((col3 IS NULL)) AND col3 = 63)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_319
+DROP VIEW IF EXISTS view_1_tab2_319 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_319
+DROP VIEW IF EXISTS view_2_tab2_319 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_319
+DROP VIEW IF EXISTS view_3_tab2_319 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8847,13 +8847,13 @@ SELECT pk FROM tab3 WHERE (((col3 IS NULL)) AND col3 = 63)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_319
+DROP VIEW IF EXISTS view_1_tab3_319 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_319
+DROP VIEW IF EXISTS view_2_tab3_319 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_319
+DROP VIEW IF EXISTS view_3_tab3_319 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8939,13 +8939,13 @@ SELECT pk FROM tab4 WHERE (((col3 IS NULL)) AND col3 = 63)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_319
+DROP VIEW IF EXISTS view_1_tab4_319 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_319
+DROP VIEW IF EXISTS view_2_tab4_319 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_319
+DROP VIEW IF EXISTS view_3_tab4_319 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9031,13 +9031,13 @@ SELECT pk FROM tab0 WHERE ((((((col3 = 66) AND (((col0 >= 36)) AND col4 > 26.53)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_320
+DROP VIEW IF EXISTS view_1_tab0_320 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_320
+DROP VIEW IF EXISTS view_2_tab0_320 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_320
+DROP VIEW IF EXISTS view_3_tab0_320 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9123,13 +9123,13 @@ SELECT pk FROM tab1 WHERE ((((((col3 = 66) AND (((col0 >= 36)) AND col4 > 26.53)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_320
+DROP VIEW IF EXISTS view_1_tab1_320 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_320
+DROP VIEW IF EXISTS view_2_tab1_320 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_320
+DROP VIEW IF EXISTS view_3_tab1_320 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9215,13 +9215,13 @@ SELECT pk FROM tab2 WHERE ((((((col3 = 66) AND (((col0 >= 36)) AND col4 > 26.53)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_320
+DROP VIEW IF EXISTS view_1_tab2_320 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_320
+DROP VIEW IF EXISTS view_2_tab2_320 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_320
+DROP VIEW IF EXISTS view_3_tab2_320 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9307,13 +9307,13 @@ SELECT pk FROM tab3 WHERE ((((((col3 = 66) AND (((col0 >= 36)) AND col4 > 26.53)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_320
+DROP VIEW IF EXISTS view_1_tab3_320 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_320
+DROP VIEW IF EXISTS view_2_tab3_320 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_320
+DROP VIEW IF EXISTS view_3_tab3_320 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9399,13 +9399,13 @@ SELECT pk FROM tab4 WHERE ((((((col3 = 66) AND (((col0 >= 36)) AND col4 > 26.53)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_320
+DROP VIEW IF EXISTS view_1_tab4_320 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_320
+DROP VIEW IF EXISTS view_2_tab4_320 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_320
+DROP VIEW IF EXISTS view_3_tab4_320 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9498,13 +9498,13 @@ SELECT pk FROM tab0 WHERE col3 IS NULL OR col1 > 29.53
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab0_321
+DROP VIEW IF EXISTS view_1_tab0_321 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_321
+DROP VIEW IF EXISTS view_2_tab0_321 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_321
+DROP VIEW IF EXISTS view_3_tab0_321 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9597,13 +9597,13 @@ SELECT pk FROM tab1 WHERE col3 IS NULL OR col1 > 29.53
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab1_321
+DROP VIEW IF EXISTS view_1_tab1_321 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_321
+DROP VIEW IF EXISTS view_2_tab1_321 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_321
+DROP VIEW IF EXISTS view_3_tab1_321 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9696,13 +9696,13 @@ SELECT pk FROM tab2 WHERE col3 IS NULL OR col1 > 29.53
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab2_321
+DROP VIEW IF EXISTS view_1_tab2_321 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_321
+DROP VIEW IF EXISTS view_2_tab2_321 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_321
+DROP VIEW IF EXISTS view_3_tab2_321 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9795,13 +9795,13 @@ SELECT pk FROM tab3 WHERE col3 IS NULL OR col1 > 29.53
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab3_321
+DROP VIEW IF EXISTS view_1_tab3_321 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_321
+DROP VIEW IF EXISTS view_2_tab3_321 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_321
+DROP VIEW IF EXISTS view_3_tab3_321 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9894,13 +9894,13 @@ SELECT pk FROM tab4 WHERE col3 IS NULL OR col1 > 29.53
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab4_321
+DROP VIEW IF EXISTS view_1_tab4_321 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_321
+DROP VIEW IF EXISTS view_2_tab4_321 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_321
+DROP VIEW IF EXISTS view_3_tab4_321 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9993,13 +9993,13 @@ SELECT pk FROM tab0 WHERE col3 BETWEEN 46 AND 60
 6
 
 statement ok
-DROP VIEW view_1_tab0_322
+DROP VIEW IF EXISTS view_1_tab0_322 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_322
+DROP VIEW IF EXISTS view_2_tab0_322 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_322
+DROP VIEW IF EXISTS view_3_tab0_322 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10092,13 +10092,13 @@ SELECT pk FROM tab1 WHERE col3 BETWEEN 46 AND 60
 6
 
 statement ok
-DROP VIEW view_1_tab1_322
+DROP VIEW IF EXISTS view_1_tab1_322 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_322
+DROP VIEW IF EXISTS view_2_tab1_322 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_322
+DROP VIEW IF EXISTS view_3_tab1_322 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10191,13 +10191,13 @@ SELECT pk FROM tab2 WHERE col3 BETWEEN 46 AND 60
 6
 
 statement ok
-DROP VIEW view_1_tab2_322
+DROP VIEW IF EXISTS view_1_tab2_322 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_322
+DROP VIEW IF EXISTS view_2_tab2_322 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_322
+DROP VIEW IF EXISTS view_3_tab2_322 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10290,13 +10290,13 @@ SELECT pk FROM tab3 WHERE col3 BETWEEN 46 AND 60
 6
 
 statement ok
-DROP VIEW view_1_tab3_322
+DROP VIEW IF EXISTS view_1_tab3_322 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_322
+DROP VIEW IF EXISTS view_2_tab3_322 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_322
+DROP VIEW IF EXISTS view_3_tab3_322 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10389,13 +10389,13 @@ SELECT pk FROM tab4 WHERE col3 BETWEEN 46 AND 60
 6
 
 statement ok
-DROP VIEW view_1_tab4_322
+DROP VIEW IF EXISTS view_1_tab4_322 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_322
+DROP VIEW IF EXISTS view_2_tab4_322 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_322
+DROP VIEW IF EXISTS view_3_tab4_322 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10481,13 +10481,13 @@ SELECT pk FROM tab0 WHERE col3 BETWEEN 88 AND 84
 ----
 
 statement ok
-DROP VIEW view_1_tab0_323
+DROP VIEW IF EXISTS view_1_tab0_323 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_323
+DROP VIEW IF EXISTS view_2_tab0_323 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_323
+DROP VIEW IF EXISTS view_3_tab0_323 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10573,13 +10573,13 @@ SELECT pk FROM tab1 WHERE col3 BETWEEN 88 AND 84
 ----
 
 statement ok
-DROP VIEW view_1_tab1_323
+DROP VIEW IF EXISTS view_1_tab1_323 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_323
+DROP VIEW IF EXISTS view_2_tab1_323 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_323
+DROP VIEW IF EXISTS view_3_tab1_323 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10665,13 +10665,13 @@ SELECT pk FROM tab2 WHERE col3 BETWEEN 88 AND 84
 ----
 
 statement ok
-DROP VIEW view_1_tab2_323
+DROP VIEW IF EXISTS view_1_tab2_323 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_323
+DROP VIEW IF EXISTS view_2_tab2_323 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_323
+DROP VIEW IF EXISTS view_3_tab2_323 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10757,13 +10757,13 @@ SELECT pk FROM tab3 WHERE col3 BETWEEN 88 AND 84
 ----
 
 statement ok
-DROP VIEW view_1_tab3_323
+DROP VIEW IF EXISTS view_1_tab3_323 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_323
+DROP VIEW IF EXISTS view_2_tab3_323 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_323
+DROP VIEW IF EXISTS view_3_tab3_323 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10849,13 +10849,13 @@ SELECT pk FROM tab4 WHERE col3 BETWEEN 88 AND 84
 ----
 
 statement ok
-DROP VIEW view_1_tab4_323
+DROP VIEW IF EXISTS view_1_tab4_323 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_323
+DROP VIEW IF EXISTS view_2_tab4_323 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_323
+DROP VIEW IF EXISTS view_3_tab4_323 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10958,13 +10958,13 @@ SELECT pk FROM tab0 WHERE col0 >= 33
 8
 
 statement ok
-DROP VIEW view_1_tab0_324
+DROP VIEW IF EXISTS view_1_tab0_324 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_324
+DROP VIEW IF EXISTS view_2_tab0_324 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_324
+DROP VIEW IF EXISTS view_3_tab0_324 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11067,13 +11067,13 @@ SELECT pk FROM tab1 WHERE col0 >= 33
 8
 
 statement ok
-DROP VIEW view_1_tab1_324
+DROP VIEW IF EXISTS view_1_tab1_324 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_324
+DROP VIEW IF EXISTS view_2_tab1_324 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_324
+DROP VIEW IF EXISTS view_3_tab1_324 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11176,13 +11176,13 @@ SELECT pk FROM tab2 WHERE col0 >= 33
 8
 
 statement ok
-DROP VIEW view_1_tab2_324
+DROP VIEW IF EXISTS view_1_tab2_324 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_324
+DROP VIEW IF EXISTS view_2_tab2_324 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_324
+DROP VIEW IF EXISTS view_3_tab2_324 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11285,13 +11285,13 @@ SELECT pk FROM tab3 WHERE col0 >= 33
 8
 
 statement ok
-DROP VIEW view_1_tab3_324
+DROP VIEW IF EXISTS view_1_tab3_324 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_324
+DROP VIEW IF EXISTS view_2_tab3_324 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_324
+DROP VIEW IF EXISTS view_3_tab3_324 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11394,13 +11394,13 @@ SELECT pk FROM tab4 WHERE col0 >= 33
 8
 
 statement ok
-DROP VIEW view_1_tab4_324
+DROP VIEW IF EXISTS view_1_tab4_324 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_324
+DROP VIEW IF EXISTS view_2_tab4_324 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_324
+DROP VIEW IF EXISTS view_3_tab4_324 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11486,13 +11486,13 @@ SELECT pk FROM tab0 WHERE col1 > 95.84
 ----
 
 statement ok
-DROP VIEW view_1_tab0_325
+DROP VIEW IF EXISTS view_1_tab0_325 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_325
+DROP VIEW IF EXISTS view_2_tab0_325 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_325
+DROP VIEW IF EXISTS view_3_tab0_325 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11578,13 +11578,13 @@ SELECT pk FROM tab1 WHERE col1 > 95.84
 ----
 
 statement ok
-DROP VIEW view_1_tab1_325
+DROP VIEW IF EXISTS view_1_tab1_325 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_325
+DROP VIEW IF EXISTS view_2_tab1_325 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_325
+DROP VIEW IF EXISTS view_3_tab1_325 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11670,13 +11670,13 @@ SELECT pk FROM tab2 WHERE col1 > 95.84
 ----
 
 statement ok
-DROP VIEW view_1_tab2_325
+DROP VIEW IF EXISTS view_1_tab2_325 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_325
+DROP VIEW IF EXISTS view_2_tab2_325 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_325
+DROP VIEW IF EXISTS view_3_tab2_325 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11762,13 +11762,13 @@ SELECT pk FROM tab3 WHERE col1 > 95.84
 ----
 
 statement ok
-DROP VIEW view_1_tab3_325
+DROP VIEW IF EXISTS view_1_tab3_325 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_325
+DROP VIEW IF EXISTS view_2_tab3_325 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_325
+DROP VIEW IF EXISTS view_3_tab3_325 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11854,13 +11854,13 @@ SELECT pk FROM tab4 WHERE col1 > 95.84
 ----
 
 statement ok
-DROP VIEW view_1_tab4_325
+DROP VIEW IF EXISTS view_1_tab4_325 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_325
+DROP VIEW IF EXISTS view_2_tab4_325 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_325
+DROP VIEW IF EXISTS view_3_tab4_325 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11953,13 +11953,13 @@ SELECT pk FROM tab0 WHERE col0 < 71
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab0_326
+DROP VIEW IF EXISTS view_1_tab0_326 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_326
+DROP VIEW IF EXISTS view_2_tab0_326 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_326
+DROP VIEW IF EXISTS view_3_tab0_326 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12052,13 +12052,13 @@ SELECT pk FROM tab1 WHERE col0 < 71
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab1_326
+DROP VIEW IF EXISTS view_1_tab1_326 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_326
+DROP VIEW IF EXISTS view_2_tab1_326 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_326
+DROP VIEW IF EXISTS view_3_tab1_326 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12151,13 +12151,13 @@ SELECT pk FROM tab2 WHERE col0 < 71
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab2_326
+DROP VIEW IF EXISTS view_1_tab2_326 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_326
+DROP VIEW IF EXISTS view_2_tab2_326 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_326
+DROP VIEW IF EXISTS view_3_tab2_326 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12250,13 +12250,13 @@ SELECT pk FROM tab3 WHERE col0 < 71
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab3_326
+DROP VIEW IF EXISTS view_1_tab3_326 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_326
+DROP VIEW IF EXISTS view_2_tab3_326 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_326
+DROP VIEW IF EXISTS view_3_tab3_326 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12349,13 +12349,13 @@ SELECT pk FROM tab4 WHERE col0 < 71
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab4_326
+DROP VIEW IF EXISTS view_1_tab4_326 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_326
+DROP VIEW IF EXISTS view_2_tab4_326 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_326
+DROP VIEW IF EXISTS view_3_tab4_326 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12441,13 +12441,13 @@ SELECT pk FROM tab0 WHERE col3 = 40
 ----
 
 statement ok
-DROP VIEW view_1_tab0_327
+DROP VIEW IF EXISTS view_1_tab0_327 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_327
+DROP VIEW IF EXISTS view_2_tab0_327 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_327
+DROP VIEW IF EXISTS view_3_tab0_327 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12533,13 +12533,13 @@ SELECT pk FROM tab1 WHERE col3 = 40
 ----
 
 statement ok
-DROP VIEW view_1_tab1_327
+DROP VIEW IF EXISTS view_1_tab1_327 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_327
+DROP VIEW IF EXISTS view_2_tab1_327 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_327
+DROP VIEW IF EXISTS view_3_tab1_327 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12625,13 +12625,13 @@ SELECT pk FROM tab2 WHERE col3 = 40
 ----
 
 statement ok
-DROP VIEW view_1_tab2_327
+DROP VIEW IF EXISTS view_1_tab2_327 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_327
+DROP VIEW IF EXISTS view_2_tab2_327 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_327
+DROP VIEW IF EXISTS view_3_tab2_327 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12717,13 +12717,13 @@ SELECT pk FROM tab3 WHERE col3 = 40
 ----
 
 statement ok
-DROP VIEW view_1_tab3_327
+DROP VIEW IF EXISTS view_1_tab3_327 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_327
+DROP VIEW IF EXISTS view_2_tab3_327 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_327
+DROP VIEW IF EXISTS view_3_tab3_327 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12809,13 +12809,13 @@ SELECT pk FROM tab4 WHERE col3 = 40
 ----
 
 statement ok
-DROP VIEW view_1_tab4_327
+DROP VIEW IF EXISTS view_1_tab4_327 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_327
+DROP VIEW IF EXISTS view_2_tab4_327 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_327
+DROP VIEW IF EXISTS view_3_tab4_327 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12908,13 +12908,13 @@ SELECT pk FROM tab0 WHERE col4 > 13.85
 9 values hashing to 4290bd41ca7ca69dc280e33882d8e9de
 
 statement ok
-DROP VIEW view_1_tab0_328
+DROP VIEW IF EXISTS view_1_tab0_328 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_328
+DROP VIEW IF EXISTS view_2_tab0_328 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_328
+DROP VIEW IF EXISTS view_3_tab0_328 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13007,13 +13007,13 @@ SELECT pk FROM tab1 WHERE col4 > 13.85
 9 values hashing to 4290bd41ca7ca69dc280e33882d8e9de
 
 statement ok
-DROP VIEW view_1_tab1_328
+DROP VIEW IF EXISTS view_1_tab1_328 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_328
+DROP VIEW IF EXISTS view_2_tab1_328 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_328
+DROP VIEW IF EXISTS view_3_tab1_328 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13106,13 +13106,13 @@ SELECT pk FROM tab2 WHERE col4 > 13.85
 9 values hashing to 4290bd41ca7ca69dc280e33882d8e9de
 
 statement ok
-DROP VIEW view_1_tab2_328
+DROP VIEW IF EXISTS view_1_tab2_328 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_328
+DROP VIEW IF EXISTS view_2_tab2_328 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_328
+DROP VIEW IF EXISTS view_3_tab2_328 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13205,13 +13205,13 @@ SELECT pk FROM tab3 WHERE col4 > 13.85
 9 values hashing to 4290bd41ca7ca69dc280e33882d8e9de
 
 statement ok
-DROP VIEW view_1_tab3_328
+DROP VIEW IF EXISTS view_1_tab3_328 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_328
+DROP VIEW IF EXISTS view_2_tab3_328 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_328
+DROP VIEW IF EXISTS view_3_tab3_328 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13304,13 +13304,13 @@ SELECT pk FROM tab4 WHERE col4 > 13.85
 9 values hashing to 4290bd41ca7ca69dc280e33882d8e9de
 
 statement ok
-DROP VIEW view_1_tab4_328
+DROP VIEW IF EXISTS view_1_tab4_328 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_328
+DROP VIEW IF EXISTS view_2_tab4_328 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_328
+DROP VIEW IF EXISTS view_3_tab4_328 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13399,13 +13399,13 @@ SELECT pk FROM tab0 WHERE (col3 >= 23 OR ((col0 <= 30)) AND col1 < 20.12 AND ((c
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_329
+DROP VIEW IF EXISTS view_1_tab0_329 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_329
+DROP VIEW IF EXISTS view_2_tab0_329 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_329
+DROP VIEW IF EXISTS view_3_tab0_329 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13494,13 +13494,13 @@ SELECT pk FROM tab1 WHERE (col3 >= 23 OR ((col0 <= 30)) AND col1 < 20.12 AND ((c
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_329
+DROP VIEW IF EXISTS view_1_tab1_329 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_329
+DROP VIEW IF EXISTS view_2_tab1_329 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_329
+DROP VIEW IF EXISTS view_3_tab1_329 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13589,13 +13589,13 @@ SELECT pk FROM tab2 WHERE (col3 >= 23 OR ((col0 <= 30)) AND col1 < 20.12 AND ((c
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_329
+DROP VIEW IF EXISTS view_1_tab2_329 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_329
+DROP VIEW IF EXISTS view_2_tab2_329 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_329
+DROP VIEW IF EXISTS view_3_tab2_329 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13684,13 +13684,13 @@ SELECT pk FROM tab3 WHERE (col3 >= 23 OR ((col0 <= 30)) AND col1 < 20.12 AND ((c
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_329
+DROP VIEW IF EXISTS view_1_tab3_329 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_329
+DROP VIEW IF EXISTS view_2_tab3_329 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_329
+DROP VIEW IF EXISTS view_3_tab3_329 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13779,13 +13779,13 @@ SELECT pk FROM tab4 WHERE (col3 >= 23 OR ((col0 <= 30)) AND col1 < 20.12 AND ((c
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_329
+DROP VIEW IF EXISTS view_1_tab4_329 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_329
+DROP VIEW IF EXISTS view_2_tab4_329 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_329
+DROP VIEW IF EXISTS view_3_tab4_329 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13871,13 +13871,13 @@ SELECT pk FROM tab0 WHERE col0 = 51
 ----
 
 statement ok
-DROP VIEW view_1_tab0_330
+DROP VIEW IF EXISTS view_1_tab0_330 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_330
+DROP VIEW IF EXISTS view_2_tab0_330 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_330
+DROP VIEW IF EXISTS view_3_tab0_330 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13963,13 +13963,13 @@ SELECT pk FROM tab1 WHERE col0 = 51
 ----
 
 statement ok
-DROP VIEW view_1_tab1_330
+DROP VIEW IF EXISTS view_1_tab1_330 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_330
+DROP VIEW IF EXISTS view_2_tab1_330 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_330
+DROP VIEW IF EXISTS view_3_tab1_330 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14055,13 +14055,13 @@ SELECT pk FROM tab2 WHERE col0 = 51
 ----
 
 statement ok
-DROP VIEW view_1_tab2_330
+DROP VIEW IF EXISTS view_1_tab2_330 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_330
+DROP VIEW IF EXISTS view_2_tab2_330 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_330
+DROP VIEW IF EXISTS view_3_tab2_330 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14147,13 +14147,13 @@ SELECT pk FROM tab3 WHERE col0 = 51
 ----
 
 statement ok
-DROP VIEW view_1_tab3_330
+DROP VIEW IF EXISTS view_1_tab3_330 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_330
+DROP VIEW IF EXISTS view_2_tab3_330 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_330
+DROP VIEW IF EXISTS view_3_tab3_330 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14239,13 +14239,13 @@ SELECT pk FROM tab4 WHERE col0 = 51
 ----
 
 statement ok
-DROP VIEW view_1_tab4_330
+DROP VIEW IF EXISTS view_1_tab4_330 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_330
+DROP VIEW IF EXISTS view_2_tab4_330 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_330
+DROP VIEW IF EXISTS view_3_tab4_330 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14359,13 +14359,13 @@ SELECT pk FROM tab0 WHERE col1 > 56.82
 7
 
 statement ok
-DROP VIEW view_1_tab0_331
+DROP VIEW IF EXISTS view_1_tab0_331 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_331
+DROP VIEW IF EXISTS view_2_tab0_331 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_331
+DROP VIEW IF EXISTS view_3_tab0_331 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14479,13 +14479,13 @@ SELECT pk FROM tab1 WHERE col1 > 56.82
 7
 
 statement ok
-DROP VIEW view_1_tab1_331
+DROP VIEW IF EXISTS view_1_tab1_331 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_331
+DROP VIEW IF EXISTS view_2_tab1_331 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_331
+DROP VIEW IF EXISTS view_3_tab1_331 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14599,13 +14599,13 @@ SELECT pk FROM tab2 WHERE col1 > 56.82
 7
 
 statement ok
-DROP VIEW view_1_tab2_331
+DROP VIEW IF EXISTS view_1_tab2_331 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_331
+DROP VIEW IF EXISTS view_2_tab2_331 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_331
+DROP VIEW IF EXISTS view_3_tab2_331 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14719,13 +14719,13 @@ SELECT pk FROM tab3 WHERE col1 > 56.82
 7
 
 statement ok
-DROP VIEW view_1_tab3_331
+DROP VIEW IF EXISTS view_1_tab3_331 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_331
+DROP VIEW IF EXISTS view_2_tab3_331 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_331
+DROP VIEW IF EXISTS view_3_tab3_331 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14839,13 +14839,13 @@ SELECT pk FROM tab4 WHERE col1 > 56.82
 7
 
 statement ok
-DROP VIEW view_1_tab4_331
+DROP VIEW IF EXISTS view_1_tab4_331 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_331
+DROP VIEW IF EXISTS view_2_tab4_331 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_331
+DROP VIEW IF EXISTS view_3_tab4_331 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14934,13 +14934,13 @@ SELECT pk FROM tab0 WHERE col1 < 89.41
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_332
+DROP VIEW IF EXISTS view_1_tab0_332 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_332
+DROP VIEW IF EXISTS view_2_tab0_332 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_332
+DROP VIEW IF EXISTS view_3_tab0_332 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15029,13 +15029,13 @@ SELECT pk FROM tab1 WHERE col1 < 89.41
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_332
+DROP VIEW IF EXISTS view_1_tab1_332 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_332
+DROP VIEW IF EXISTS view_2_tab1_332 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_332
+DROP VIEW IF EXISTS view_3_tab1_332 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15124,13 +15124,13 @@ SELECT pk FROM tab2 WHERE col1 < 89.41
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_332
+DROP VIEW IF EXISTS view_1_tab2_332 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_332
+DROP VIEW IF EXISTS view_2_tab2_332 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_332
+DROP VIEW IF EXISTS view_3_tab2_332 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15219,13 +15219,13 @@ SELECT pk FROM tab3 WHERE col1 < 89.41
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_332
+DROP VIEW IF EXISTS view_1_tab3_332 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_332
+DROP VIEW IF EXISTS view_2_tab3_332 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_332
+DROP VIEW IF EXISTS view_3_tab3_332 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15314,13 +15314,13 @@ SELECT pk FROM tab4 WHERE col1 < 89.41
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_332
+DROP VIEW IF EXISTS view_1_tab4_332 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_332
+DROP VIEW IF EXISTS view_2_tab4_332 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_332
+DROP VIEW IF EXISTS view_3_tab4_332 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15434,13 +15434,13 @@ SELECT pk FROM tab0 WHERE col0 > 49
 8
 
 statement ok
-DROP VIEW view_1_tab0_333
+DROP VIEW IF EXISTS view_1_tab0_333 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_333
+DROP VIEW IF EXISTS view_2_tab0_333 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_333
+DROP VIEW IF EXISTS view_3_tab0_333 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15554,13 +15554,13 @@ SELECT pk FROM tab1 WHERE col0 > 49
 8
 
 statement ok
-DROP VIEW view_1_tab1_333
+DROP VIEW IF EXISTS view_1_tab1_333 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_333
+DROP VIEW IF EXISTS view_2_tab1_333 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_333
+DROP VIEW IF EXISTS view_3_tab1_333 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15674,13 +15674,13 @@ SELECT pk FROM tab2 WHERE col0 > 49
 8
 
 statement ok
-DROP VIEW view_1_tab2_333
+DROP VIEW IF EXISTS view_1_tab2_333 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_333
+DROP VIEW IF EXISTS view_2_tab2_333 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_333
+DROP VIEW IF EXISTS view_3_tab2_333 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15794,13 +15794,13 @@ SELECT pk FROM tab3 WHERE col0 > 49
 8
 
 statement ok
-DROP VIEW view_1_tab3_333
+DROP VIEW IF EXISTS view_1_tab3_333 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_333
+DROP VIEW IF EXISTS view_2_tab3_333 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_333
+DROP VIEW IF EXISTS view_3_tab3_333 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15914,13 +15914,13 @@ SELECT pk FROM tab4 WHERE col0 > 49
 8
 
 statement ok
-DROP VIEW view_1_tab4_333
+DROP VIEW IF EXISTS view_1_tab4_333 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_333
+DROP VIEW IF EXISTS view_2_tab4_333 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_333
+DROP VIEW IF EXISTS view_3_tab4_333 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16039,13 +16039,13 @@ SELECT pk FROM tab0 WHERE col4 < 62.6
 9
 
 statement ok
-DROP VIEW view_1_tab0_334
+DROP VIEW IF EXISTS view_1_tab0_334 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_334
+DROP VIEW IF EXISTS view_2_tab0_334 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_334
+DROP VIEW IF EXISTS view_3_tab0_334 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16164,13 +16164,13 @@ SELECT pk FROM tab1 WHERE col4 < 62.6
 9
 
 statement ok
-DROP VIEW view_1_tab1_334
+DROP VIEW IF EXISTS view_1_tab1_334 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_334
+DROP VIEW IF EXISTS view_2_tab1_334 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_334
+DROP VIEW IF EXISTS view_3_tab1_334 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16289,13 +16289,13 @@ SELECT pk FROM tab2 WHERE col4 < 62.6
 9
 
 statement ok
-DROP VIEW view_1_tab2_334
+DROP VIEW IF EXISTS view_1_tab2_334 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_334
+DROP VIEW IF EXISTS view_2_tab2_334 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_334
+DROP VIEW IF EXISTS view_3_tab2_334 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16414,13 +16414,13 @@ SELECT pk FROM tab3 WHERE col4 < 62.6
 9
 
 statement ok
-DROP VIEW view_1_tab3_334
+DROP VIEW IF EXISTS view_1_tab3_334 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_334
+DROP VIEW IF EXISTS view_2_tab3_334 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_334
+DROP VIEW IF EXISTS view_3_tab3_334 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16539,13 +16539,13 @@ SELECT pk FROM tab4 WHERE col4 < 62.6
 9
 
 statement ok
-DROP VIEW view_1_tab4_334
+DROP VIEW IF EXISTS view_1_tab4_334 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_334
+DROP VIEW IF EXISTS view_2_tab4_334 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_334
+DROP VIEW IF EXISTS view_3_tab4_334 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16659,13 +16659,13 @@ SELECT pk FROM tab0 WHERE col3 > 40
 7
 
 statement ok
-DROP VIEW view_1_tab0_335
+DROP VIEW IF EXISTS view_1_tab0_335 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_335
+DROP VIEW IF EXISTS view_2_tab0_335 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_335
+DROP VIEW IF EXISTS view_3_tab0_335 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16779,13 +16779,13 @@ SELECT pk FROM tab1 WHERE col3 > 40
 7
 
 statement ok
-DROP VIEW view_1_tab1_335
+DROP VIEW IF EXISTS view_1_tab1_335 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_335
+DROP VIEW IF EXISTS view_2_tab1_335 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_335
+DROP VIEW IF EXISTS view_3_tab1_335 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16899,13 +16899,13 @@ SELECT pk FROM tab2 WHERE col3 > 40
 7
 
 statement ok
-DROP VIEW view_1_tab2_335
+DROP VIEW IF EXISTS view_1_tab2_335 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_335
+DROP VIEW IF EXISTS view_2_tab2_335 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_335
+DROP VIEW IF EXISTS view_3_tab2_335 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17019,13 +17019,13 @@ SELECT pk FROM tab3 WHERE col3 > 40
 7
 
 statement ok
-DROP VIEW view_1_tab3_335
+DROP VIEW IF EXISTS view_1_tab3_335 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_335
+DROP VIEW IF EXISTS view_2_tab3_335 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_335
+DROP VIEW IF EXISTS view_3_tab3_335 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17139,13 +17139,13 @@ SELECT pk FROM tab4 WHERE col3 > 40
 7
 
 statement ok
-DROP VIEW view_1_tab4_335
+DROP VIEW IF EXISTS view_1_tab4_335 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_335
+DROP VIEW IF EXISTS view_2_tab4_335 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_335
+DROP VIEW IF EXISTS view_3_tab4_335 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17231,13 +17231,13 @@ SELECT pk FROM tab0 WHERE col0 >= 87
 ----
 
 statement ok
-DROP VIEW view_1_tab0_336
+DROP VIEW IF EXISTS view_1_tab0_336 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_336
+DROP VIEW IF EXISTS view_2_tab0_336 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_336
+DROP VIEW IF EXISTS view_3_tab0_336 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17323,13 +17323,13 @@ SELECT pk FROM tab1 WHERE col0 >= 87
 ----
 
 statement ok
-DROP VIEW view_1_tab1_336
+DROP VIEW IF EXISTS view_1_tab1_336 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_336
+DROP VIEW IF EXISTS view_2_tab1_336 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_336
+DROP VIEW IF EXISTS view_3_tab1_336 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17415,13 +17415,13 @@ SELECT pk FROM tab2 WHERE col0 >= 87
 ----
 
 statement ok
-DROP VIEW view_1_tab2_336
+DROP VIEW IF EXISTS view_1_tab2_336 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_336
+DROP VIEW IF EXISTS view_2_tab2_336 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_336
+DROP VIEW IF EXISTS view_3_tab2_336 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17507,13 +17507,13 @@ SELECT pk FROM tab3 WHERE col0 >= 87
 ----
 
 statement ok
-DROP VIEW view_1_tab3_336
+DROP VIEW IF EXISTS view_1_tab3_336 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_336
+DROP VIEW IF EXISTS view_2_tab3_336 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_336
+DROP VIEW IF EXISTS view_3_tab3_336 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17599,13 +17599,13 @@ SELECT pk FROM tab4 WHERE col0 >= 87
 ----
 
 statement ok
-DROP VIEW view_1_tab4_336
+DROP VIEW IF EXISTS view_1_tab4_336 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_336
+DROP VIEW IF EXISTS view_2_tab4_336 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_336
+DROP VIEW IF EXISTS view_3_tab4_336 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17708,13 +17708,13 @@ SELECT pk FROM tab0 WHERE col4 > 42.91
 9
 
 statement ok
-DROP VIEW view_1_tab0_337
+DROP VIEW IF EXISTS view_1_tab0_337 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_337
+DROP VIEW IF EXISTS view_2_tab0_337 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_337
+DROP VIEW IF EXISTS view_3_tab0_337 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17817,13 +17817,13 @@ SELECT pk FROM tab1 WHERE col4 > 42.91
 9
 
 statement ok
-DROP VIEW view_1_tab1_337
+DROP VIEW IF EXISTS view_1_tab1_337 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_337
+DROP VIEW IF EXISTS view_2_tab1_337 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_337
+DROP VIEW IF EXISTS view_3_tab1_337 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17926,13 +17926,13 @@ SELECT pk FROM tab2 WHERE col4 > 42.91
 9
 
 statement ok
-DROP VIEW view_1_tab2_337
+DROP VIEW IF EXISTS view_1_tab2_337 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_337
+DROP VIEW IF EXISTS view_2_tab2_337 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_337
+DROP VIEW IF EXISTS view_3_tab2_337 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18035,13 +18035,13 @@ SELECT pk FROM tab3 WHERE col4 > 42.91
 9
 
 statement ok
-DROP VIEW view_1_tab3_337
+DROP VIEW IF EXISTS view_1_tab3_337 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_337
+DROP VIEW IF EXISTS view_2_tab3_337 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_337
+DROP VIEW IF EXISTS view_3_tab3_337 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18144,13 +18144,13 @@ SELECT pk FROM tab4 WHERE col4 > 42.91
 9
 
 statement ok
-DROP VIEW view_1_tab4_337
+DROP VIEW IF EXISTS view_1_tab4_337 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_337
+DROP VIEW IF EXISTS view_2_tab4_337 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_337
+DROP VIEW IF EXISTS view_3_tab4_337 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18257,13 +18257,13 @@ SELECT pk FROM tab0 WHERE (col3 > 69)
 7
 
 statement ok
-DROP VIEW view_1_tab0_338
+DROP VIEW IF EXISTS view_1_tab0_338 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_338
+DROP VIEW IF EXISTS view_2_tab0_338 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_338
+DROP VIEW IF EXISTS view_3_tab0_338 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18370,13 +18370,13 @@ SELECT pk FROM tab1 WHERE (col3 > 69)
 7
 
 statement ok
-DROP VIEW view_1_tab1_338
+DROP VIEW IF EXISTS view_1_tab1_338 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_338
+DROP VIEW IF EXISTS view_2_tab1_338 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_338
+DROP VIEW IF EXISTS view_3_tab1_338 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18483,13 +18483,13 @@ SELECT pk FROM tab2 WHERE (col3 > 69)
 7
 
 statement ok
-DROP VIEW view_1_tab2_338
+DROP VIEW IF EXISTS view_1_tab2_338 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_338
+DROP VIEW IF EXISTS view_2_tab2_338 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_338
+DROP VIEW IF EXISTS view_3_tab2_338 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18596,13 +18596,13 @@ SELECT pk FROM tab3 WHERE (col3 > 69)
 7
 
 statement ok
-DROP VIEW view_1_tab3_338
+DROP VIEW IF EXISTS view_1_tab3_338 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_338
+DROP VIEW IF EXISTS view_2_tab3_338 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_338
+DROP VIEW IF EXISTS view_3_tab3_338 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18709,13 +18709,13 @@ SELECT pk FROM tab4 WHERE (col3 > 69)
 7
 
 statement ok
-DROP VIEW view_1_tab4_338
+DROP VIEW IF EXISTS view_1_tab4_338 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_338
+DROP VIEW IF EXISTS view_2_tab4_338 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_338
+DROP VIEW IF EXISTS view_3_tab4_338 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18801,13 +18801,13 @@ SELECT pk FROM tab0 WHERE col4 > 67.67 AND col3 IN (52,47,10,34,16,83)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_339
+DROP VIEW IF EXISTS view_1_tab0_339 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_339
+DROP VIEW IF EXISTS view_2_tab0_339 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_339
+DROP VIEW IF EXISTS view_3_tab0_339 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18893,13 +18893,13 @@ SELECT pk FROM tab1 WHERE col4 > 67.67 AND col3 IN (52,47,10,34,16,83)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_339
+DROP VIEW IF EXISTS view_1_tab1_339 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_339
+DROP VIEW IF EXISTS view_2_tab1_339 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_339
+DROP VIEW IF EXISTS view_3_tab1_339 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18985,13 +18985,13 @@ SELECT pk FROM tab2 WHERE col4 > 67.67 AND col3 IN (52,47,10,34,16,83)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_339
+DROP VIEW IF EXISTS view_1_tab2_339 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_339
+DROP VIEW IF EXISTS view_2_tab2_339 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_339
+DROP VIEW IF EXISTS view_3_tab2_339 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19077,13 +19077,13 @@ SELECT pk FROM tab3 WHERE col4 > 67.67 AND col3 IN (52,47,10,34,16,83)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_339
+DROP VIEW IF EXISTS view_1_tab3_339 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_339
+DROP VIEW IF EXISTS view_2_tab3_339 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_339
+DROP VIEW IF EXISTS view_3_tab3_339 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19169,13 +19169,13 @@ SELECT pk FROM tab4 WHERE col4 > 67.67 AND col3 IN (52,47,10,34,16,83)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_339
+DROP VIEW IF EXISTS view_1_tab4_339 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_339
+DROP VIEW IF EXISTS view_2_tab4_339 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_339
+DROP VIEW IF EXISTS view_3_tab4_339 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19294,13 +19294,13 @@ SELECT pk FROM tab0 WHERE (col3 IS NULL) OR col0 IS NULL AND col1 > 45.14 OR col
 9
 
 statement ok
-DROP VIEW view_1_tab0_340
+DROP VIEW IF EXISTS view_1_tab0_340 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_340
+DROP VIEW IF EXISTS view_2_tab0_340 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_340
+DROP VIEW IF EXISTS view_3_tab0_340 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19419,13 +19419,13 @@ SELECT pk FROM tab1 WHERE (col3 IS NULL) OR col0 IS NULL AND col1 > 45.14 OR col
 9
 
 statement ok
-DROP VIEW view_1_tab1_340
+DROP VIEW IF EXISTS view_1_tab1_340 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_340
+DROP VIEW IF EXISTS view_2_tab1_340 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_340
+DROP VIEW IF EXISTS view_3_tab1_340 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19544,13 +19544,13 @@ SELECT pk FROM tab2 WHERE (col3 IS NULL) OR col0 IS NULL AND col1 > 45.14 OR col
 9
 
 statement ok
-DROP VIEW view_1_tab2_340
+DROP VIEW IF EXISTS view_1_tab2_340 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_340
+DROP VIEW IF EXISTS view_2_tab2_340 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_340
+DROP VIEW IF EXISTS view_3_tab2_340 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19669,13 +19669,13 @@ SELECT pk FROM tab3 WHERE (col3 IS NULL) OR col0 IS NULL AND col1 > 45.14 OR col
 9
 
 statement ok
-DROP VIEW view_1_tab3_340
+DROP VIEW IF EXISTS view_1_tab3_340 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_340
+DROP VIEW IF EXISTS view_2_tab3_340 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_340
+DROP VIEW IF EXISTS view_3_tab3_340 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19794,13 +19794,13 @@ SELECT pk FROM tab4 WHERE (col3 IS NULL) OR col0 IS NULL AND col1 > 45.14 OR col
 9
 
 statement ok
-DROP VIEW view_1_tab4_340
+DROP VIEW IF EXISTS view_1_tab4_340 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_340
+DROP VIEW IF EXISTS view_2_tab4_340 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_340
+DROP VIEW IF EXISTS view_3_tab4_340 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19907,13 +19907,13 @@ SELECT pk FROM tab0 WHERE (col0 IN (99,27,88,27,16,64)) AND col4 > 10.42 OR col4
 8
 
 statement ok
-DROP VIEW view_1_tab0_341
+DROP VIEW IF EXISTS view_1_tab0_341 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_341
+DROP VIEW IF EXISTS view_2_tab0_341 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_341
+DROP VIEW IF EXISTS view_3_tab0_341 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20020,13 +20020,13 @@ SELECT pk FROM tab1 WHERE (col0 IN (99,27,88,27,16,64)) AND col4 > 10.42 OR col4
 8
 
 statement ok
-DROP VIEW view_1_tab1_341
+DROP VIEW IF EXISTS view_1_tab1_341 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_341
+DROP VIEW IF EXISTS view_2_tab1_341 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_341
+DROP VIEW IF EXISTS view_3_tab1_341 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20133,13 +20133,13 @@ SELECT pk FROM tab2 WHERE (col0 IN (99,27,88,27,16,64)) AND col4 > 10.42 OR col4
 8
 
 statement ok
-DROP VIEW view_1_tab2_341
+DROP VIEW IF EXISTS view_1_tab2_341 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_341
+DROP VIEW IF EXISTS view_2_tab2_341 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_341
+DROP VIEW IF EXISTS view_3_tab2_341 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20246,13 +20246,13 @@ SELECT pk FROM tab3 WHERE (col0 IN (99,27,88,27,16,64)) AND col4 > 10.42 OR col4
 8
 
 statement ok
-DROP VIEW view_1_tab3_341
+DROP VIEW IF EXISTS view_1_tab3_341 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_341
+DROP VIEW IF EXISTS view_2_tab3_341 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_341
+DROP VIEW IF EXISTS view_3_tab3_341 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20359,13 +20359,13 @@ SELECT pk FROM tab4 WHERE (col0 IN (99,27,88,27,16,64)) AND col4 > 10.42 OR col4
 8
 
 statement ok
-DROP VIEW view_1_tab4_341
+DROP VIEW IF EXISTS view_1_tab4_341 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_341
+DROP VIEW IF EXISTS view_2_tab4_341 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_341
+DROP VIEW IF EXISTS view_3_tab4_341 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20458,13 +20458,13 @@ SELECT pk FROM tab0 WHERE ((col1 = 56.5)) OR col0 >= 5
 9 values hashing to 502f27eec143c19418cc601be1d35451
 
 statement ok
-DROP VIEW view_1_tab0_342
+DROP VIEW IF EXISTS view_1_tab0_342 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_342
+DROP VIEW IF EXISTS view_2_tab0_342 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_342
+DROP VIEW IF EXISTS view_3_tab0_342 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20557,13 +20557,13 @@ SELECT pk FROM tab1 WHERE ((col1 = 56.5)) OR col0 >= 5
 9 values hashing to 502f27eec143c19418cc601be1d35451
 
 statement ok
-DROP VIEW view_1_tab1_342
+DROP VIEW IF EXISTS view_1_tab1_342 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_342
+DROP VIEW IF EXISTS view_2_tab1_342 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_342
+DROP VIEW IF EXISTS view_3_tab1_342 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20656,13 +20656,13 @@ SELECT pk FROM tab2 WHERE ((col1 = 56.5)) OR col0 >= 5
 9 values hashing to 502f27eec143c19418cc601be1d35451
 
 statement ok
-DROP VIEW view_1_tab2_342
+DROP VIEW IF EXISTS view_1_tab2_342 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_342
+DROP VIEW IF EXISTS view_2_tab2_342 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_342
+DROP VIEW IF EXISTS view_3_tab2_342 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20755,13 +20755,13 @@ SELECT pk FROM tab3 WHERE ((col1 = 56.5)) OR col0 >= 5
 9 values hashing to 502f27eec143c19418cc601be1d35451
 
 statement ok
-DROP VIEW view_1_tab3_342
+DROP VIEW IF EXISTS view_1_tab3_342 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_342
+DROP VIEW IF EXISTS view_2_tab3_342 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_342
+DROP VIEW IF EXISTS view_3_tab3_342 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20854,13 +20854,13 @@ SELECT pk FROM tab4 WHERE ((col1 = 56.5)) OR col0 >= 5
 9 values hashing to 502f27eec143c19418cc601be1d35451
 
 statement ok
-DROP VIEW view_1_tab4_342
+DROP VIEW IF EXISTS view_1_tab4_342 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_342
+DROP VIEW IF EXISTS view_2_tab4_342 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_342
+DROP VIEW IF EXISTS view_3_tab4_342 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20963,13 +20963,13 @@ SELECT pk FROM tab0 WHERE col0 < 38
 9
 
 statement ok
-DROP VIEW view_1_tab0_343
+DROP VIEW IF EXISTS view_1_tab0_343 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_343
+DROP VIEW IF EXISTS view_2_tab0_343 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_343
+DROP VIEW IF EXISTS view_3_tab0_343 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21072,13 +21072,13 @@ SELECT pk FROM tab1 WHERE col0 < 38
 9
 
 statement ok
-DROP VIEW view_1_tab1_343
+DROP VIEW IF EXISTS view_1_tab1_343 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_343
+DROP VIEW IF EXISTS view_2_tab1_343 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_343
+DROP VIEW IF EXISTS view_3_tab1_343 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21181,13 +21181,13 @@ SELECT pk FROM tab2 WHERE col0 < 38
 9
 
 statement ok
-DROP VIEW view_1_tab2_343
+DROP VIEW IF EXISTS view_1_tab2_343 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_343
+DROP VIEW IF EXISTS view_2_tab2_343 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_343
+DROP VIEW IF EXISTS view_3_tab2_343 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21290,13 +21290,13 @@ SELECT pk FROM tab3 WHERE col0 < 38
 9
 
 statement ok
-DROP VIEW view_1_tab3_343
+DROP VIEW IF EXISTS view_1_tab3_343 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_343
+DROP VIEW IF EXISTS view_2_tab3_343 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_343
+DROP VIEW IF EXISTS view_3_tab3_343 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21399,13 +21399,13 @@ SELECT pk FROM tab4 WHERE col0 < 38
 9
 
 statement ok
-DROP VIEW view_1_tab4_343
+DROP VIEW IF EXISTS view_1_tab4_343 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_343
+DROP VIEW IF EXISTS view_2_tab4_343 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_343
+DROP VIEW IF EXISTS view_3_tab4_343 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21491,13 +21491,13 @@ SELECT pk FROM tab0 WHERE (col4 = 78.55 AND (col0 > 61))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_344
+DROP VIEW IF EXISTS view_1_tab0_344 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_344
+DROP VIEW IF EXISTS view_2_tab0_344 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_344
+DROP VIEW IF EXISTS view_3_tab0_344 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21583,13 +21583,13 @@ SELECT pk FROM tab1 WHERE (col4 = 78.55 AND (col0 > 61))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_344
+DROP VIEW IF EXISTS view_1_tab1_344 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_344
+DROP VIEW IF EXISTS view_2_tab1_344 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_344
+DROP VIEW IF EXISTS view_3_tab1_344 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21675,13 +21675,13 @@ SELECT pk FROM tab2 WHERE (col4 = 78.55 AND (col0 > 61))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_344
+DROP VIEW IF EXISTS view_1_tab2_344 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_344
+DROP VIEW IF EXISTS view_2_tab2_344 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_344
+DROP VIEW IF EXISTS view_3_tab2_344 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21767,13 +21767,13 @@ SELECT pk FROM tab3 WHERE (col4 = 78.55 AND (col0 > 61))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_344
+DROP VIEW IF EXISTS view_1_tab3_344 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_344
+DROP VIEW IF EXISTS view_2_tab3_344 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_344
+DROP VIEW IF EXISTS view_3_tab3_344 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21859,13 +21859,13 @@ SELECT pk FROM tab4 WHERE (col4 = 78.55 AND (col0 > 61))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_344
+DROP VIEW IF EXISTS view_1_tab4_344 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_344
+DROP VIEW IF EXISTS view_2_tab4_344 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_344
+DROP VIEW IF EXISTS view_3_tab4_344 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21958,13 +21958,13 @@ SELECT pk FROM tab0 WHERE col1 > 22.55
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab0_345
+DROP VIEW IF EXISTS view_1_tab0_345 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_345
+DROP VIEW IF EXISTS view_2_tab0_345 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_345
+DROP VIEW IF EXISTS view_3_tab0_345 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22057,13 +22057,13 @@ SELECT pk FROM tab1 WHERE col1 > 22.55
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab1_345
+DROP VIEW IF EXISTS view_1_tab1_345 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_345
+DROP VIEW IF EXISTS view_2_tab1_345 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_345
+DROP VIEW IF EXISTS view_3_tab1_345 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22156,13 +22156,13 @@ SELECT pk FROM tab2 WHERE col1 > 22.55
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab2_345
+DROP VIEW IF EXISTS view_1_tab2_345 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_345
+DROP VIEW IF EXISTS view_2_tab2_345 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_345
+DROP VIEW IF EXISTS view_3_tab2_345 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22255,13 +22255,13 @@ SELECT pk FROM tab3 WHERE col1 > 22.55
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab3_345
+DROP VIEW IF EXISTS view_1_tab3_345 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_345
+DROP VIEW IF EXISTS view_2_tab3_345 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_345
+DROP VIEW IF EXISTS view_3_tab3_345 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22354,13 +22354,13 @@ SELECT pk FROM tab4 WHERE col1 > 22.55
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab4_345
+DROP VIEW IF EXISTS view_1_tab4_345 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_345
+DROP VIEW IF EXISTS view_2_tab4_345 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_345
+DROP VIEW IF EXISTS view_3_tab4_345 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22449,13 +22449,13 @@ SELECT pk FROM tab0 WHERE col1 IS NULL OR col4 < 0.19 OR col0 IS NULL OR (col0 >
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_346
+DROP VIEW IF EXISTS view_1_tab0_346 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_346
+DROP VIEW IF EXISTS view_2_tab0_346 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_346
+DROP VIEW IF EXISTS view_3_tab0_346 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22544,13 +22544,13 @@ SELECT pk FROM tab1 WHERE col1 IS NULL OR col4 < 0.19 OR col0 IS NULL OR (col0 >
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_346
+DROP VIEW IF EXISTS view_1_tab1_346 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_346
+DROP VIEW IF EXISTS view_2_tab1_346 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_346
+DROP VIEW IF EXISTS view_3_tab1_346 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22639,13 +22639,13 @@ SELECT pk FROM tab2 WHERE col1 IS NULL OR col4 < 0.19 OR col0 IS NULL OR (col0 >
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_346
+DROP VIEW IF EXISTS view_1_tab2_346 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_346
+DROP VIEW IF EXISTS view_2_tab2_346 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_346
+DROP VIEW IF EXISTS view_3_tab2_346 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22734,13 +22734,13 @@ SELECT pk FROM tab3 WHERE col1 IS NULL OR col4 < 0.19 OR col0 IS NULL OR (col0 >
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_346
+DROP VIEW IF EXISTS view_1_tab3_346 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_346
+DROP VIEW IF EXISTS view_2_tab3_346 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_346
+DROP VIEW IF EXISTS view_3_tab3_346 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22829,13 +22829,13 @@ SELECT pk FROM tab4 WHERE col1 IS NULL OR col4 < 0.19 OR col0 IS NULL OR (col0 >
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_346
+DROP VIEW IF EXISTS view_1_tab4_346 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_346
+DROP VIEW IF EXISTS view_2_tab4_346 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_346
+DROP VIEW IF EXISTS view_3_tab4_346 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22921,13 +22921,13 @@ SELECT pk FROM tab0 WHERE col0 < 4 AND col3 > 37 AND col3 < 53
 ----
 
 statement ok
-DROP VIEW view_1_tab0_347
+DROP VIEW IF EXISTS view_1_tab0_347 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_347
+DROP VIEW IF EXISTS view_2_tab0_347 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_347
+DROP VIEW IF EXISTS view_3_tab0_347 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23013,13 +23013,13 @@ SELECT pk FROM tab1 WHERE col0 < 4 AND col3 > 37 AND col3 < 53
 ----
 
 statement ok
-DROP VIEW view_1_tab1_347
+DROP VIEW IF EXISTS view_1_tab1_347 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_347
+DROP VIEW IF EXISTS view_2_tab1_347 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_347
+DROP VIEW IF EXISTS view_3_tab1_347 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23105,13 +23105,13 @@ SELECT pk FROM tab2 WHERE col0 < 4 AND col3 > 37 AND col3 < 53
 ----
 
 statement ok
-DROP VIEW view_1_tab2_347
+DROP VIEW IF EXISTS view_1_tab2_347 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_347
+DROP VIEW IF EXISTS view_2_tab2_347 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_347
+DROP VIEW IF EXISTS view_3_tab2_347 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23197,13 +23197,13 @@ SELECT pk FROM tab3 WHERE col0 < 4 AND col3 > 37 AND col3 < 53
 ----
 
 statement ok
-DROP VIEW view_1_tab3_347
+DROP VIEW IF EXISTS view_1_tab3_347 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_347
+DROP VIEW IF EXISTS view_2_tab3_347 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_347
+DROP VIEW IF EXISTS view_3_tab3_347 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23289,13 +23289,13 @@ SELECT pk FROM tab4 WHERE col0 < 4 AND col3 > 37 AND col3 < 53
 ----
 
 statement ok
-DROP VIEW view_1_tab4_347
+DROP VIEW IF EXISTS view_1_tab4_347 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_347
+DROP VIEW IF EXISTS view_2_tab4_347 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_347
+DROP VIEW IF EXISTS view_3_tab4_347 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23413,13 +23413,13 @@ SELECT pk FROM tab0 WHERE col0 >= 8
 9
 
 statement ok
-DROP VIEW view_1_tab0_348
+DROP VIEW IF EXISTS view_1_tab0_348 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_348
+DROP VIEW IF EXISTS view_2_tab0_348 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_348
+DROP VIEW IF EXISTS view_3_tab0_348 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23537,13 +23537,13 @@ SELECT pk FROM tab1 WHERE col0 >= 8
 9
 
 statement ok
-DROP VIEW view_1_tab1_348
+DROP VIEW IF EXISTS view_1_tab1_348 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_348
+DROP VIEW IF EXISTS view_2_tab1_348 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_348
+DROP VIEW IF EXISTS view_3_tab1_348 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23661,13 +23661,13 @@ SELECT pk FROM tab2 WHERE col0 >= 8
 9
 
 statement ok
-DROP VIEW view_1_tab2_348
+DROP VIEW IF EXISTS view_1_tab2_348 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_348
+DROP VIEW IF EXISTS view_2_tab2_348 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_348
+DROP VIEW IF EXISTS view_3_tab2_348 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23785,13 +23785,13 @@ SELECT pk FROM tab3 WHERE col0 >= 8
 9
 
 statement ok
-DROP VIEW view_1_tab3_348
+DROP VIEW IF EXISTS view_1_tab3_348 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_348
+DROP VIEW IF EXISTS view_2_tab3_348 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_348
+DROP VIEW IF EXISTS view_3_tab3_348 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23909,13 +23909,13 @@ SELECT pk FROM tab4 WHERE col0 >= 8
 9
 
 statement ok
-DROP VIEW view_1_tab4_348
+DROP VIEW IF EXISTS view_1_tab4_348 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_348
+DROP VIEW IF EXISTS view_2_tab4_348 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_348
+DROP VIEW IF EXISTS view_3_tab4_348 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24001,13 +24001,13 @@ SELECT pk FROM tab0 WHERE (col0 > 94)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_349
+DROP VIEW IF EXISTS view_1_tab0_349 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_349
+DROP VIEW IF EXISTS view_2_tab0_349 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_349
+DROP VIEW IF EXISTS view_3_tab0_349 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24093,13 +24093,13 @@ SELECT pk FROM tab1 WHERE (col0 > 94)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_349
+DROP VIEW IF EXISTS view_1_tab1_349 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_349
+DROP VIEW IF EXISTS view_2_tab1_349 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_349
+DROP VIEW IF EXISTS view_3_tab1_349 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24185,13 +24185,13 @@ SELECT pk FROM tab2 WHERE (col0 > 94)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_349
+DROP VIEW IF EXISTS view_1_tab2_349 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_349
+DROP VIEW IF EXISTS view_2_tab2_349 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_349
+DROP VIEW IF EXISTS view_3_tab2_349 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24277,13 +24277,13 @@ SELECT pk FROM tab3 WHERE (col0 > 94)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_349
+DROP VIEW IF EXISTS view_1_tab3_349 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_349
+DROP VIEW IF EXISTS view_2_tab3_349 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_349
+DROP VIEW IF EXISTS view_3_tab3_349 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24369,13 +24369,13 @@ SELECT pk FROM tab4 WHERE (col0 > 94)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_349
+DROP VIEW IF EXISTS view_1_tab4_349 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_349
+DROP VIEW IF EXISTS view_2_tab4_349 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_349
+DROP VIEW IF EXISTS view_3_tab4_349 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24461,13 +24461,13 @@ SELECT pk FROM tab0 WHERE col0 > 18 AND col0 > 78
 ----
 
 statement ok
-DROP VIEW view_1_tab0_350
+DROP VIEW IF EXISTS view_1_tab0_350 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_350
+DROP VIEW IF EXISTS view_2_tab0_350 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_350
+DROP VIEW IF EXISTS view_3_tab0_350 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24553,13 +24553,13 @@ SELECT pk FROM tab1 WHERE col0 > 18 AND col0 > 78
 ----
 
 statement ok
-DROP VIEW view_1_tab1_350
+DROP VIEW IF EXISTS view_1_tab1_350 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_350
+DROP VIEW IF EXISTS view_2_tab1_350 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_350
+DROP VIEW IF EXISTS view_3_tab1_350 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24645,13 +24645,13 @@ SELECT pk FROM tab2 WHERE col0 > 18 AND col0 > 78
 ----
 
 statement ok
-DROP VIEW view_1_tab2_350
+DROP VIEW IF EXISTS view_1_tab2_350 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_350
+DROP VIEW IF EXISTS view_2_tab2_350 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_350
+DROP VIEW IF EXISTS view_3_tab2_350 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24737,13 +24737,13 @@ SELECT pk FROM tab3 WHERE col0 > 18 AND col0 > 78
 ----
 
 statement ok
-DROP VIEW view_1_tab3_350
+DROP VIEW IF EXISTS view_1_tab3_350 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_350
+DROP VIEW IF EXISTS view_2_tab3_350 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_350
+DROP VIEW IF EXISTS view_3_tab3_350 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24829,13 +24829,13 @@ SELECT pk FROM tab4 WHERE col0 > 18 AND col0 > 78
 ----
 
 statement ok
-DROP VIEW view_1_tab4_350
+DROP VIEW IF EXISTS view_1_tab4_350 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_350
+DROP VIEW IF EXISTS view_2_tab4_350 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_350
+DROP VIEW IF EXISTS view_3_tab4_350 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24949,13 +24949,13 @@ SELECT pk FROM tab0 WHERE col4 BETWEEN 52.12 AND 90.29
 9
 
 statement ok
-DROP VIEW view_1_tab0_351
+DROP VIEW IF EXISTS view_1_tab0_351 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_351
+DROP VIEW IF EXISTS view_2_tab0_351 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_351
+DROP VIEW IF EXISTS view_3_tab0_351 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25069,13 +25069,13 @@ SELECT pk FROM tab1 WHERE col4 BETWEEN 52.12 AND 90.29
 9
 
 statement ok
-DROP VIEW view_1_tab1_351
+DROP VIEW IF EXISTS view_1_tab1_351 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_351
+DROP VIEW IF EXISTS view_2_tab1_351 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_351
+DROP VIEW IF EXISTS view_3_tab1_351 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25189,13 +25189,13 @@ SELECT pk FROM tab2 WHERE col4 BETWEEN 52.12 AND 90.29
 9
 
 statement ok
-DROP VIEW view_1_tab2_351
+DROP VIEW IF EXISTS view_1_tab2_351 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_351
+DROP VIEW IF EXISTS view_2_tab2_351 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_351
+DROP VIEW IF EXISTS view_3_tab2_351 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25309,13 +25309,13 @@ SELECT pk FROM tab3 WHERE col4 BETWEEN 52.12 AND 90.29
 9
 
 statement ok
-DROP VIEW view_1_tab3_351
+DROP VIEW IF EXISTS view_1_tab3_351 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_351
+DROP VIEW IF EXISTS view_2_tab3_351 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_351
+DROP VIEW IF EXISTS view_3_tab3_351 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25429,13 +25429,13 @@ SELECT pk FROM tab4 WHERE col4 BETWEEN 52.12 AND 90.29
 9
 
 statement ok
-DROP VIEW view_1_tab4_351
+DROP VIEW IF EXISTS view_1_tab4_351 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_351
+DROP VIEW IF EXISTS view_2_tab4_351 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_351
+DROP VIEW IF EXISTS view_3_tab4_351 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25521,13 +25521,13 @@ SELECT pk FROM tab0 WHERE col1 > 81.45 AND col4 BETWEEN 25.22 AND 40.20
 ----
 
 statement ok
-DROP VIEW view_1_tab0_352
+DROP VIEW IF EXISTS view_1_tab0_352 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_352
+DROP VIEW IF EXISTS view_2_tab0_352 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_352
+DROP VIEW IF EXISTS view_3_tab0_352 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25613,13 +25613,13 @@ SELECT pk FROM tab1 WHERE col1 > 81.45 AND col4 BETWEEN 25.22 AND 40.20
 ----
 
 statement ok
-DROP VIEW view_1_tab1_352
+DROP VIEW IF EXISTS view_1_tab1_352 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_352
+DROP VIEW IF EXISTS view_2_tab1_352 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_352
+DROP VIEW IF EXISTS view_3_tab1_352 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25705,13 +25705,13 @@ SELECT pk FROM tab2 WHERE col1 > 81.45 AND col4 BETWEEN 25.22 AND 40.20
 ----
 
 statement ok
-DROP VIEW view_1_tab2_352
+DROP VIEW IF EXISTS view_1_tab2_352 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_352
+DROP VIEW IF EXISTS view_2_tab2_352 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_352
+DROP VIEW IF EXISTS view_3_tab2_352 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25797,13 +25797,13 @@ SELECT pk FROM tab3 WHERE col1 > 81.45 AND col4 BETWEEN 25.22 AND 40.20
 ----
 
 statement ok
-DROP VIEW view_1_tab3_352
+DROP VIEW IF EXISTS view_1_tab3_352 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_352
+DROP VIEW IF EXISTS view_2_tab3_352 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_352
+DROP VIEW IF EXISTS view_3_tab3_352 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25889,13 +25889,13 @@ SELECT pk FROM tab4 WHERE col1 > 81.45 AND col4 BETWEEN 25.22 AND 40.20
 ----
 
 statement ok
-DROP VIEW view_1_tab4_352
+DROP VIEW IF EXISTS view_1_tab4_352 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_352
+DROP VIEW IF EXISTS view_2_tab4_352 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_352
+DROP VIEW IF EXISTS view_3_tab4_352 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25988,13 +25988,13 @@ SELECT pk FROM tab0 WHERE ((col4 < 16.61 AND col4 IN (45.74)) OR col0 >= 72)
 8
 
 statement ok
-DROP VIEW view_1_tab0_353
+DROP VIEW IF EXISTS view_1_tab0_353 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_353
+DROP VIEW IF EXISTS view_2_tab0_353 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_353
+DROP VIEW IF EXISTS view_3_tab0_353 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26087,13 +26087,13 @@ SELECT pk FROM tab1 WHERE ((col4 < 16.61 AND col4 IN (45.74)) OR col0 >= 72)
 8
 
 statement ok
-DROP VIEW view_1_tab1_353
+DROP VIEW IF EXISTS view_1_tab1_353 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_353
+DROP VIEW IF EXISTS view_2_tab1_353 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_353
+DROP VIEW IF EXISTS view_3_tab1_353 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26186,13 +26186,13 @@ SELECT pk FROM tab2 WHERE ((col4 < 16.61 AND col4 IN (45.74)) OR col0 >= 72)
 8
 
 statement ok
-DROP VIEW view_1_tab2_353
+DROP VIEW IF EXISTS view_1_tab2_353 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_353
+DROP VIEW IF EXISTS view_2_tab2_353 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_353
+DROP VIEW IF EXISTS view_3_tab2_353 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26285,13 +26285,13 @@ SELECT pk FROM tab3 WHERE ((col4 < 16.61 AND col4 IN (45.74)) OR col0 >= 72)
 8
 
 statement ok
-DROP VIEW view_1_tab3_353
+DROP VIEW IF EXISTS view_1_tab3_353 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_353
+DROP VIEW IF EXISTS view_2_tab3_353 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_353
+DROP VIEW IF EXISTS view_3_tab3_353 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26384,13 +26384,13 @@ SELECT pk FROM tab4 WHERE ((col4 < 16.61 AND col4 IN (45.74)) OR col0 >= 72)
 8
 
 statement ok
-DROP VIEW view_1_tab4_353
+DROP VIEW IF EXISTS view_1_tab4_353 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_353
+DROP VIEW IF EXISTS view_2_tab4_353 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_353
+DROP VIEW IF EXISTS view_3_tab4_353 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26504,13 +26504,13 @@ SELECT pk FROM tab0 WHERE ((((col3 > 94))) OR col3 > 39)
 7
 
 statement ok
-DROP VIEW view_1_tab0_354
+DROP VIEW IF EXISTS view_1_tab0_354 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_354
+DROP VIEW IF EXISTS view_2_tab0_354 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_354
+DROP VIEW IF EXISTS view_3_tab0_354 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26624,13 +26624,13 @@ SELECT pk FROM tab1 WHERE ((((col3 > 94))) OR col3 > 39)
 7
 
 statement ok
-DROP VIEW view_1_tab1_354
+DROP VIEW IF EXISTS view_1_tab1_354 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_354
+DROP VIEW IF EXISTS view_2_tab1_354 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_354
+DROP VIEW IF EXISTS view_3_tab1_354 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26744,13 +26744,13 @@ SELECT pk FROM tab2 WHERE ((((col3 > 94))) OR col3 > 39)
 7
 
 statement ok
-DROP VIEW view_1_tab2_354
+DROP VIEW IF EXISTS view_1_tab2_354 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_354
+DROP VIEW IF EXISTS view_2_tab2_354 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_354
+DROP VIEW IF EXISTS view_3_tab2_354 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26864,13 +26864,13 @@ SELECT pk FROM tab3 WHERE ((((col3 > 94))) OR col3 > 39)
 7
 
 statement ok
-DROP VIEW view_1_tab3_354
+DROP VIEW IF EXISTS view_1_tab3_354 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_354
+DROP VIEW IF EXISTS view_2_tab3_354 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_354
+DROP VIEW IF EXISTS view_3_tab3_354 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26984,13 +26984,13 @@ SELECT pk FROM tab4 WHERE ((((col3 > 94))) OR col3 > 39)
 7
 
 statement ok
-DROP VIEW view_1_tab4_354
+DROP VIEW IF EXISTS view_1_tab4_354 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_354
+DROP VIEW IF EXISTS view_2_tab4_354 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_354
+DROP VIEW IF EXISTS view_3_tab4_354 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27083,13 +27083,13 @@ SELECT pk FROM tab0 WHERE (col0 = 53) OR ((col1 = 3.66) AND (col0 >= 48) AND ((c
 3
 
 statement ok
-DROP VIEW view_1_tab0_355
+DROP VIEW IF EXISTS view_1_tab0_355 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_355
+DROP VIEW IF EXISTS view_2_tab0_355 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_355
+DROP VIEW IF EXISTS view_3_tab0_355 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27182,13 +27182,13 @@ SELECT pk FROM tab1 WHERE (col0 = 53) OR ((col1 = 3.66) AND (col0 >= 48) AND ((c
 3
 
 statement ok
-DROP VIEW view_1_tab1_355
+DROP VIEW IF EXISTS view_1_tab1_355 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_355
+DROP VIEW IF EXISTS view_2_tab1_355 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_355
+DROP VIEW IF EXISTS view_3_tab1_355 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27281,13 +27281,13 @@ SELECT pk FROM tab2 WHERE (col0 = 53) OR ((col1 = 3.66) AND (col0 >= 48) AND ((c
 3
 
 statement ok
-DROP VIEW view_1_tab2_355
+DROP VIEW IF EXISTS view_1_tab2_355 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_355
+DROP VIEW IF EXISTS view_2_tab2_355 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_355
+DROP VIEW IF EXISTS view_3_tab2_355 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27380,13 +27380,13 @@ SELECT pk FROM tab3 WHERE (col0 = 53) OR ((col1 = 3.66) AND (col0 >= 48) AND ((c
 3
 
 statement ok
-DROP VIEW view_1_tab3_355
+DROP VIEW IF EXISTS view_1_tab3_355 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_355
+DROP VIEW IF EXISTS view_2_tab3_355 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_355
+DROP VIEW IF EXISTS view_3_tab3_355 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27479,13 +27479,13 @@ SELECT pk FROM tab4 WHERE (col0 = 53) OR ((col1 = 3.66) AND (col0 >= 48) AND ((c
 3
 
 statement ok
-DROP VIEW view_1_tab4_355
+DROP VIEW IF EXISTS view_1_tab4_355 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_355
+DROP VIEW IF EXISTS view_2_tab4_355 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_355
+DROP VIEW IF EXISTS view_3_tab4_355 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27578,13 +27578,13 @@ SELECT pk FROM tab0 WHERE (col1 <= 63.99) AND col1 < 20.0
 0
 
 statement ok
-DROP VIEW view_1_tab0_356
+DROP VIEW IF EXISTS view_1_tab0_356 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_356
+DROP VIEW IF EXISTS view_2_tab0_356 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_356
+DROP VIEW IF EXISTS view_3_tab0_356 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27677,13 +27677,13 @@ SELECT pk FROM tab1 WHERE (col1 <= 63.99) AND col1 < 20.0
 0
 
 statement ok
-DROP VIEW view_1_tab1_356
+DROP VIEW IF EXISTS view_1_tab1_356 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_356
+DROP VIEW IF EXISTS view_2_tab1_356 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_356
+DROP VIEW IF EXISTS view_3_tab1_356 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27776,13 +27776,13 @@ SELECT pk FROM tab2 WHERE (col1 <= 63.99) AND col1 < 20.0
 0
 
 statement ok
-DROP VIEW view_1_tab2_356
+DROP VIEW IF EXISTS view_1_tab2_356 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_356
+DROP VIEW IF EXISTS view_2_tab2_356 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_356
+DROP VIEW IF EXISTS view_3_tab2_356 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27875,13 +27875,13 @@ SELECT pk FROM tab3 WHERE (col1 <= 63.99) AND col1 < 20.0
 0
 
 statement ok
-DROP VIEW view_1_tab3_356
+DROP VIEW IF EXISTS view_1_tab3_356 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_356
+DROP VIEW IF EXISTS view_2_tab3_356 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_356
+DROP VIEW IF EXISTS view_3_tab3_356 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27974,13 +27974,13 @@ SELECT pk FROM tab4 WHERE (col1 <= 63.99) AND col1 < 20.0
 0
 
 statement ok
-DROP VIEW view_1_tab4_356
+DROP VIEW IF EXISTS view_1_tab4_356 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_356
+DROP VIEW IF EXISTS view_2_tab4_356 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_356
+DROP VIEW IF EXISTS view_3_tab4_356 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28080,13 +28080,13 @@ SELECT pk FROM tab0 WHERE (col4 > 22.87 AND col1 = 0.50 AND (col4 >= 31.31) AND 
 2
 
 statement ok
-DROP VIEW view_1_tab0_357
+DROP VIEW IF EXISTS view_1_tab0_357 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_357
+DROP VIEW IF EXISTS view_2_tab0_357 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_357
+DROP VIEW IF EXISTS view_3_tab0_357 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28186,13 +28186,13 @@ SELECT pk FROM tab1 WHERE (col4 > 22.87 AND col1 = 0.50 AND (col4 >= 31.31) AND 
 2
 
 statement ok
-DROP VIEW view_1_tab1_357
+DROP VIEW IF EXISTS view_1_tab1_357 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_357
+DROP VIEW IF EXISTS view_2_tab1_357 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_357
+DROP VIEW IF EXISTS view_3_tab1_357 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28292,13 +28292,13 @@ SELECT pk FROM tab2 WHERE (col4 > 22.87 AND col1 = 0.50 AND (col4 >= 31.31) AND 
 2
 
 statement ok
-DROP VIEW view_1_tab2_357
+DROP VIEW IF EXISTS view_1_tab2_357 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_357
+DROP VIEW IF EXISTS view_2_tab2_357 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_357
+DROP VIEW IF EXISTS view_3_tab2_357 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28398,13 +28398,13 @@ SELECT pk FROM tab3 WHERE (col4 > 22.87 AND col1 = 0.50 AND (col4 >= 31.31) AND 
 2
 
 statement ok
-DROP VIEW view_1_tab3_357
+DROP VIEW IF EXISTS view_1_tab3_357 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_357
+DROP VIEW IF EXISTS view_2_tab3_357 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_357
+DROP VIEW IF EXISTS view_3_tab3_357 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28504,13 +28504,13 @@ SELECT pk FROM tab4 WHERE (col4 > 22.87 AND col1 = 0.50 AND (col4 >= 31.31) AND 
 2
 
 statement ok
-DROP VIEW view_1_tab4_357
+DROP VIEW IF EXISTS view_1_tab4_357 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_357
+DROP VIEW IF EXISTS view_2_tab4_357 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_357
+DROP VIEW IF EXISTS view_3_tab4_357 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28629,13 +28629,13 @@ SELECT pk FROM tab0 WHERE col3 < 64
 9
 
 statement ok
-DROP VIEW view_1_tab0_358
+DROP VIEW IF EXISTS view_1_tab0_358 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_358
+DROP VIEW IF EXISTS view_2_tab0_358 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_358
+DROP VIEW IF EXISTS view_3_tab0_358 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28754,13 +28754,13 @@ SELECT pk FROM tab1 WHERE col3 < 64
 9
 
 statement ok
-DROP VIEW view_1_tab1_358
+DROP VIEW IF EXISTS view_1_tab1_358 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_358
+DROP VIEW IF EXISTS view_2_tab1_358 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_358
+DROP VIEW IF EXISTS view_3_tab1_358 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28879,13 +28879,13 @@ SELECT pk FROM tab2 WHERE col3 < 64
 9
 
 statement ok
-DROP VIEW view_1_tab2_358
+DROP VIEW IF EXISTS view_1_tab2_358 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_358
+DROP VIEW IF EXISTS view_2_tab2_358 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_358
+DROP VIEW IF EXISTS view_3_tab2_358 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29004,13 +29004,13 @@ SELECT pk FROM tab3 WHERE col3 < 64
 9
 
 statement ok
-DROP VIEW view_1_tab3_358
+DROP VIEW IF EXISTS view_1_tab3_358 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_358
+DROP VIEW IF EXISTS view_2_tab3_358 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_358
+DROP VIEW IF EXISTS view_3_tab3_358 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29129,13 +29129,13 @@ SELECT pk FROM tab4 WHERE col3 < 64
 9
 
 statement ok
-DROP VIEW view_1_tab4_358
+DROP VIEW IF EXISTS view_1_tab4_358 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_358
+DROP VIEW IF EXISTS view_2_tab4_358 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_358
+DROP VIEW IF EXISTS view_3_tab4_358 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29228,13 +29228,13 @@ SELECT pk FROM tab0 WHERE col3 = 29
 3
 
 statement ok
-DROP VIEW view_1_tab0_359
+DROP VIEW IF EXISTS view_1_tab0_359 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_359
+DROP VIEW IF EXISTS view_2_tab0_359 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_359
+DROP VIEW IF EXISTS view_3_tab0_359 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29327,13 +29327,13 @@ SELECT pk FROM tab1 WHERE col3 = 29
 3
 
 statement ok
-DROP VIEW view_1_tab1_359
+DROP VIEW IF EXISTS view_1_tab1_359 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_359
+DROP VIEW IF EXISTS view_2_tab1_359 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_359
+DROP VIEW IF EXISTS view_3_tab1_359 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29426,13 +29426,13 @@ SELECT pk FROM tab2 WHERE col3 = 29
 3
 
 statement ok
-DROP VIEW view_1_tab2_359
+DROP VIEW IF EXISTS view_1_tab2_359 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_359
+DROP VIEW IF EXISTS view_2_tab2_359 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_359
+DROP VIEW IF EXISTS view_3_tab2_359 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29525,13 +29525,13 @@ SELECT pk FROM tab3 WHERE col3 = 29
 3
 
 statement ok
-DROP VIEW view_1_tab3_359
+DROP VIEW IF EXISTS view_1_tab3_359 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_359
+DROP VIEW IF EXISTS view_2_tab3_359 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_359
+DROP VIEW IF EXISTS view_3_tab3_359 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29624,13 +29624,13 @@ SELECT pk FROM tab4 WHERE col3 = 29
 3
 
 statement ok
-DROP VIEW view_1_tab4_359
+DROP VIEW IF EXISTS view_1_tab4_359 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_359
+DROP VIEW IF EXISTS view_2_tab4_359 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_359
+DROP VIEW IF EXISTS view_3_tab4_359 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29723,13 +29723,13 @@ SELECT pk FROM tab0 WHERE col3 IS NULL OR col0 < 5 AND (col0 < 40) AND col0 < 18
 2
 
 statement ok
-DROP VIEW view_1_tab0_360
+DROP VIEW IF EXISTS view_1_tab0_360 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_360
+DROP VIEW IF EXISTS view_2_tab0_360 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_360
+DROP VIEW IF EXISTS view_3_tab0_360 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29822,13 +29822,13 @@ SELECT pk FROM tab1 WHERE col3 IS NULL OR col0 < 5 AND (col0 < 40) AND col0 < 18
 2
 
 statement ok
-DROP VIEW view_1_tab1_360
+DROP VIEW IF EXISTS view_1_tab1_360 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_360
+DROP VIEW IF EXISTS view_2_tab1_360 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_360
+DROP VIEW IF EXISTS view_3_tab1_360 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29921,13 +29921,13 @@ SELECT pk FROM tab2 WHERE col3 IS NULL OR col0 < 5 AND (col0 < 40) AND col0 < 18
 2
 
 statement ok
-DROP VIEW view_1_tab2_360
+DROP VIEW IF EXISTS view_1_tab2_360 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_360
+DROP VIEW IF EXISTS view_2_tab2_360 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_360
+DROP VIEW IF EXISTS view_3_tab2_360 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30020,13 +30020,13 @@ SELECT pk FROM tab3 WHERE col3 IS NULL OR col0 < 5 AND (col0 < 40) AND col0 < 18
 2
 
 statement ok
-DROP VIEW view_1_tab3_360
+DROP VIEW IF EXISTS view_1_tab3_360 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_360
+DROP VIEW IF EXISTS view_2_tab3_360 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_360
+DROP VIEW IF EXISTS view_3_tab3_360 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30119,13 +30119,13 @@ SELECT pk FROM tab4 WHERE col3 IS NULL OR col0 < 5 AND (col0 < 40) AND col0 < 18
 2
 
 statement ok
-DROP VIEW view_1_tab4_360
+DROP VIEW IF EXISTS view_1_tab4_360 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_360
+DROP VIEW IF EXISTS view_2_tab4_360 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_360
+DROP VIEW IF EXISTS view_3_tab4_360 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30211,13 +30211,13 @@ SELECT pk FROM tab0 WHERE col0 >= 80 OR ((col0 <= 70 AND (col0 > 30) OR ((col0 =
 ----
 
 statement ok
-DROP VIEW view_1_tab0_361
+DROP VIEW IF EXISTS view_1_tab0_361 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_361
+DROP VIEW IF EXISTS view_2_tab0_361 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_361
+DROP VIEW IF EXISTS view_3_tab0_361 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30303,13 +30303,13 @@ SELECT pk FROM tab1 WHERE col0 >= 80 OR ((col0 <= 70 AND (col0 > 30) OR ((col0 =
 ----
 
 statement ok
-DROP VIEW view_1_tab1_361
+DROP VIEW IF EXISTS view_1_tab1_361 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_361
+DROP VIEW IF EXISTS view_2_tab1_361 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_361
+DROP VIEW IF EXISTS view_3_tab1_361 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30395,13 +30395,13 @@ SELECT pk FROM tab2 WHERE col0 >= 80 OR ((col0 <= 70 AND (col0 > 30) OR ((col0 =
 ----
 
 statement ok
-DROP VIEW view_1_tab2_361
+DROP VIEW IF EXISTS view_1_tab2_361 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_361
+DROP VIEW IF EXISTS view_2_tab2_361 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_361
+DROP VIEW IF EXISTS view_3_tab2_361 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30487,13 +30487,13 @@ SELECT pk FROM tab3 WHERE col0 >= 80 OR ((col0 <= 70 AND (col0 > 30) OR ((col0 =
 ----
 
 statement ok
-DROP VIEW view_1_tab3_361
+DROP VIEW IF EXISTS view_1_tab3_361 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_361
+DROP VIEW IF EXISTS view_2_tab3_361 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_361
+DROP VIEW IF EXISTS view_3_tab3_361 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30579,13 +30579,13 @@ SELECT pk FROM tab4 WHERE col0 >= 80 OR ((col0 <= 70 AND (col0 > 30) OR ((col0 =
 ----
 
 statement ok
-DROP VIEW view_1_tab4_361
+DROP VIEW IF EXISTS view_1_tab4_361 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_361
+DROP VIEW IF EXISTS view_2_tab4_361 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_361
+DROP VIEW IF EXISTS view_3_tab4_361 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30674,13 +30674,13 @@ SELECT pk FROM tab0 WHERE col0 < 84
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_362
+DROP VIEW IF EXISTS view_1_tab0_362 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_362
+DROP VIEW IF EXISTS view_2_tab0_362 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_362
+DROP VIEW IF EXISTS view_3_tab0_362 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30769,13 +30769,13 @@ SELECT pk FROM tab1 WHERE col0 < 84
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_362
+DROP VIEW IF EXISTS view_1_tab1_362 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_362
+DROP VIEW IF EXISTS view_2_tab1_362 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_362
+DROP VIEW IF EXISTS view_3_tab1_362 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30864,13 +30864,13 @@ SELECT pk FROM tab2 WHERE col0 < 84
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_362
+DROP VIEW IF EXISTS view_1_tab2_362 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_362
+DROP VIEW IF EXISTS view_2_tab2_362 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_362
+DROP VIEW IF EXISTS view_3_tab2_362 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30959,13 +30959,13 @@ SELECT pk FROM tab3 WHERE col0 < 84
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_362
+DROP VIEW IF EXISTS view_1_tab3_362 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_362
+DROP VIEW IF EXISTS view_2_tab3_362 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_362
+DROP VIEW IF EXISTS view_3_tab3_362 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31054,13 +31054,13 @@ SELECT pk FROM tab4 WHERE col0 < 84
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_362
+DROP VIEW IF EXISTS view_1_tab4_362 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_362
+DROP VIEW IF EXISTS view_2_tab4_362 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_362
+DROP VIEW IF EXISTS view_3_tab4_362 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31149,13 +31149,13 @@ SELECT pk FROM tab0 WHERE (col1 >= 43.31) OR (((col3 < 28 OR col0 <= 11) AND col
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_363
+DROP VIEW IF EXISTS view_1_tab0_363 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_363
+DROP VIEW IF EXISTS view_2_tab0_363 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_363
+DROP VIEW IF EXISTS view_3_tab0_363 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31244,13 +31244,13 @@ SELECT pk FROM tab1 WHERE (col1 >= 43.31) OR (((col3 < 28 OR col0 <= 11) AND col
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_363
+DROP VIEW IF EXISTS view_1_tab1_363 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_363
+DROP VIEW IF EXISTS view_2_tab1_363 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_363
+DROP VIEW IF EXISTS view_3_tab1_363 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31339,13 +31339,13 @@ SELECT pk FROM tab2 WHERE (col1 >= 43.31) OR (((col3 < 28 OR col0 <= 11) AND col
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_363
+DROP VIEW IF EXISTS view_1_tab2_363 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_363
+DROP VIEW IF EXISTS view_2_tab2_363 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_363
+DROP VIEW IF EXISTS view_3_tab2_363 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31434,13 +31434,13 @@ SELECT pk FROM tab3 WHERE (col1 >= 43.31) OR (((col3 < 28 OR col0 <= 11) AND col
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_363
+DROP VIEW IF EXISTS view_1_tab3_363 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_363
+DROP VIEW IF EXISTS view_2_tab3_363 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_363
+DROP VIEW IF EXISTS view_3_tab3_363 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31529,13 +31529,13 @@ SELECT pk FROM tab4 WHERE (col1 >= 43.31) OR (((col3 < 28 OR col0 <= 11) AND col
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_363
+DROP VIEW IF EXISTS view_1_tab4_363 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_363
+DROP VIEW IF EXISTS view_2_tab4_363 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_363
+DROP VIEW IF EXISTS view_3_tab4_363 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31655,13 +31655,13 @@ SELECT pk FROM tab0 WHERE col4 <= 56.3
 5
 
 statement ok
-DROP VIEW view_1_tab0_364
+DROP VIEW IF EXISTS view_1_tab0_364 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_364
+DROP VIEW IF EXISTS view_2_tab0_364 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_364
+DROP VIEW IF EXISTS view_3_tab0_364 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31781,13 +31781,13 @@ SELECT pk FROM tab1 WHERE col4 <= 56.3
 5
 
 statement ok
-DROP VIEW view_1_tab1_364
+DROP VIEW IF EXISTS view_1_tab1_364 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_364
+DROP VIEW IF EXISTS view_2_tab1_364 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_364
+DROP VIEW IF EXISTS view_3_tab1_364 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31907,13 +31907,13 @@ SELECT pk FROM tab2 WHERE col4 <= 56.3
 5
 
 statement ok
-DROP VIEW view_1_tab2_364
+DROP VIEW IF EXISTS view_1_tab2_364 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_364
+DROP VIEW IF EXISTS view_2_tab2_364 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_364
+DROP VIEW IF EXISTS view_3_tab2_364 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32033,13 +32033,13 @@ SELECT pk FROM tab3 WHERE col4 <= 56.3
 5
 
 statement ok
-DROP VIEW view_1_tab3_364
+DROP VIEW IF EXISTS view_1_tab3_364 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_364
+DROP VIEW IF EXISTS view_2_tab3_364 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_364
+DROP VIEW IF EXISTS view_3_tab3_364 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32159,13 +32159,13 @@ SELECT pk FROM tab4 WHERE col4 <= 56.3
 5
 
 statement ok
-DROP VIEW view_1_tab4_364
+DROP VIEW IF EXISTS view_1_tab4_364 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_364
+DROP VIEW IF EXISTS view_2_tab4_364 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_364
+DROP VIEW IF EXISTS view_3_tab4_364 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32251,13 +32251,13 @@ SELECT pk FROM tab0 WHERE (col0 = 42)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_365
+DROP VIEW IF EXISTS view_1_tab0_365 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_365
+DROP VIEW IF EXISTS view_2_tab0_365 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_365
+DROP VIEW IF EXISTS view_3_tab0_365 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32343,13 +32343,13 @@ SELECT pk FROM tab1 WHERE (col0 = 42)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_365
+DROP VIEW IF EXISTS view_1_tab1_365 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_365
+DROP VIEW IF EXISTS view_2_tab1_365 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_365
+DROP VIEW IF EXISTS view_3_tab1_365 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32435,13 +32435,13 @@ SELECT pk FROM tab2 WHERE (col0 = 42)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_365
+DROP VIEW IF EXISTS view_1_tab2_365 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_365
+DROP VIEW IF EXISTS view_2_tab2_365 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_365
+DROP VIEW IF EXISTS view_3_tab2_365 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32527,13 +32527,13 @@ SELECT pk FROM tab3 WHERE (col0 = 42)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_365
+DROP VIEW IF EXISTS view_1_tab3_365 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_365
+DROP VIEW IF EXISTS view_2_tab3_365 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_365
+DROP VIEW IF EXISTS view_3_tab3_365 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32619,13 +32619,13 @@ SELECT pk FROM tab4 WHERE (col0 = 42)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_365
+DROP VIEW IF EXISTS view_1_tab4_365 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_365
+DROP VIEW IF EXISTS view_2_tab4_365 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_365
+DROP VIEW IF EXISTS view_3_tab4_365 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32711,13 +32711,13 @@ SELECT pk FROM tab0 WHERE (col4 = 69.90)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_366
+DROP VIEW IF EXISTS view_1_tab0_366 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_366
+DROP VIEW IF EXISTS view_2_tab0_366 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_366
+DROP VIEW IF EXISTS view_3_tab0_366 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32803,13 +32803,13 @@ SELECT pk FROM tab1 WHERE (col4 = 69.90)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_366
+DROP VIEW IF EXISTS view_1_tab1_366 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_366
+DROP VIEW IF EXISTS view_2_tab1_366 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_366
+DROP VIEW IF EXISTS view_3_tab1_366 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32895,13 +32895,13 @@ SELECT pk FROM tab2 WHERE (col4 = 69.90)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_366
+DROP VIEW IF EXISTS view_1_tab2_366 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_366
+DROP VIEW IF EXISTS view_2_tab2_366 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_366
+DROP VIEW IF EXISTS view_3_tab2_366 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32987,13 +32987,13 @@ SELECT pk FROM tab3 WHERE (col4 = 69.90)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_366
+DROP VIEW IF EXISTS view_1_tab3_366 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_366
+DROP VIEW IF EXISTS view_2_tab3_366 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_366
+DROP VIEW IF EXISTS view_3_tab3_366 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33079,13 +33079,13 @@ SELECT pk FROM tab4 WHERE (col4 = 69.90)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_366
+DROP VIEW IF EXISTS view_1_tab4_366 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_366
+DROP VIEW IF EXISTS view_2_tab4_366 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_366
+DROP VIEW IF EXISTS view_3_tab4_366 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33174,13 +33174,13 @@ SELECT pk FROM tab0 WHERE col3 IS NULL OR (((col0 < 64 AND (col0 BETWEEN 25 AND 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_367
+DROP VIEW IF EXISTS view_1_tab0_367 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_367
+DROP VIEW IF EXISTS view_2_tab0_367 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_367
+DROP VIEW IF EXISTS view_3_tab0_367 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33269,13 +33269,13 @@ SELECT pk FROM tab1 WHERE col3 IS NULL OR (((col0 < 64 AND (col0 BETWEEN 25 AND 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_367
+DROP VIEW IF EXISTS view_1_tab1_367 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_367
+DROP VIEW IF EXISTS view_2_tab1_367 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_367
+DROP VIEW IF EXISTS view_3_tab1_367 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33364,13 +33364,13 @@ SELECT pk FROM tab2 WHERE col3 IS NULL OR (((col0 < 64 AND (col0 BETWEEN 25 AND 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_367
+DROP VIEW IF EXISTS view_1_tab2_367 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_367
+DROP VIEW IF EXISTS view_2_tab2_367 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_367
+DROP VIEW IF EXISTS view_3_tab2_367 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33459,13 +33459,13 @@ SELECT pk FROM tab3 WHERE col3 IS NULL OR (((col0 < 64 AND (col0 BETWEEN 25 AND 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_367
+DROP VIEW IF EXISTS view_1_tab3_367 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_367
+DROP VIEW IF EXISTS view_2_tab3_367 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_367
+DROP VIEW IF EXISTS view_3_tab3_367 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33554,13 +33554,13 @@ SELECT pk FROM tab4 WHERE col3 IS NULL OR (((col0 < 64 AND (col0 BETWEEN 25 AND 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_367
+DROP VIEW IF EXISTS view_1_tab4_367 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_367
+DROP VIEW IF EXISTS view_2_tab4_367 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_367
+DROP VIEW IF EXISTS view_3_tab4_367 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33653,13 +33653,13 @@ SELECT pk FROM tab0 WHERE col0 IS NULL OR col4 <= 23.61
 4
 
 statement ok
-DROP VIEW view_1_tab0_368
+DROP VIEW IF EXISTS view_1_tab0_368 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_368
+DROP VIEW IF EXISTS view_2_tab0_368 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_368
+DROP VIEW IF EXISTS view_3_tab0_368 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33752,13 +33752,13 @@ SELECT pk FROM tab1 WHERE col0 IS NULL OR col4 <= 23.61
 4
 
 statement ok
-DROP VIEW view_1_tab1_368
+DROP VIEW IF EXISTS view_1_tab1_368 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_368
+DROP VIEW IF EXISTS view_2_tab1_368 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_368
+DROP VIEW IF EXISTS view_3_tab1_368 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33851,13 +33851,13 @@ SELECT pk FROM tab2 WHERE col0 IS NULL OR col4 <= 23.61
 4
 
 statement ok
-DROP VIEW view_1_tab2_368
+DROP VIEW IF EXISTS view_1_tab2_368 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_368
+DROP VIEW IF EXISTS view_2_tab2_368 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_368
+DROP VIEW IF EXISTS view_3_tab2_368 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33950,13 +33950,13 @@ SELECT pk FROM tab3 WHERE col0 IS NULL OR col4 <= 23.61
 4
 
 statement ok
-DROP VIEW view_1_tab3_368
+DROP VIEW IF EXISTS view_1_tab3_368 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_368
+DROP VIEW IF EXISTS view_2_tab3_368 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_368
+DROP VIEW IF EXISTS view_3_tab3_368 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34049,13 +34049,13 @@ SELECT pk FROM tab4 WHERE col0 IS NULL OR col4 <= 23.61
 4
 
 statement ok
-DROP VIEW view_1_tab4_368
+DROP VIEW IF EXISTS view_1_tab4_368 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_368
+DROP VIEW IF EXISTS view_2_tab4_368 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_368
+DROP VIEW IF EXISTS view_3_tab4_368 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34175,13 +34175,13 @@ SELECT pk FROM tab0 WHERE ((col4 < 72.64) AND col1 < 16.25 OR col3 < 19 AND (col
 9
 
 statement ok
-DROP VIEW view_1_tab0_369
+DROP VIEW IF EXISTS view_1_tab0_369 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_369
+DROP VIEW IF EXISTS view_2_tab0_369 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_369
+DROP VIEW IF EXISTS view_3_tab0_369 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34301,13 +34301,13 @@ SELECT pk FROM tab1 WHERE ((col4 < 72.64) AND col1 < 16.25 OR col3 < 19 AND (col
 9
 
 statement ok
-DROP VIEW view_1_tab1_369
+DROP VIEW IF EXISTS view_1_tab1_369 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_369
+DROP VIEW IF EXISTS view_2_tab1_369 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_369
+DROP VIEW IF EXISTS view_3_tab1_369 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34427,13 +34427,13 @@ SELECT pk FROM tab2 WHERE ((col4 < 72.64) AND col1 < 16.25 OR col3 < 19 AND (col
 9
 
 statement ok
-DROP VIEW view_1_tab2_369
+DROP VIEW IF EXISTS view_1_tab2_369 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_369
+DROP VIEW IF EXISTS view_2_tab2_369 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_369
+DROP VIEW IF EXISTS view_3_tab2_369 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34553,13 +34553,13 @@ SELECT pk FROM tab3 WHERE ((col4 < 72.64) AND col1 < 16.25 OR col3 < 19 AND (col
 9
 
 statement ok
-DROP VIEW view_1_tab3_369
+DROP VIEW IF EXISTS view_1_tab3_369 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_369
+DROP VIEW IF EXISTS view_2_tab3_369 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_369
+DROP VIEW IF EXISTS view_3_tab3_369 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34679,13 +34679,13 @@ SELECT pk FROM tab4 WHERE ((col4 < 72.64) AND col1 < 16.25 OR col3 < 19 AND (col
 9
 
 statement ok
-DROP VIEW view_1_tab4_369
+DROP VIEW IF EXISTS view_1_tab4_369 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_369
+DROP VIEW IF EXISTS view_2_tab4_369 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_369
+DROP VIEW IF EXISTS view_3_tab4_369 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34771,13 +34771,13 @@ SELECT pk FROM tab0 WHERE col0 = 81 AND ((col3 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_370
+DROP VIEW IF EXISTS view_1_tab0_370 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_370
+DROP VIEW IF EXISTS view_2_tab0_370 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_370
+DROP VIEW IF EXISTS view_3_tab0_370 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34863,13 +34863,13 @@ SELECT pk FROM tab1 WHERE col0 = 81 AND ((col3 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_370
+DROP VIEW IF EXISTS view_1_tab1_370 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_370
+DROP VIEW IF EXISTS view_2_tab1_370 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_370
+DROP VIEW IF EXISTS view_3_tab1_370 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34955,13 +34955,13 @@ SELECT pk FROM tab2 WHERE col0 = 81 AND ((col3 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_370
+DROP VIEW IF EXISTS view_1_tab2_370 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_370
+DROP VIEW IF EXISTS view_2_tab2_370 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_370
+DROP VIEW IF EXISTS view_3_tab2_370 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35047,13 +35047,13 @@ SELECT pk FROM tab3 WHERE col0 = 81 AND ((col3 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_370
+DROP VIEW IF EXISTS view_1_tab3_370 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_370
+DROP VIEW IF EXISTS view_2_tab3_370 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_370
+DROP VIEW IF EXISTS view_3_tab3_370 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35139,13 +35139,13 @@ SELECT pk FROM tab4 WHERE col0 = 81 AND ((col3 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_370
+DROP VIEW IF EXISTS view_1_tab4_370 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_370
+DROP VIEW IF EXISTS view_2_tab4_370 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_370
+DROP VIEW IF EXISTS view_3_tab4_370 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35238,13 +35238,13 @@ SELECT pk FROM tab0 WHERE (col0 > 78) OR col4 <= 17.11
 4
 
 statement ok
-DROP VIEW view_1_tab0_371
+DROP VIEW IF EXISTS view_1_tab0_371 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_371
+DROP VIEW IF EXISTS view_2_tab0_371 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_371
+DROP VIEW IF EXISTS view_3_tab0_371 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35337,13 +35337,13 @@ SELECT pk FROM tab1 WHERE (col0 > 78) OR col4 <= 17.11
 4
 
 statement ok
-DROP VIEW view_1_tab1_371
+DROP VIEW IF EXISTS view_1_tab1_371 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_371
+DROP VIEW IF EXISTS view_2_tab1_371 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_371
+DROP VIEW IF EXISTS view_3_tab1_371 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35436,13 +35436,13 @@ SELECT pk FROM tab2 WHERE (col0 > 78) OR col4 <= 17.11
 4
 
 statement ok
-DROP VIEW view_1_tab2_371
+DROP VIEW IF EXISTS view_1_tab2_371 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_371
+DROP VIEW IF EXISTS view_2_tab2_371 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_371
+DROP VIEW IF EXISTS view_3_tab2_371 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35535,13 +35535,13 @@ SELECT pk FROM tab3 WHERE (col0 > 78) OR col4 <= 17.11
 4
 
 statement ok
-DROP VIEW view_1_tab3_371
+DROP VIEW IF EXISTS view_1_tab3_371 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_371
+DROP VIEW IF EXISTS view_2_tab3_371 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_371
+DROP VIEW IF EXISTS view_3_tab3_371 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35634,13 +35634,13 @@ SELECT pk FROM tab4 WHERE (col0 > 78) OR col4 <= 17.11
 4
 
 statement ok
-DROP VIEW view_1_tab4_371
+DROP VIEW IF EXISTS view_1_tab4_371 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_371
+DROP VIEW IF EXISTS view_2_tab4_371 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_371
+DROP VIEW IF EXISTS view_3_tab4_371 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35726,13 +35726,13 @@ SELECT pk FROM tab0 WHERE col3 BETWEEN 75 AND 42
 ----
 
 statement ok
-DROP VIEW view_1_tab0_372
+DROP VIEW IF EXISTS view_1_tab0_372 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_372
+DROP VIEW IF EXISTS view_2_tab0_372 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_372
+DROP VIEW IF EXISTS view_3_tab0_372 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35818,13 +35818,13 @@ SELECT pk FROM tab1 WHERE col3 BETWEEN 75 AND 42
 ----
 
 statement ok
-DROP VIEW view_1_tab1_372
+DROP VIEW IF EXISTS view_1_tab1_372 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_372
+DROP VIEW IF EXISTS view_2_tab1_372 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_372
+DROP VIEW IF EXISTS view_3_tab1_372 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35910,13 +35910,13 @@ SELECT pk FROM tab2 WHERE col3 BETWEEN 75 AND 42
 ----
 
 statement ok
-DROP VIEW view_1_tab2_372
+DROP VIEW IF EXISTS view_1_tab2_372 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_372
+DROP VIEW IF EXISTS view_2_tab2_372 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_372
+DROP VIEW IF EXISTS view_3_tab2_372 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36002,13 +36002,13 @@ SELECT pk FROM tab3 WHERE col3 BETWEEN 75 AND 42
 ----
 
 statement ok
-DROP VIEW view_1_tab3_372
+DROP VIEW IF EXISTS view_1_tab3_372 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_372
+DROP VIEW IF EXISTS view_2_tab3_372 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_372
+DROP VIEW IF EXISTS view_3_tab3_372 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36094,13 +36094,13 @@ SELECT pk FROM tab4 WHERE col3 BETWEEN 75 AND 42
 ----
 
 statement ok
-DROP VIEW view_1_tab4_372
+DROP VIEW IF EXISTS view_1_tab4_372 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_372
+DROP VIEW IF EXISTS view_2_tab4_372 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_372
+DROP VIEW IF EXISTS view_3_tab4_372 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36186,13 +36186,13 @@ SELECT pk FROM tab0 WHERE col3 IN (SELECT col0 FROM tab0 WHERE col0 > 39)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_373
+DROP VIEW IF EXISTS view_1_tab0_373 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_373
+DROP VIEW IF EXISTS view_2_tab0_373 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_373
+DROP VIEW IF EXISTS view_3_tab0_373 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36278,13 +36278,13 @@ SELECT pk FROM tab1 WHERE col3 IN (SELECT col0 FROM tab1 WHERE col0 > 39)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_373
+DROP VIEW IF EXISTS view_1_tab1_373 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_373
+DROP VIEW IF EXISTS view_2_tab1_373 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_373
+DROP VIEW IF EXISTS view_3_tab1_373 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36370,13 +36370,13 @@ SELECT pk FROM tab2 WHERE col3 IN (SELECT col0 FROM tab2 WHERE col0 > 39)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_373
+DROP VIEW IF EXISTS view_1_tab2_373 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_373
+DROP VIEW IF EXISTS view_2_tab2_373 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_373
+DROP VIEW IF EXISTS view_3_tab2_373 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36462,13 +36462,13 @@ SELECT pk FROM tab3 WHERE col3 IN (SELECT col0 FROM tab3 WHERE col0 > 39)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_373
+DROP VIEW IF EXISTS view_1_tab3_373 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_373
+DROP VIEW IF EXISTS view_2_tab3_373 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_373
+DROP VIEW IF EXISTS view_3_tab3_373 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36554,13 +36554,13 @@ SELECT pk FROM tab4 WHERE col3 IN (SELECT col0 FROM tab4 WHERE col0 > 39)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_373
+DROP VIEW IF EXISTS view_1_tab4_373 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_373
+DROP VIEW IF EXISTS view_2_tab4_373 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_373
+DROP VIEW IF EXISTS view_3_tab4_373 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36660,13 +36660,13 @@ SELECT pk FROM tab0 WHERE col1 > 71.95
 6
 
 statement ok
-DROP VIEW view_1_tab0_374
+DROP VIEW IF EXISTS view_1_tab0_374 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_374
+DROP VIEW IF EXISTS view_2_tab0_374 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_374
+DROP VIEW IF EXISTS view_3_tab0_374 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36766,13 +36766,13 @@ SELECT pk FROM tab1 WHERE col1 > 71.95
 6
 
 statement ok
-DROP VIEW view_1_tab1_374
+DROP VIEW IF EXISTS view_1_tab1_374 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_374
+DROP VIEW IF EXISTS view_2_tab1_374 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_374
+DROP VIEW IF EXISTS view_3_tab1_374 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36872,13 +36872,13 @@ SELECT pk FROM tab2 WHERE col1 > 71.95
 6
 
 statement ok
-DROP VIEW view_1_tab2_374
+DROP VIEW IF EXISTS view_1_tab2_374 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_374
+DROP VIEW IF EXISTS view_2_tab2_374 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_374
+DROP VIEW IF EXISTS view_3_tab2_374 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36978,13 +36978,13 @@ SELECT pk FROM tab3 WHERE col1 > 71.95
 6
 
 statement ok
-DROP VIEW view_1_tab3_374
+DROP VIEW IF EXISTS view_1_tab3_374 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_374
+DROP VIEW IF EXISTS view_2_tab3_374 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_374
+DROP VIEW IF EXISTS view_3_tab3_374 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37084,13 +37084,13 @@ SELECT pk FROM tab4 WHERE col1 > 71.95
 6
 
 statement ok
-DROP VIEW view_1_tab4_374
+DROP VIEW IF EXISTS view_1_tab4_374 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_374
+DROP VIEW IF EXISTS view_2_tab4_374 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_374
+DROP VIEW IF EXISTS view_3_tab4_374 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37190,13 +37190,13 @@ SELECT pk FROM tab0 WHERE ((col3 <= 69 AND (col4 > 50.62) OR col0 <= 76 AND (col
 9
 
 statement ok
-DROP VIEW view_1_tab0_375
+DROP VIEW IF EXISTS view_1_tab0_375 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_375
+DROP VIEW IF EXISTS view_2_tab0_375 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_375
+DROP VIEW IF EXISTS view_3_tab0_375 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37296,13 +37296,13 @@ SELECT pk FROM tab1 WHERE ((col3 <= 69 AND (col4 > 50.62) OR col0 <= 76 AND (col
 9
 
 statement ok
-DROP VIEW view_1_tab1_375
+DROP VIEW IF EXISTS view_1_tab1_375 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_375
+DROP VIEW IF EXISTS view_2_tab1_375 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_375
+DROP VIEW IF EXISTS view_3_tab1_375 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37402,13 +37402,13 @@ SELECT pk FROM tab2 WHERE ((col3 <= 69 AND (col4 > 50.62) OR col0 <= 76 AND (col
 9
 
 statement ok
-DROP VIEW view_1_tab2_375
+DROP VIEW IF EXISTS view_1_tab2_375 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_375
+DROP VIEW IF EXISTS view_2_tab2_375 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_375
+DROP VIEW IF EXISTS view_3_tab2_375 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37508,13 +37508,13 @@ SELECT pk FROM tab3 WHERE ((col3 <= 69 AND (col4 > 50.62) OR col0 <= 76 AND (col
 9
 
 statement ok
-DROP VIEW view_1_tab3_375
+DROP VIEW IF EXISTS view_1_tab3_375 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_375
+DROP VIEW IF EXISTS view_2_tab3_375 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_375
+DROP VIEW IF EXISTS view_3_tab3_375 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37614,11 +37614,11 @@ SELECT pk FROM tab4 WHERE ((col3 <= 69 AND (col4 > 50.62) OR col0 <= 76 AND (col
 9
 
 statement ok
-DROP VIEW view_1_tab4_375
+DROP VIEW IF EXISTS view_1_tab4_375 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_375
+DROP VIEW IF EXISTS view_2_tab4_375 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_375
+DROP VIEW IF EXISTS view_3_tab4_375 CASCADE
 

--- a/test/index/view/10/slt_good_3.test
+++ b/test/index/view/10/slt_good_3.test
@@ -192,13 +192,13 @@ SELECT pk FROM tab0 WHERE col3 = 22 OR (col0 <= 44 OR col3 >= 14 AND col0 <= 14)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_376
+DROP VIEW IF EXISTS view_1_tab0_376 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_376
+DROP VIEW IF EXISTS view_2_tab0_376 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_376
+DROP VIEW IF EXISTS view_3_tab0_376 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -287,13 +287,13 @@ SELECT pk FROM tab1 WHERE col3 = 22 OR (col0 <= 44 OR col3 >= 14 AND col0 <= 14)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_376
+DROP VIEW IF EXISTS view_1_tab1_376 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_376
+DROP VIEW IF EXISTS view_2_tab1_376 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_376
+DROP VIEW IF EXISTS view_3_tab1_376 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -382,13 +382,13 @@ SELECT pk FROM tab2 WHERE col3 = 22 OR (col0 <= 44 OR col3 >= 14 AND col0 <= 14)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_376
+DROP VIEW IF EXISTS view_1_tab2_376 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_376
+DROP VIEW IF EXISTS view_2_tab2_376 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_376
+DROP VIEW IF EXISTS view_3_tab2_376 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -477,13 +477,13 @@ SELECT pk FROM tab3 WHERE col3 = 22 OR (col0 <= 44 OR col3 >= 14 AND col0 <= 14)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_376
+DROP VIEW IF EXISTS view_1_tab3_376 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_376
+DROP VIEW IF EXISTS view_2_tab3_376 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_376
+DROP VIEW IF EXISTS view_3_tab3_376 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -572,13 +572,13 @@ SELECT pk FROM tab4 WHERE col3 = 22 OR (col0 <= 44 OR col3 >= 14 AND col0 <= 14)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_376
+DROP VIEW IF EXISTS view_1_tab4_376 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_376
+DROP VIEW IF EXISTS view_2_tab4_376 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_376
+DROP VIEW IF EXISTS view_3_tab4_376 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -692,13 +692,13 @@ SELECT pk FROM tab0 WHERE (col0 > 66)
 9
 
 statement ok
-DROP VIEW view_1_tab0_377
+DROP VIEW IF EXISTS view_1_tab0_377 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_377
+DROP VIEW IF EXISTS view_2_tab0_377 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_377
+DROP VIEW IF EXISTS view_3_tab0_377 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -812,13 +812,13 @@ SELECT pk FROM tab1 WHERE (col0 > 66)
 9
 
 statement ok
-DROP VIEW view_1_tab1_377
+DROP VIEW IF EXISTS view_1_tab1_377 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_377
+DROP VIEW IF EXISTS view_2_tab1_377 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_377
+DROP VIEW IF EXISTS view_3_tab1_377 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -932,13 +932,13 @@ SELECT pk FROM tab2 WHERE (col0 > 66)
 9
 
 statement ok
-DROP VIEW view_1_tab2_377
+DROP VIEW IF EXISTS view_1_tab2_377 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_377
+DROP VIEW IF EXISTS view_2_tab2_377 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_377
+DROP VIEW IF EXISTS view_3_tab2_377 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1052,13 +1052,13 @@ SELECT pk FROM tab3 WHERE (col0 > 66)
 9
 
 statement ok
-DROP VIEW view_1_tab3_377
+DROP VIEW IF EXISTS view_1_tab3_377 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_377
+DROP VIEW IF EXISTS view_2_tab3_377 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_377
+DROP VIEW IF EXISTS view_3_tab3_377 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1172,13 +1172,13 @@ SELECT pk FROM tab4 WHERE (col0 > 66)
 9
 
 statement ok
-DROP VIEW view_1_tab4_377
+DROP VIEW IF EXISTS view_1_tab4_377 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_377
+DROP VIEW IF EXISTS view_2_tab4_377 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_377
+DROP VIEW IF EXISTS view_3_tab4_377 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1271,13 +1271,13 @@ SELECT pk FROM tab0 WHERE col3 <= 6 OR col3 IS NULL AND (col3 >= 41 AND col0 < 8
 2
 
 statement ok
-DROP VIEW view_1_tab0_378
+DROP VIEW IF EXISTS view_1_tab0_378 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_378
+DROP VIEW IF EXISTS view_2_tab0_378 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_378
+DROP VIEW IF EXISTS view_3_tab0_378 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1370,13 +1370,13 @@ SELECT pk FROM tab1 WHERE col3 <= 6 OR col3 IS NULL AND (col3 >= 41 AND col0 < 8
 2
 
 statement ok
-DROP VIEW view_1_tab1_378
+DROP VIEW IF EXISTS view_1_tab1_378 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_378
+DROP VIEW IF EXISTS view_2_tab1_378 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_378
+DROP VIEW IF EXISTS view_3_tab1_378 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1469,13 +1469,13 @@ SELECT pk FROM tab2 WHERE col3 <= 6 OR col3 IS NULL AND (col3 >= 41 AND col0 < 8
 2
 
 statement ok
-DROP VIEW view_1_tab2_378
+DROP VIEW IF EXISTS view_1_tab2_378 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_378
+DROP VIEW IF EXISTS view_2_tab2_378 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_378
+DROP VIEW IF EXISTS view_3_tab2_378 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1568,13 +1568,13 @@ SELECT pk FROM tab3 WHERE col3 <= 6 OR col3 IS NULL AND (col3 >= 41 AND col0 < 8
 2
 
 statement ok
-DROP VIEW view_1_tab3_378
+DROP VIEW IF EXISTS view_1_tab3_378 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_378
+DROP VIEW IF EXISTS view_2_tab3_378 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_378
+DROP VIEW IF EXISTS view_3_tab3_378 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1667,13 +1667,13 @@ SELECT pk FROM tab4 WHERE col3 <= 6 OR col3 IS NULL AND (col3 >= 41 AND col0 < 8
 2
 
 statement ok
-DROP VIEW view_1_tab4_378
+DROP VIEW IF EXISTS view_1_tab4_378 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_378
+DROP VIEW IF EXISTS view_2_tab4_378 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_378
+DROP VIEW IF EXISTS view_3_tab4_378 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1766,13 +1766,13 @@ SELECT pk FROM tab0 WHERE ((col0 > 85) OR ((col0 < 81)))
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab0_379
+DROP VIEW IF EXISTS view_1_tab0_379 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_379
+DROP VIEW IF EXISTS view_2_tab0_379 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_379
+DROP VIEW IF EXISTS view_3_tab0_379 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1865,13 +1865,13 @@ SELECT pk FROM tab1 WHERE ((col0 > 85) OR ((col0 < 81)))
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab1_379
+DROP VIEW IF EXISTS view_1_tab1_379 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_379
+DROP VIEW IF EXISTS view_2_tab1_379 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_379
+DROP VIEW IF EXISTS view_3_tab1_379 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1964,13 +1964,13 @@ SELECT pk FROM tab2 WHERE ((col0 > 85) OR ((col0 < 81)))
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab2_379
+DROP VIEW IF EXISTS view_1_tab2_379 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_379
+DROP VIEW IF EXISTS view_2_tab2_379 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_379
+DROP VIEW IF EXISTS view_3_tab2_379 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2063,13 +2063,13 @@ SELECT pk FROM tab3 WHERE ((col0 > 85) OR ((col0 < 81)))
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab3_379
+DROP VIEW IF EXISTS view_1_tab3_379 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_379
+DROP VIEW IF EXISTS view_2_tab3_379 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_379
+DROP VIEW IF EXISTS view_3_tab3_379 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2162,13 +2162,13 @@ SELECT pk FROM tab4 WHERE ((col0 > 85) OR ((col0 < 81)))
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab4_379
+DROP VIEW IF EXISTS view_1_tab4_379 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_379
+DROP VIEW IF EXISTS view_2_tab4_379 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_379
+DROP VIEW IF EXISTS view_3_tab4_379 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2268,13 +2268,13 @@ SELECT pk FROM tab0 WHERE (col0 >= 92)
 9
 
 statement ok
-DROP VIEW view_1_tab0_380
+DROP VIEW IF EXISTS view_1_tab0_380 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_380
+DROP VIEW IF EXISTS view_2_tab0_380 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_380
+DROP VIEW IF EXISTS view_3_tab0_380 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2374,13 +2374,13 @@ SELECT pk FROM tab1 WHERE (col0 >= 92)
 9
 
 statement ok
-DROP VIEW view_1_tab1_380
+DROP VIEW IF EXISTS view_1_tab1_380 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_380
+DROP VIEW IF EXISTS view_2_tab1_380 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_380
+DROP VIEW IF EXISTS view_3_tab1_380 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2480,13 +2480,13 @@ SELECT pk FROM tab2 WHERE (col0 >= 92)
 9
 
 statement ok
-DROP VIEW view_1_tab2_380
+DROP VIEW IF EXISTS view_1_tab2_380 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_380
+DROP VIEW IF EXISTS view_2_tab2_380 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_380
+DROP VIEW IF EXISTS view_3_tab2_380 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2586,13 +2586,13 @@ SELECT pk FROM tab3 WHERE (col0 >= 92)
 9
 
 statement ok
-DROP VIEW view_1_tab3_380
+DROP VIEW IF EXISTS view_1_tab3_380 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_380
+DROP VIEW IF EXISTS view_2_tab3_380 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_380
+DROP VIEW IF EXISTS view_3_tab3_380 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2692,13 +2692,13 @@ SELECT pk FROM tab4 WHERE (col0 >= 92)
 9
 
 statement ok
-DROP VIEW view_1_tab4_380
+DROP VIEW IF EXISTS view_1_tab4_380 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_380
+DROP VIEW IF EXISTS view_2_tab4_380 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_380
+DROP VIEW IF EXISTS view_3_tab4_380 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2798,13 +2798,13 @@ SELECT pk FROM tab0 WHERE col0 >= 14 AND ((col4 > 68.52)) AND (((col1 IN (20.80,
 8
 
 statement ok
-DROP VIEW view_1_tab0_381
+DROP VIEW IF EXISTS view_1_tab0_381 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_381
+DROP VIEW IF EXISTS view_2_tab0_381 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_381
+DROP VIEW IF EXISTS view_3_tab0_381 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2904,13 +2904,13 @@ SELECT pk FROM tab1 WHERE col0 >= 14 AND ((col4 > 68.52)) AND (((col1 IN (20.80,
 8
 
 statement ok
-DROP VIEW view_1_tab1_381
+DROP VIEW IF EXISTS view_1_tab1_381 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_381
+DROP VIEW IF EXISTS view_2_tab1_381 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_381
+DROP VIEW IF EXISTS view_3_tab1_381 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3010,13 +3010,13 @@ SELECT pk FROM tab2 WHERE col0 >= 14 AND ((col4 > 68.52)) AND (((col1 IN (20.80,
 8
 
 statement ok
-DROP VIEW view_1_tab2_381
+DROP VIEW IF EXISTS view_1_tab2_381 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_381
+DROP VIEW IF EXISTS view_2_tab2_381 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_381
+DROP VIEW IF EXISTS view_3_tab2_381 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3116,13 +3116,13 @@ SELECT pk FROM tab3 WHERE col0 >= 14 AND ((col4 > 68.52)) AND (((col1 IN (20.80,
 8
 
 statement ok
-DROP VIEW view_1_tab3_381
+DROP VIEW IF EXISTS view_1_tab3_381 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_381
+DROP VIEW IF EXISTS view_2_tab3_381 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_381
+DROP VIEW IF EXISTS view_3_tab3_381 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3222,13 +3222,13 @@ SELECT pk FROM tab4 WHERE col0 >= 14 AND ((col4 > 68.52)) AND (((col1 IN (20.80,
 8
 
 statement ok
-DROP VIEW view_1_tab4_381
+DROP VIEW IF EXISTS view_1_tab4_381 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_381
+DROP VIEW IF EXISTS view_2_tab4_381 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_381
+DROP VIEW IF EXISTS view_3_tab4_381 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3314,13 +3314,13 @@ SELECT pk FROM tab0 WHERE col0 BETWEEN 27 AND 50 AND col1 > 18.58 AND col4 > 13.
 ----
 
 statement ok
-DROP VIEW view_1_tab0_382
+DROP VIEW IF EXISTS view_1_tab0_382 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_382
+DROP VIEW IF EXISTS view_2_tab0_382 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_382
+DROP VIEW IF EXISTS view_3_tab0_382 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3406,13 +3406,13 @@ SELECT pk FROM tab1 WHERE col0 BETWEEN 27 AND 50 AND col1 > 18.58 AND col4 > 13.
 ----
 
 statement ok
-DROP VIEW view_1_tab1_382
+DROP VIEW IF EXISTS view_1_tab1_382 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_382
+DROP VIEW IF EXISTS view_2_tab1_382 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_382
+DROP VIEW IF EXISTS view_3_tab1_382 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3498,13 +3498,13 @@ SELECT pk FROM tab2 WHERE col0 BETWEEN 27 AND 50 AND col1 > 18.58 AND col4 > 13.
 ----
 
 statement ok
-DROP VIEW view_1_tab2_382
+DROP VIEW IF EXISTS view_1_tab2_382 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_382
+DROP VIEW IF EXISTS view_2_tab2_382 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_382
+DROP VIEW IF EXISTS view_3_tab2_382 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3590,13 +3590,13 @@ SELECT pk FROM tab3 WHERE col0 BETWEEN 27 AND 50 AND col1 > 18.58 AND col4 > 13.
 ----
 
 statement ok
-DROP VIEW view_1_tab3_382
+DROP VIEW IF EXISTS view_1_tab3_382 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_382
+DROP VIEW IF EXISTS view_2_tab3_382 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_382
+DROP VIEW IF EXISTS view_3_tab3_382 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3682,13 +3682,13 @@ SELECT pk FROM tab4 WHERE col0 BETWEEN 27 AND 50 AND col1 > 18.58 AND col4 > 13.
 ----
 
 statement ok
-DROP VIEW view_1_tab4_382
+DROP VIEW IF EXISTS view_1_tab4_382 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_382
+DROP VIEW IF EXISTS view_2_tab4_382 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_382
+DROP VIEW IF EXISTS view_3_tab4_382 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3774,13 +3774,13 @@ SELECT pk FROM tab0 WHERE col3 = 94
 ----
 
 statement ok
-DROP VIEW view_1_tab0_383
+DROP VIEW IF EXISTS view_1_tab0_383 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_383
+DROP VIEW IF EXISTS view_2_tab0_383 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_383
+DROP VIEW IF EXISTS view_3_tab0_383 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3866,13 +3866,13 @@ SELECT pk FROM tab1 WHERE col3 = 94
 ----
 
 statement ok
-DROP VIEW view_1_tab1_383
+DROP VIEW IF EXISTS view_1_tab1_383 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_383
+DROP VIEW IF EXISTS view_2_tab1_383 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_383
+DROP VIEW IF EXISTS view_3_tab1_383 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3958,13 +3958,13 @@ SELECT pk FROM tab2 WHERE col3 = 94
 ----
 
 statement ok
-DROP VIEW view_1_tab2_383
+DROP VIEW IF EXISTS view_1_tab2_383 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_383
+DROP VIEW IF EXISTS view_2_tab2_383 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_383
+DROP VIEW IF EXISTS view_3_tab2_383 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4050,13 +4050,13 @@ SELECT pk FROM tab3 WHERE col3 = 94
 ----
 
 statement ok
-DROP VIEW view_1_tab3_383
+DROP VIEW IF EXISTS view_1_tab3_383 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_383
+DROP VIEW IF EXISTS view_2_tab3_383 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_383
+DROP VIEW IF EXISTS view_3_tab3_383 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4142,13 +4142,13 @@ SELECT pk FROM tab4 WHERE col3 = 94
 ----
 
 statement ok
-DROP VIEW view_1_tab4_383
+DROP VIEW IF EXISTS view_1_tab4_383 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_383
+DROP VIEW IF EXISTS view_2_tab4_383 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_383
+DROP VIEW IF EXISTS view_3_tab4_383 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4241,13 +4241,13 @@ SELECT pk FROM tab0 WHERE (((col0 < 73 AND col1 > 96.67 OR col3 < 2)))
 2
 
 statement ok
-DROP VIEW view_1_tab0_384
+DROP VIEW IF EXISTS view_1_tab0_384 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_384
+DROP VIEW IF EXISTS view_2_tab0_384 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_384
+DROP VIEW IF EXISTS view_3_tab0_384 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4340,13 +4340,13 @@ SELECT pk FROM tab1 WHERE (((col0 < 73 AND col1 > 96.67 OR col3 < 2)))
 2
 
 statement ok
-DROP VIEW view_1_tab1_384
+DROP VIEW IF EXISTS view_1_tab1_384 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_384
+DROP VIEW IF EXISTS view_2_tab1_384 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_384
+DROP VIEW IF EXISTS view_3_tab1_384 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4439,13 +4439,13 @@ SELECT pk FROM tab2 WHERE (((col0 < 73 AND col1 > 96.67 OR col3 < 2)))
 2
 
 statement ok
-DROP VIEW view_1_tab2_384
+DROP VIEW IF EXISTS view_1_tab2_384 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_384
+DROP VIEW IF EXISTS view_2_tab2_384 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_384
+DROP VIEW IF EXISTS view_3_tab2_384 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4538,13 +4538,13 @@ SELECT pk FROM tab3 WHERE (((col0 < 73 AND col1 > 96.67 OR col3 < 2)))
 2
 
 statement ok
-DROP VIEW view_1_tab3_384
+DROP VIEW IF EXISTS view_1_tab3_384 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_384
+DROP VIEW IF EXISTS view_2_tab3_384 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_384
+DROP VIEW IF EXISTS view_3_tab3_384 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4637,13 +4637,13 @@ SELECT pk FROM tab4 WHERE (((col0 < 73 AND col1 > 96.67 OR col3 < 2)))
 2
 
 statement ok
-DROP VIEW view_1_tab4_384
+DROP VIEW IF EXISTS view_1_tab4_384 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_384
+DROP VIEW IF EXISTS view_2_tab4_384 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_384
+DROP VIEW IF EXISTS view_3_tab4_384 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4746,13 +4746,13 @@ SELECT pk FROM tab0 WHERE col1 < 50.34 AND ((col0 > 33 OR col4 > 33.73) OR col4 
 9
 
 statement ok
-DROP VIEW view_1_tab0_385
+DROP VIEW IF EXISTS view_1_tab0_385 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_385
+DROP VIEW IF EXISTS view_2_tab0_385 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_385
+DROP VIEW IF EXISTS view_3_tab0_385 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4855,13 +4855,13 @@ SELECT pk FROM tab1 WHERE col1 < 50.34 AND ((col0 > 33 OR col4 > 33.73) OR col4 
 9
 
 statement ok
-DROP VIEW view_1_tab1_385
+DROP VIEW IF EXISTS view_1_tab1_385 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_385
+DROP VIEW IF EXISTS view_2_tab1_385 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_385
+DROP VIEW IF EXISTS view_3_tab1_385 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4964,13 +4964,13 @@ SELECT pk FROM tab2 WHERE col1 < 50.34 AND ((col0 > 33 OR col4 > 33.73) OR col4 
 9
 
 statement ok
-DROP VIEW view_1_tab2_385
+DROP VIEW IF EXISTS view_1_tab2_385 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_385
+DROP VIEW IF EXISTS view_2_tab2_385 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_385
+DROP VIEW IF EXISTS view_3_tab2_385 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5073,13 +5073,13 @@ SELECT pk FROM tab3 WHERE col1 < 50.34 AND ((col0 > 33 OR col4 > 33.73) OR col4 
 9
 
 statement ok
-DROP VIEW view_1_tab3_385
+DROP VIEW IF EXISTS view_1_tab3_385 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_385
+DROP VIEW IF EXISTS view_2_tab3_385 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_385
+DROP VIEW IF EXISTS view_3_tab3_385 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5182,13 +5182,13 @@ SELECT pk FROM tab4 WHERE col1 < 50.34 AND ((col0 > 33 OR col4 > 33.73) OR col4 
 9
 
 statement ok
-DROP VIEW view_1_tab4_385
+DROP VIEW IF EXISTS view_1_tab4_385 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_385
+DROP VIEW IF EXISTS view_2_tab4_385 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_385
+DROP VIEW IF EXISTS view_3_tab4_385 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5306,13 +5306,13 @@ SELECT pk FROM tab0 WHERE (col3 >= 31)
 9
 
 statement ok
-DROP VIEW view_1_tab0_386
+DROP VIEW IF EXISTS view_1_tab0_386 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_386
+DROP VIEW IF EXISTS view_2_tab0_386 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_386
+DROP VIEW IF EXISTS view_3_tab0_386 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5430,13 +5430,13 @@ SELECT pk FROM tab1 WHERE (col3 >= 31)
 9
 
 statement ok
-DROP VIEW view_1_tab1_386
+DROP VIEW IF EXISTS view_1_tab1_386 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_386
+DROP VIEW IF EXISTS view_2_tab1_386 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_386
+DROP VIEW IF EXISTS view_3_tab1_386 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5554,13 +5554,13 @@ SELECT pk FROM tab2 WHERE (col3 >= 31)
 9
 
 statement ok
-DROP VIEW view_1_tab2_386
+DROP VIEW IF EXISTS view_1_tab2_386 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_386
+DROP VIEW IF EXISTS view_2_tab2_386 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_386
+DROP VIEW IF EXISTS view_3_tab2_386 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5678,13 +5678,13 @@ SELECT pk FROM tab3 WHERE (col3 >= 31)
 9
 
 statement ok
-DROP VIEW view_1_tab3_386
+DROP VIEW IF EXISTS view_1_tab3_386 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_386
+DROP VIEW IF EXISTS view_2_tab3_386 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_386
+DROP VIEW IF EXISTS view_3_tab3_386 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5802,13 +5802,13 @@ SELECT pk FROM tab4 WHERE (col3 >= 31)
 9
 
 statement ok
-DROP VIEW view_1_tab4_386
+DROP VIEW IF EXISTS view_1_tab4_386 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_386
+DROP VIEW IF EXISTS view_2_tab4_386 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_386
+DROP VIEW IF EXISTS view_3_tab4_386 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5927,13 +5927,13 @@ SELECT pk FROM tab0 WHERE (col3 < 72)
 8
 
 statement ok
-DROP VIEW view_1_tab0_387
+DROP VIEW IF EXISTS view_1_tab0_387 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_387
+DROP VIEW IF EXISTS view_2_tab0_387 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_387
+DROP VIEW IF EXISTS view_3_tab0_387 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6052,13 +6052,13 @@ SELECT pk FROM tab1 WHERE (col3 < 72)
 8
 
 statement ok
-DROP VIEW view_1_tab1_387
+DROP VIEW IF EXISTS view_1_tab1_387 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_387
+DROP VIEW IF EXISTS view_2_tab1_387 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_387
+DROP VIEW IF EXISTS view_3_tab1_387 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6177,13 +6177,13 @@ SELECT pk FROM tab2 WHERE (col3 < 72)
 8
 
 statement ok
-DROP VIEW view_1_tab2_387
+DROP VIEW IF EXISTS view_1_tab2_387 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_387
+DROP VIEW IF EXISTS view_2_tab2_387 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_387
+DROP VIEW IF EXISTS view_3_tab2_387 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6302,13 +6302,13 @@ SELECT pk FROM tab3 WHERE (col3 < 72)
 8
 
 statement ok
-DROP VIEW view_1_tab3_387
+DROP VIEW IF EXISTS view_1_tab3_387 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_387
+DROP VIEW IF EXISTS view_2_tab3_387 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_387
+DROP VIEW IF EXISTS view_3_tab3_387 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6427,13 +6427,13 @@ SELECT pk FROM tab4 WHERE (col3 < 72)
 8
 
 statement ok
-DROP VIEW view_1_tab4_387
+DROP VIEW IF EXISTS view_1_tab4_387 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_387
+DROP VIEW IF EXISTS view_2_tab4_387 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_387
+DROP VIEW IF EXISTS view_3_tab4_387 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6519,13 +6519,13 @@ SELECT pk FROM tab0 WHERE (((col1 IN (66.9,97.33)) AND (col1 < 57.59) AND col4 <
 ----
 
 statement ok
-DROP VIEW view_1_tab0_388
+DROP VIEW IF EXISTS view_1_tab0_388 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_388
+DROP VIEW IF EXISTS view_2_tab0_388 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_388
+DROP VIEW IF EXISTS view_3_tab0_388 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6611,13 +6611,13 @@ SELECT pk FROM tab1 WHERE (((col1 IN (66.9,97.33)) AND (col1 < 57.59) AND col4 <
 ----
 
 statement ok
-DROP VIEW view_1_tab1_388
+DROP VIEW IF EXISTS view_1_tab1_388 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_388
+DROP VIEW IF EXISTS view_2_tab1_388 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_388
+DROP VIEW IF EXISTS view_3_tab1_388 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6703,13 +6703,13 @@ SELECT pk FROM tab2 WHERE (((col1 IN (66.9,97.33)) AND (col1 < 57.59) AND col4 <
 ----
 
 statement ok
-DROP VIEW view_1_tab2_388
+DROP VIEW IF EXISTS view_1_tab2_388 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_388
+DROP VIEW IF EXISTS view_2_tab2_388 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_388
+DROP VIEW IF EXISTS view_3_tab2_388 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6795,13 +6795,13 @@ SELECT pk FROM tab3 WHERE (((col1 IN (66.9,97.33)) AND (col1 < 57.59) AND col4 <
 ----
 
 statement ok
-DROP VIEW view_1_tab3_388
+DROP VIEW IF EXISTS view_1_tab3_388 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_388
+DROP VIEW IF EXISTS view_2_tab3_388 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_388
+DROP VIEW IF EXISTS view_3_tab3_388 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6887,13 +6887,13 @@ SELECT pk FROM tab4 WHERE (((col1 IN (66.9,97.33)) AND (col1 < 57.59) AND col4 <
 ----
 
 statement ok
-DROP VIEW view_1_tab4_388
+DROP VIEW IF EXISTS view_1_tab4_388 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_388
+DROP VIEW IF EXISTS view_2_tab4_388 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_388
+DROP VIEW IF EXISTS view_3_tab4_388 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7013,13 +7013,13 @@ SELECT pk FROM tab0 WHERE col0 >= 46
 9
 
 statement ok
-DROP VIEW view_1_tab0_389
+DROP VIEW IF EXISTS view_1_tab0_389 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_389
+DROP VIEW IF EXISTS view_2_tab0_389 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_389
+DROP VIEW IF EXISTS view_3_tab0_389 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7139,13 +7139,13 @@ SELECT pk FROM tab1 WHERE col0 >= 46
 9
 
 statement ok
-DROP VIEW view_1_tab1_389
+DROP VIEW IF EXISTS view_1_tab1_389 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_389
+DROP VIEW IF EXISTS view_2_tab1_389 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_389
+DROP VIEW IF EXISTS view_3_tab1_389 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7265,13 +7265,13 @@ SELECT pk FROM tab2 WHERE col0 >= 46
 9
 
 statement ok
-DROP VIEW view_1_tab2_389
+DROP VIEW IF EXISTS view_1_tab2_389 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_389
+DROP VIEW IF EXISTS view_2_tab2_389 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_389
+DROP VIEW IF EXISTS view_3_tab2_389 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7391,13 +7391,13 @@ SELECT pk FROM tab3 WHERE col0 >= 46
 9
 
 statement ok
-DROP VIEW view_1_tab3_389
+DROP VIEW IF EXISTS view_1_tab3_389 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_389
+DROP VIEW IF EXISTS view_2_tab3_389 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_389
+DROP VIEW IF EXISTS view_3_tab3_389 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7517,13 +7517,13 @@ SELECT pk FROM tab4 WHERE col0 >= 46
 9
 
 statement ok
-DROP VIEW view_1_tab4_389
+DROP VIEW IF EXISTS view_1_tab4_389 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_389
+DROP VIEW IF EXISTS view_2_tab4_389 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_389
+DROP VIEW IF EXISTS view_3_tab4_389 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7643,13 +7643,13 @@ SELECT pk FROM tab0 WHERE col0 <= 71
 7
 
 statement ok
-DROP VIEW view_1_tab0_390
+DROP VIEW IF EXISTS view_1_tab0_390 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_390
+DROP VIEW IF EXISTS view_2_tab0_390 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_390
+DROP VIEW IF EXISTS view_3_tab0_390 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7769,13 +7769,13 @@ SELECT pk FROM tab1 WHERE col0 <= 71
 7
 
 statement ok
-DROP VIEW view_1_tab1_390
+DROP VIEW IF EXISTS view_1_tab1_390 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_390
+DROP VIEW IF EXISTS view_2_tab1_390 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_390
+DROP VIEW IF EXISTS view_3_tab1_390 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7895,13 +7895,13 @@ SELECT pk FROM tab2 WHERE col0 <= 71
 7
 
 statement ok
-DROP VIEW view_1_tab2_390
+DROP VIEW IF EXISTS view_1_tab2_390 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_390
+DROP VIEW IF EXISTS view_2_tab2_390 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_390
+DROP VIEW IF EXISTS view_3_tab2_390 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8021,13 +8021,13 @@ SELECT pk FROM tab3 WHERE col0 <= 71
 7
 
 statement ok
-DROP VIEW view_1_tab3_390
+DROP VIEW IF EXISTS view_1_tab3_390 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_390
+DROP VIEW IF EXISTS view_2_tab3_390 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_390
+DROP VIEW IF EXISTS view_3_tab3_390 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8147,13 +8147,13 @@ SELECT pk FROM tab4 WHERE col0 <= 71
 7
 
 statement ok
-DROP VIEW view_1_tab4_390
+DROP VIEW IF EXISTS view_1_tab4_390 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_390
+DROP VIEW IF EXISTS view_2_tab4_390 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_390
+DROP VIEW IF EXISTS view_3_tab4_390 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8273,13 +8273,13 @@ SELECT pk FROM tab0 WHERE col0 >= 39
 9
 
 statement ok
-DROP VIEW view_1_tab0_391
+DROP VIEW IF EXISTS view_1_tab0_391 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_391
+DROP VIEW IF EXISTS view_2_tab0_391 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_391
+DROP VIEW IF EXISTS view_3_tab0_391 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8399,13 +8399,13 @@ SELECT pk FROM tab1 WHERE col0 >= 39
 9
 
 statement ok
-DROP VIEW view_1_tab1_391
+DROP VIEW IF EXISTS view_1_tab1_391 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_391
+DROP VIEW IF EXISTS view_2_tab1_391 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_391
+DROP VIEW IF EXISTS view_3_tab1_391 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8525,13 +8525,13 @@ SELECT pk FROM tab2 WHERE col0 >= 39
 9
 
 statement ok
-DROP VIEW view_1_tab2_391
+DROP VIEW IF EXISTS view_1_tab2_391 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_391
+DROP VIEW IF EXISTS view_2_tab2_391 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_391
+DROP VIEW IF EXISTS view_3_tab2_391 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8651,13 +8651,13 @@ SELECT pk FROM tab3 WHERE col0 >= 39
 9
 
 statement ok
-DROP VIEW view_1_tab3_391
+DROP VIEW IF EXISTS view_1_tab3_391 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_391
+DROP VIEW IF EXISTS view_2_tab3_391 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_391
+DROP VIEW IF EXISTS view_3_tab3_391 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8777,13 +8777,13 @@ SELECT pk FROM tab4 WHERE col0 >= 39
 9
 
 statement ok
-DROP VIEW view_1_tab4_391
+DROP VIEW IF EXISTS view_1_tab4_391 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_391
+DROP VIEW IF EXISTS view_2_tab4_391 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_391
+DROP VIEW IF EXISTS view_3_tab4_391 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8902,13 +8902,13 @@ SELECT pk FROM tab0 WHERE col4 <= 71.46
 9
 
 statement ok
-DROP VIEW view_1_tab0_392
+DROP VIEW IF EXISTS view_1_tab0_392 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_392
+DROP VIEW IF EXISTS view_2_tab0_392 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_392
+DROP VIEW IF EXISTS view_3_tab0_392 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9027,13 +9027,13 @@ SELECT pk FROM tab1 WHERE col4 <= 71.46
 9
 
 statement ok
-DROP VIEW view_1_tab1_392
+DROP VIEW IF EXISTS view_1_tab1_392 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_392
+DROP VIEW IF EXISTS view_2_tab1_392 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_392
+DROP VIEW IF EXISTS view_3_tab1_392 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9152,13 +9152,13 @@ SELECT pk FROM tab2 WHERE col4 <= 71.46
 9
 
 statement ok
-DROP VIEW view_1_tab2_392
+DROP VIEW IF EXISTS view_1_tab2_392 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_392
+DROP VIEW IF EXISTS view_2_tab2_392 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_392
+DROP VIEW IF EXISTS view_3_tab2_392 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9277,13 +9277,13 @@ SELECT pk FROM tab3 WHERE col4 <= 71.46
 9
 
 statement ok
-DROP VIEW view_1_tab3_392
+DROP VIEW IF EXISTS view_1_tab3_392 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_392
+DROP VIEW IF EXISTS view_2_tab3_392 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_392
+DROP VIEW IF EXISTS view_3_tab3_392 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9402,13 +9402,13 @@ SELECT pk FROM tab4 WHERE col4 <= 71.46
 9
 
 statement ok
-DROP VIEW view_1_tab4_392
+DROP VIEW IF EXISTS view_1_tab4_392 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_392
+DROP VIEW IF EXISTS view_2_tab4_392 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_392
+DROP VIEW IF EXISTS view_3_tab4_392 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9528,13 +9528,13 @@ SELECT pk FROM tab0 WHERE (col0 < 72)
 7
 
 statement ok
-DROP VIEW view_1_tab0_393
+DROP VIEW IF EXISTS view_1_tab0_393 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_393
+DROP VIEW IF EXISTS view_2_tab0_393 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_393
+DROP VIEW IF EXISTS view_3_tab0_393 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9654,13 +9654,13 @@ SELECT pk FROM tab1 WHERE (col0 < 72)
 7
 
 statement ok
-DROP VIEW view_1_tab1_393
+DROP VIEW IF EXISTS view_1_tab1_393 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_393
+DROP VIEW IF EXISTS view_2_tab1_393 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_393
+DROP VIEW IF EXISTS view_3_tab1_393 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9780,13 +9780,13 @@ SELECT pk FROM tab2 WHERE (col0 < 72)
 7
 
 statement ok
-DROP VIEW view_1_tab2_393
+DROP VIEW IF EXISTS view_1_tab2_393 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_393
+DROP VIEW IF EXISTS view_2_tab2_393 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_393
+DROP VIEW IF EXISTS view_3_tab2_393 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9906,13 +9906,13 @@ SELECT pk FROM tab3 WHERE (col0 < 72)
 7
 
 statement ok
-DROP VIEW view_1_tab3_393
+DROP VIEW IF EXISTS view_1_tab3_393 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_393
+DROP VIEW IF EXISTS view_2_tab3_393 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_393
+DROP VIEW IF EXISTS view_3_tab3_393 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10032,13 +10032,13 @@ SELECT pk FROM tab4 WHERE (col0 < 72)
 7
 
 statement ok
-DROP VIEW view_1_tab4_393
+DROP VIEW IF EXISTS view_1_tab4_393 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_393
+DROP VIEW IF EXISTS view_2_tab4_393 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_393
+DROP VIEW IF EXISTS view_3_tab4_393 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10157,13 +10157,13 @@ SELECT pk FROM tab0 WHERE ((col1 >= 63.83)) OR (col3 BETWEEN 55 AND 81 OR (col4 
 9
 
 statement ok
-DROP VIEW view_1_tab0_394
+DROP VIEW IF EXISTS view_1_tab0_394 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_394
+DROP VIEW IF EXISTS view_2_tab0_394 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_394
+DROP VIEW IF EXISTS view_3_tab0_394 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10282,13 +10282,13 @@ SELECT pk FROM tab1 WHERE ((col1 >= 63.83)) OR (col3 BETWEEN 55 AND 81 OR (col4 
 9
 
 statement ok
-DROP VIEW view_1_tab1_394
+DROP VIEW IF EXISTS view_1_tab1_394 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_394
+DROP VIEW IF EXISTS view_2_tab1_394 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_394
+DROP VIEW IF EXISTS view_3_tab1_394 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10407,13 +10407,13 @@ SELECT pk FROM tab2 WHERE ((col1 >= 63.83)) OR (col3 BETWEEN 55 AND 81 OR (col4 
 9
 
 statement ok
-DROP VIEW view_1_tab2_394
+DROP VIEW IF EXISTS view_1_tab2_394 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_394
+DROP VIEW IF EXISTS view_2_tab2_394 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_394
+DROP VIEW IF EXISTS view_3_tab2_394 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10532,13 +10532,13 @@ SELECT pk FROM tab3 WHERE ((col1 >= 63.83)) OR (col3 BETWEEN 55 AND 81 OR (col4 
 9
 
 statement ok
-DROP VIEW view_1_tab3_394
+DROP VIEW IF EXISTS view_1_tab3_394 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_394
+DROP VIEW IF EXISTS view_2_tab3_394 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_394
+DROP VIEW IF EXISTS view_3_tab3_394 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10657,13 +10657,13 @@ SELECT pk FROM tab4 WHERE ((col1 >= 63.83)) OR (col3 BETWEEN 55 AND 81 OR (col4 
 9
 
 statement ok
-DROP VIEW view_1_tab4_394
+DROP VIEW IF EXISTS view_1_tab4_394 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_394
+DROP VIEW IF EXISTS view_2_tab4_394 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_394
+DROP VIEW IF EXISTS view_3_tab4_394 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10781,13 +10781,13 @@ SELECT pk FROM tab0 WHERE col0 <= 85
 7
 
 statement ok
-DROP VIEW view_1_tab0_395
+DROP VIEW IF EXISTS view_1_tab0_395 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_395
+DROP VIEW IF EXISTS view_2_tab0_395 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_395
+DROP VIEW IF EXISTS view_3_tab0_395 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10905,13 +10905,13 @@ SELECT pk FROM tab1 WHERE col0 <= 85
 7
 
 statement ok
-DROP VIEW view_1_tab1_395
+DROP VIEW IF EXISTS view_1_tab1_395 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_395
+DROP VIEW IF EXISTS view_2_tab1_395 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_395
+DROP VIEW IF EXISTS view_3_tab1_395 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11029,13 +11029,13 @@ SELECT pk FROM tab2 WHERE col0 <= 85
 7
 
 statement ok
-DROP VIEW view_1_tab2_395
+DROP VIEW IF EXISTS view_1_tab2_395 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_395
+DROP VIEW IF EXISTS view_2_tab2_395 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_395
+DROP VIEW IF EXISTS view_3_tab2_395 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11153,13 +11153,13 @@ SELECT pk FROM tab3 WHERE col0 <= 85
 7
 
 statement ok
-DROP VIEW view_1_tab3_395
+DROP VIEW IF EXISTS view_1_tab3_395 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_395
+DROP VIEW IF EXISTS view_2_tab3_395 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_395
+DROP VIEW IF EXISTS view_3_tab3_395 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11277,13 +11277,13 @@ SELECT pk FROM tab4 WHERE col0 <= 85
 7
 
 statement ok
-DROP VIEW view_1_tab4_395
+DROP VIEW IF EXISTS view_1_tab4_395 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_395
+DROP VIEW IF EXISTS view_2_tab4_395 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_395
+DROP VIEW IF EXISTS view_3_tab4_395 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11369,13 +11369,13 @@ SELECT pk FROM tab0 WHERE (((col0 = 78)))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_396
+DROP VIEW IF EXISTS view_1_tab0_396 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_396
+DROP VIEW IF EXISTS view_2_tab0_396 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_396
+DROP VIEW IF EXISTS view_3_tab0_396 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11461,13 +11461,13 @@ SELECT pk FROM tab1 WHERE (((col0 = 78)))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_396
+DROP VIEW IF EXISTS view_1_tab1_396 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_396
+DROP VIEW IF EXISTS view_2_tab1_396 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_396
+DROP VIEW IF EXISTS view_3_tab1_396 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11553,13 +11553,13 @@ SELECT pk FROM tab2 WHERE (((col0 = 78)))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_396
+DROP VIEW IF EXISTS view_1_tab2_396 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_396
+DROP VIEW IF EXISTS view_2_tab2_396 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_396
+DROP VIEW IF EXISTS view_3_tab2_396 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11645,13 +11645,13 @@ SELECT pk FROM tab3 WHERE (((col0 = 78)))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_396
+DROP VIEW IF EXISTS view_1_tab3_396 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_396
+DROP VIEW IF EXISTS view_2_tab3_396 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_396
+DROP VIEW IF EXISTS view_3_tab3_396 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11737,13 +11737,13 @@ SELECT pk FROM tab4 WHERE (((col0 = 78)))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_396
+DROP VIEW IF EXISTS view_1_tab4_396 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_396
+DROP VIEW IF EXISTS view_2_tab4_396 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_396
+DROP VIEW IF EXISTS view_3_tab4_396 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11843,13 +11843,13 @@ SELECT pk FROM tab0 WHERE (col3 >= 91) AND (col1 < 82.52)
 9
 
 statement ok
-DROP VIEW view_1_tab0_397
+DROP VIEW IF EXISTS view_1_tab0_397 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_397
+DROP VIEW IF EXISTS view_2_tab0_397 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_397
+DROP VIEW IF EXISTS view_3_tab0_397 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11949,13 +11949,13 @@ SELECT pk FROM tab1 WHERE (col3 >= 91) AND (col1 < 82.52)
 9
 
 statement ok
-DROP VIEW view_1_tab1_397
+DROP VIEW IF EXISTS view_1_tab1_397 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_397
+DROP VIEW IF EXISTS view_2_tab1_397 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_397
+DROP VIEW IF EXISTS view_3_tab1_397 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12055,13 +12055,13 @@ SELECT pk FROM tab2 WHERE (col3 >= 91) AND (col1 < 82.52)
 9
 
 statement ok
-DROP VIEW view_1_tab2_397
+DROP VIEW IF EXISTS view_1_tab2_397 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_397
+DROP VIEW IF EXISTS view_2_tab2_397 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_397
+DROP VIEW IF EXISTS view_3_tab2_397 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12161,13 +12161,13 @@ SELECT pk FROM tab3 WHERE (col3 >= 91) AND (col1 < 82.52)
 9
 
 statement ok
-DROP VIEW view_1_tab3_397
+DROP VIEW IF EXISTS view_1_tab3_397 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_397
+DROP VIEW IF EXISTS view_2_tab3_397 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_397
+DROP VIEW IF EXISTS view_3_tab3_397 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12267,13 +12267,13 @@ SELECT pk FROM tab4 WHERE (col3 >= 91) AND (col1 < 82.52)
 9
 
 statement ok
-DROP VIEW view_1_tab4_397
+DROP VIEW IF EXISTS view_1_tab4_397 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_397
+DROP VIEW IF EXISTS view_2_tab4_397 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_397
+DROP VIEW IF EXISTS view_3_tab4_397 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12373,13 +12373,13 @@ SELECT pk FROM tab0 WHERE col3 <= 16
 7
 
 statement ok
-DROP VIEW view_1_tab0_398
+DROP VIEW IF EXISTS view_1_tab0_398 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_398
+DROP VIEW IF EXISTS view_2_tab0_398 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_398
+DROP VIEW IF EXISTS view_3_tab0_398 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12479,13 +12479,13 @@ SELECT pk FROM tab1 WHERE col3 <= 16
 7
 
 statement ok
-DROP VIEW view_1_tab1_398
+DROP VIEW IF EXISTS view_1_tab1_398 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_398
+DROP VIEW IF EXISTS view_2_tab1_398 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_398
+DROP VIEW IF EXISTS view_3_tab1_398 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12585,13 +12585,13 @@ SELECT pk FROM tab2 WHERE col3 <= 16
 7
 
 statement ok
-DROP VIEW view_1_tab2_398
+DROP VIEW IF EXISTS view_1_tab2_398 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_398
+DROP VIEW IF EXISTS view_2_tab2_398 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_398
+DROP VIEW IF EXISTS view_3_tab2_398 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12691,13 +12691,13 @@ SELECT pk FROM tab3 WHERE col3 <= 16
 7
 
 statement ok
-DROP VIEW view_1_tab3_398
+DROP VIEW IF EXISTS view_1_tab3_398 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_398
+DROP VIEW IF EXISTS view_2_tab3_398 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_398
+DROP VIEW IF EXISTS view_3_tab3_398 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12797,13 +12797,13 @@ SELECT pk FROM tab4 WHERE col3 <= 16
 7
 
 statement ok
-DROP VIEW view_1_tab4_398
+DROP VIEW IF EXISTS view_1_tab4_398 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_398
+DROP VIEW IF EXISTS view_2_tab4_398 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_398
+DROP VIEW IF EXISTS view_3_tab4_398 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12917,13 +12917,13 @@ SELECT pk FROM tab0 WHERE (col0 >= 62)
 9
 
 statement ok
-DROP VIEW view_1_tab0_399
+DROP VIEW IF EXISTS view_1_tab0_399 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_399
+DROP VIEW IF EXISTS view_2_tab0_399 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_399
+DROP VIEW IF EXISTS view_3_tab0_399 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13037,13 +13037,13 @@ SELECT pk FROM tab1 WHERE (col0 >= 62)
 9
 
 statement ok
-DROP VIEW view_1_tab1_399
+DROP VIEW IF EXISTS view_1_tab1_399 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_399
+DROP VIEW IF EXISTS view_2_tab1_399 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_399
+DROP VIEW IF EXISTS view_3_tab1_399 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13157,13 +13157,13 @@ SELECT pk FROM tab2 WHERE (col0 >= 62)
 9
 
 statement ok
-DROP VIEW view_1_tab2_399
+DROP VIEW IF EXISTS view_1_tab2_399 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_399
+DROP VIEW IF EXISTS view_2_tab2_399 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_399
+DROP VIEW IF EXISTS view_3_tab2_399 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13277,13 +13277,13 @@ SELECT pk FROM tab3 WHERE (col0 >= 62)
 9
 
 statement ok
-DROP VIEW view_1_tab3_399
+DROP VIEW IF EXISTS view_1_tab3_399 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_399
+DROP VIEW IF EXISTS view_2_tab3_399 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_399
+DROP VIEW IF EXISTS view_3_tab3_399 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13397,13 +13397,13 @@ SELECT pk FROM tab4 WHERE (col0 >= 62)
 9
 
 statement ok
-DROP VIEW view_1_tab4_399
+DROP VIEW IF EXISTS view_1_tab4_399 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_399
+DROP VIEW IF EXISTS view_2_tab4_399 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_399
+DROP VIEW IF EXISTS view_3_tab4_399 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13496,13 +13496,13 @@ SELECT pk FROM tab0 WHERE col3 > 3
 9 values hashing to 502f27eec143c19418cc601be1d35451
 
 statement ok
-DROP VIEW view_1_tab0_400
+DROP VIEW IF EXISTS view_1_tab0_400 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_400
+DROP VIEW IF EXISTS view_2_tab0_400 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_400
+DROP VIEW IF EXISTS view_3_tab0_400 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13595,13 +13595,13 @@ SELECT pk FROM tab1 WHERE col3 > 3
 9 values hashing to 502f27eec143c19418cc601be1d35451
 
 statement ok
-DROP VIEW view_1_tab1_400
+DROP VIEW IF EXISTS view_1_tab1_400 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_400
+DROP VIEW IF EXISTS view_2_tab1_400 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_400
+DROP VIEW IF EXISTS view_3_tab1_400 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13694,13 +13694,13 @@ SELECT pk FROM tab2 WHERE col3 > 3
 9 values hashing to 502f27eec143c19418cc601be1d35451
 
 statement ok
-DROP VIEW view_1_tab2_400
+DROP VIEW IF EXISTS view_1_tab2_400 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_400
+DROP VIEW IF EXISTS view_2_tab2_400 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_400
+DROP VIEW IF EXISTS view_3_tab2_400 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13793,13 +13793,13 @@ SELECT pk FROM tab3 WHERE col3 > 3
 9 values hashing to 502f27eec143c19418cc601be1d35451
 
 statement ok
-DROP VIEW view_1_tab3_400
+DROP VIEW IF EXISTS view_1_tab3_400 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_400
+DROP VIEW IF EXISTS view_2_tab3_400 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_400
+DROP VIEW IF EXISTS view_3_tab3_400 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13892,13 +13892,13 @@ SELECT pk FROM tab4 WHERE col3 > 3
 9 values hashing to 502f27eec143c19418cc601be1d35451
 
 statement ok
-DROP VIEW view_1_tab4_400
+DROP VIEW IF EXISTS view_1_tab4_400 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_400
+DROP VIEW IF EXISTS view_2_tab4_400 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_400
+DROP VIEW IF EXISTS view_3_tab4_400 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13998,13 +13998,13 @@ SELECT pk FROM tab0 WHERE col1 > 82.1
 5
 
 statement ok
-DROP VIEW view_1_tab0_402
+DROP VIEW IF EXISTS view_1_tab0_402 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_402
+DROP VIEW IF EXISTS view_2_tab0_402 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_402
+DROP VIEW IF EXISTS view_3_tab0_402 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14104,13 +14104,13 @@ SELECT pk FROM tab1 WHERE col1 > 82.1
 5
 
 statement ok
-DROP VIEW view_1_tab1_402
+DROP VIEW IF EXISTS view_1_tab1_402 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_402
+DROP VIEW IF EXISTS view_2_tab1_402 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_402
+DROP VIEW IF EXISTS view_3_tab1_402 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14210,13 +14210,13 @@ SELECT pk FROM tab2 WHERE col1 > 82.1
 5
 
 statement ok
-DROP VIEW view_1_tab2_402
+DROP VIEW IF EXISTS view_1_tab2_402 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_402
+DROP VIEW IF EXISTS view_2_tab2_402 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_402
+DROP VIEW IF EXISTS view_3_tab2_402 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14316,13 +14316,13 @@ SELECT pk FROM tab3 WHERE col1 > 82.1
 5
 
 statement ok
-DROP VIEW view_1_tab3_402
+DROP VIEW IF EXISTS view_1_tab3_402 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_402
+DROP VIEW IF EXISTS view_2_tab3_402 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_402
+DROP VIEW IF EXISTS view_3_tab3_402 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14422,13 +14422,13 @@ SELECT pk FROM tab4 WHERE col1 > 82.1
 5
 
 statement ok
-DROP VIEW view_1_tab4_402
+DROP VIEW IF EXISTS view_1_tab4_402 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_402
+DROP VIEW IF EXISTS view_2_tab4_402 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_402
+DROP VIEW IF EXISTS view_3_tab4_402 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14514,13 +14514,13 @@ SELECT pk FROM tab0 WHERE ((col1 > 94.32)) AND (col0 >= 92)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_403
+DROP VIEW IF EXISTS view_1_tab0_403 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_403
+DROP VIEW IF EXISTS view_2_tab0_403 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_403
+DROP VIEW IF EXISTS view_3_tab0_403 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14606,13 +14606,13 @@ SELECT pk FROM tab1 WHERE ((col1 > 94.32)) AND (col0 >= 92)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_403
+DROP VIEW IF EXISTS view_1_tab1_403 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_403
+DROP VIEW IF EXISTS view_2_tab1_403 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_403
+DROP VIEW IF EXISTS view_3_tab1_403 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14698,13 +14698,13 @@ SELECT pk FROM tab2 WHERE ((col1 > 94.32)) AND (col0 >= 92)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_403
+DROP VIEW IF EXISTS view_1_tab2_403 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_403
+DROP VIEW IF EXISTS view_2_tab2_403 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_403
+DROP VIEW IF EXISTS view_3_tab2_403 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14790,13 +14790,13 @@ SELECT pk FROM tab3 WHERE ((col1 > 94.32)) AND (col0 >= 92)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_403
+DROP VIEW IF EXISTS view_1_tab3_403 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_403
+DROP VIEW IF EXISTS view_2_tab3_403 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_403
+DROP VIEW IF EXISTS view_3_tab3_403 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14882,13 +14882,13 @@ SELECT pk FROM tab4 WHERE ((col1 > 94.32)) AND (col0 >= 92)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_403
+DROP VIEW IF EXISTS view_1_tab4_403 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_403
+DROP VIEW IF EXISTS view_2_tab4_403 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_403
+DROP VIEW IF EXISTS view_3_tab4_403 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15007,13 +15007,13 @@ SELECT pk FROM tab0 WHERE col1 IN (85.32) AND (col0 = 48) OR col3 > 54
 9
 
 statement ok
-DROP VIEW view_1_tab0_404
+DROP VIEW IF EXISTS view_1_tab0_404 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_404
+DROP VIEW IF EXISTS view_2_tab0_404 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_404
+DROP VIEW IF EXISTS view_3_tab0_404 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15132,13 +15132,13 @@ SELECT pk FROM tab1 WHERE col1 IN (85.32) AND (col0 = 48) OR col3 > 54
 9
 
 statement ok
-DROP VIEW view_1_tab1_404
+DROP VIEW IF EXISTS view_1_tab1_404 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_404
+DROP VIEW IF EXISTS view_2_tab1_404 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_404
+DROP VIEW IF EXISTS view_3_tab1_404 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15257,13 +15257,13 @@ SELECT pk FROM tab2 WHERE col1 IN (85.32) AND (col0 = 48) OR col3 > 54
 9
 
 statement ok
-DROP VIEW view_1_tab2_404
+DROP VIEW IF EXISTS view_1_tab2_404 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_404
+DROP VIEW IF EXISTS view_2_tab2_404 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_404
+DROP VIEW IF EXISTS view_3_tab2_404 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15382,13 +15382,13 @@ SELECT pk FROM tab3 WHERE col1 IN (85.32) AND (col0 = 48) OR col3 > 54
 9
 
 statement ok
-DROP VIEW view_1_tab3_404
+DROP VIEW IF EXISTS view_1_tab3_404 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_404
+DROP VIEW IF EXISTS view_2_tab3_404 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_404
+DROP VIEW IF EXISTS view_3_tab3_404 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15507,13 +15507,13 @@ SELECT pk FROM tab4 WHERE col1 IN (85.32) AND (col0 = 48) OR col3 > 54
 9
 
 statement ok
-DROP VIEW view_1_tab4_404
+DROP VIEW IF EXISTS view_1_tab4_404 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_404
+DROP VIEW IF EXISTS view_2_tab4_404 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_404
+DROP VIEW IF EXISTS view_3_tab4_404 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15620,13 +15620,13 @@ SELECT pk FROM tab0 WHERE (col3 < 50)
 7
 
 statement ok
-DROP VIEW view_1_tab0_405
+DROP VIEW IF EXISTS view_1_tab0_405 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_405
+DROP VIEW IF EXISTS view_2_tab0_405 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_405
+DROP VIEW IF EXISTS view_3_tab0_405 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15733,13 +15733,13 @@ SELECT pk FROM tab1 WHERE (col3 < 50)
 7
 
 statement ok
-DROP VIEW view_1_tab1_405
+DROP VIEW IF EXISTS view_1_tab1_405 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_405
+DROP VIEW IF EXISTS view_2_tab1_405 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_405
+DROP VIEW IF EXISTS view_3_tab1_405 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15846,13 +15846,13 @@ SELECT pk FROM tab2 WHERE (col3 < 50)
 7
 
 statement ok
-DROP VIEW view_1_tab2_405
+DROP VIEW IF EXISTS view_1_tab2_405 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_405
+DROP VIEW IF EXISTS view_2_tab2_405 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_405
+DROP VIEW IF EXISTS view_3_tab2_405 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15959,13 +15959,13 @@ SELECT pk FROM tab3 WHERE (col3 < 50)
 7
 
 statement ok
-DROP VIEW view_1_tab3_405
+DROP VIEW IF EXISTS view_1_tab3_405 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_405
+DROP VIEW IF EXISTS view_2_tab3_405 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_405
+DROP VIEW IF EXISTS view_3_tab3_405 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16072,13 +16072,13 @@ SELECT pk FROM tab4 WHERE (col3 < 50)
 7
 
 statement ok
-DROP VIEW view_1_tab4_405
+DROP VIEW IF EXISTS view_1_tab4_405 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_405
+DROP VIEW IF EXISTS view_2_tab4_405 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_405
+DROP VIEW IF EXISTS view_3_tab4_405 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16178,13 +16178,13 @@ SELECT pk FROM tab0 WHERE ((col0 > 21 AND col4 > 70.69 AND col4 > 33.45)) AND co
 8
 
 statement ok
-DROP VIEW view_1_tab0_406
+DROP VIEW IF EXISTS view_1_tab0_406 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_406
+DROP VIEW IF EXISTS view_2_tab0_406 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_406
+DROP VIEW IF EXISTS view_3_tab0_406 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16284,13 +16284,13 @@ SELECT pk FROM tab1 WHERE ((col0 > 21 AND col4 > 70.69 AND col4 > 33.45)) AND co
 8
 
 statement ok
-DROP VIEW view_1_tab1_406
+DROP VIEW IF EXISTS view_1_tab1_406 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_406
+DROP VIEW IF EXISTS view_2_tab1_406 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_406
+DROP VIEW IF EXISTS view_3_tab1_406 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16390,13 +16390,13 @@ SELECT pk FROM tab2 WHERE ((col0 > 21 AND col4 > 70.69 AND col4 > 33.45)) AND co
 8
 
 statement ok
-DROP VIEW view_1_tab2_406
+DROP VIEW IF EXISTS view_1_tab2_406 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_406
+DROP VIEW IF EXISTS view_2_tab2_406 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_406
+DROP VIEW IF EXISTS view_3_tab2_406 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16496,13 +16496,13 @@ SELECT pk FROM tab3 WHERE ((col0 > 21 AND col4 > 70.69 AND col4 > 33.45)) AND co
 8
 
 statement ok
-DROP VIEW view_1_tab3_406
+DROP VIEW IF EXISTS view_1_tab3_406 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_406
+DROP VIEW IF EXISTS view_2_tab3_406 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_406
+DROP VIEW IF EXISTS view_3_tab3_406 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16602,13 +16602,13 @@ SELECT pk FROM tab4 WHERE ((col0 > 21 AND col4 > 70.69 AND col4 > 33.45)) AND co
 8
 
 statement ok
-DROP VIEW view_1_tab4_406
+DROP VIEW IF EXISTS view_1_tab4_406 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_406
+DROP VIEW IF EXISTS view_2_tab4_406 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_406
+DROP VIEW IF EXISTS view_3_tab4_406 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16697,13 +16697,13 @@ SELECT pk FROM tab0 WHERE col4 > 6.40
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_407
+DROP VIEW IF EXISTS view_1_tab0_407 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_407
+DROP VIEW IF EXISTS view_2_tab0_407 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_407
+DROP VIEW IF EXISTS view_3_tab0_407 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16792,13 +16792,13 @@ SELECT pk FROM tab1 WHERE col4 > 6.40
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_407
+DROP VIEW IF EXISTS view_1_tab1_407 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_407
+DROP VIEW IF EXISTS view_2_tab1_407 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_407
+DROP VIEW IF EXISTS view_3_tab1_407 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16887,13 +16887,13 @@ SELECT pk FROM tab2 WHERE col4 > 6.40
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_407
+DROP VIEW IF EXISTS view_1_tab2_407 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_407
+DROP VIEW IF EXISTS view_2_tab2_407 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_407
+DROP VIEW IF EXISTS view_3_tab2_407 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16982,13 +16982,13 @@ SELECT pk FROM tab3 WHERE col4 > 6.40
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_407
+DROP VIEW IF EXISTS view_1_tab3_407 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_407
+DROP VIEW IF EXISTS view_2_tab3_407 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_407
+DROP VIEW IF EXISTS view_3_tab3_407 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17077,13 +17077,13 @@ SELECT pk FROM tab4 WHERE col4 > 6.40
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_407
+DROP VIEW IF EXISTS view_1_tab4_407 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_407
+DROP VIEW IF EXISTS view_2_tab4_407 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_407
+DROP VIEW IF EXISTS view_3_tab4_407 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17169,13 +17169,13 @@ SELECT pk FROM tab0 WHERE col3 IS NULL AND (((((col1 < 63.79))) OR col0 >= 35 AN
 ----
 
 statement ok
-DROP VIEW view_1_tab0_408
+DROP VIEW IF EXISTS view_1_tab0_408 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_408
+DROP VIEW IF EXISTS view_2_tab0_408 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_408
+DROP VIEW IF EXISTS view_3_tab0_408 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17261,13 +17261,13 @@ SELECT pk FROM tab1 WHERE col3 IS NULL AND (((((col1 < 63.79))) OR col0 >= 35 AN
 ----
 
 statement ok
-DROP VIEW view_1_tab1_408
+DROP VIEW IF EXISTS view_1_tab1_408 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_408
+DROP VIEW IF EXISTS view_2_tab1_408 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_408
+DROP VIEW IF EXISTS view_3_tab1_408 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17353,13 +17353,13 @@ SELECT pk FROM tab2 WHERE col3 IS NULL AND (((((col1 < 63.79))) OR col0 >= 35 AN
 ----
 
 statement ok
-DROP VIEW view_1_tab2_408
+DROP VIEW IF EXISTS view_1_tab2_408 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_408
+DROP VIEW IF EXISTS view_2_tab2_408 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_408
+DROP VIEW IF EXISTS view_3_tab2_408 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17445,13 +17445,13 @@ SELECT pk FROM tab3 WHERE col3 IS NULL AND (((((col1 < 63.79))) OR col0 >= 35 AN
 ----
 
 statement ok
-DROP VIEW view_1_tab3_408
+DROP VIEW IF EXISTS view_1_tab3_408 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_408
+DROP VIEW IF EXISTS view_2_tab3_408 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_408
+DROP VIEW IF EXISTS view_3_tab3_408 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17537,13 +17537,13 @@ SELECT pk FROM tab4 WHERE col3 IS NULL AND (((((col1 < 63.79))) OR col0 >= 35 AN
 ----
 
 statement ok
-DROP VIEW view_1_tab4_408
+DROP VIEW IF EXISTS view_1_tab4_408 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_408
+DROP VIEW IF EXISTS view_2_tab4_408 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_408
+DROP VIEW IF EXISTS view_3_tab4_408 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17650,13 +17650,13 @@ SELECT pk FROM tab0 WHERE ((((col1 >= 65.44)))) OR ((col3 > 70 AND ((col0 < 62))
 8
 
 statement ok
-DROP VIEW view_1_tab0_409
+DROP VIEW IF EXISTS view_1_tab0_409 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_409
+DROP VIEW IF EXISTS view_2_tab0_409 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_409
+DROP VIEW IF EXISTS view_3_tab0_409 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17763,13 +17763,13 @@ SELECT pk FROM tab1 WHERE ((((col1 >= 65.44)))) OR ((col3 > 70 AND ((col0 < 62))
 8
 
 statement ok
-DROP VIEW view_1_tab1_409
+DROP VIEW IF EXISTS view_1_tab1_409 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_409
+DROP VIEW IF EXISTS view_2_tab1_409 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_409
+DROP VIEW IF EXISTS view_3_tab1_409 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17876,13 +17876,13 @@ SELECT pk FROM tab2 WHERE ((((col1 >= 65.44)))) OR ((col3 > 70 AND ((col0 < 62))
 8
 
 statement ok
-DROP VIEW view_1_tab2_409
+DROP VIEW IF EXISTS view_1_tab2_409 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_409
+DROP VIEW IF EXISTS view_2_tab2_409 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_409
+DROP VIEW IF EXISTS view_3_tab2_409 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17989,13 +17989,13 @@ SELECT pk FROM tab3 WHERE ((((col1 >= 65.44)))) OR ((col3 > 70 AND ((col0 < 62))
 8
 
 statement ok
-DROP VIEW view_1_tab3_409
+DROP VIEW IF EXISTS view_1_tab3_409 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_409
+DROP VIEW IF EXISTS view_2_tab3_409 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_409
+DROP VIEW IF EXISTS view_3_tab3_409 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18102,13 +18102,13 @@ SELECT pk FROM tab4 WHERE ((((col1 >= 65.44)))) OR ((col3 > 70 AND ((col0 < 62))
 8
 
 statement ok
-DROP VIEW view_1_tab4_409
+DROP VIEW IF EXISTS view_1_tab4_409 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_409
+DROP VIEW IF EXISTS view_2_tab4_409 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_409
+DROP VIEW IF EXISTS view_3_tab4_409 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18201,13 +18201,13 @@ SELECT pk FROM tab0 WHERE col3 <= 67 AND ((col4 < 56.31 AND (col3 < 40) AND (col
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab0_410
+DROP VIEW IF EXISTS view_1_tab0_410 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_410
+DROP VIEW IF EXISTS view_2_tab0_410 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_410
+DROP VIEW IF EXISTS view_3_tab0_410 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18300,13 +18300,13 @@ SELECT pk FROM tab1 WHERE col3 <= 67 AND ((col4 < 56.31 AND (col3 < 40) AND (col
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab1_410
+DROP VIEW IF EXISTS view_1_tab1_410 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_410
+DROP VIEW IF EXISTS view_2_tab1_410 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_410
+DROP VIEW IF EXISTS view_3_tab1_410 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18399,13 +18399,13 @@ SELECT pk FROM tab2 WHERE col3 <= 67 AND ((col4 < 56.31 AND (col3 < 40) AND (col
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab2_410
+DROP VIEW IF EXISTS view_1_tab2_410 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_410
+DROP VIEW IF EXISTS view_2_tab2_410 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_410
+DROP VIEW IF EXISTS view_3_tab2_410 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18498,13 +18498,13 @@ SELECT pk FROM tab3 WHERE col3 <= 67 AND ((col4 < 56.31 AND (col3 < 40) AND (col
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab3_410
+DROP VIEW IF EXISTS view_1_tab3_410 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_410
+DROP VIEW IF EXISTS view_2_tab3_410 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_410
+DROP VIEW IF EXISTS view_3_tab3_410 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18597,13 +18597,13 @@ SELECT pk FROM tab4 WHERE col3 <= 67 AND ((col4 < 56.31 AND (col3 < 40) AND (col
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab4_410
+DROP VIEW IF EXISTS view_1_tab4_410 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_410
+DROP VIEW IF EXISTS view_2_tab4_410 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_410
+DROP VIEW IF EXISTS view_3_tab4_410 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18696,13 +18696,13 @@ SELECT pk FROM tab0 WHERE (((col0 > 57 OR col1 <= 75.61)))
 9 values hashing to 4290bd41ca7ca69dc280e33882d8e9de
 
 statement ok
-DROP VIEW view_1_tab0_411
+DROP VIEW IF EXISTS view_1_tab0_411 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_411
+DROP VIEW IF EXISTS view_2_tab0_411 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_411
+DROP VIEW IF EXISTS view_3_tab0_411 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18795,13 +18795,13 @@ SELECT pk FROM tab1 WHERE (((col0 > 57 OR col1 <= 75.61)))
 9 values hashing to 4290bd41ca7ca69dc280e33882d8e9de
 
 statement ok
-DROP VIEW view_1_tab1_411
+DROP VIEW IF EXISTS view_1_tab1_411 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_411
+DROP VIEW IF EXISTS view_2_tab1_411 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_411
+DROP VIEW IF EXISTS view_3_tab1_411 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18894,13 +18894,13 @@ SELECT pk FROM tab2 WHERE (((col0 > 57 OR col1 <= 75.61)))
 9 values hashing to 4290bd41ca7ca69dc280e33882d8e9de
 
 statement ok
-DROP VIEW view_1_tab2_411
+DROP VIEW IF EXISTS view_1_tab2_411 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_411
+DROP VIEW IF EXISTS view_2_tab2_411 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_411
+DROP VIEW IF EXISTS view_3_tab2_411 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18993,13 +18993,13 @@ SELECT pk FROM tab3 WHERE (((col0 > 57 OR col1 <= 75.61)))
 9 values hashing to 4290bd41ca7ca69dc280e33882d8e9de
 
 statement ok
-DROP VIEW view_1_tab3_411
+DROP VIEW IF EXISTS view_1_tab3_411 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_411
+DROP VIEW IF EXISTS view_2_tab3_411 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_411
+DROP VIEW IF EXISTS view_3_tab3_411 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19092,13 +19092,13 @@ SELECT pk FROM tab4 WHERE (((col0 > 57 OR col1 <= 75.61)))
 9 values hashing to 4290bd41ca7ca69dc280e33882d8e9de
 
 statement ok
-DROP VIEW view_1_tab4_411
+DROP VIEW IF EXISTS view_1_tab4_411 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_411
+DROP VIEW IF EXISTS view_2_tab4_411 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_411
+DROP VIEW IF EXISTS view_3_tab4_411 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19191,13 +19191,13 @@ SELECT pk FROM tab0 WHERE col0 > 94
 9
 
 statement ok
-DROP VIEW view_1_tab0_412
+DROP VIEW IF EXISTS view_1_tab0_412 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_412
+DROP VIEW IF EXISTS view_2_tab0_412 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_412
+DROP VIEW IF EXISTS view_3_tab0_412 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19290,13 +19290,13 @@ SELECT pk FROM tab1 WHERE col0 > 94
 9
 
 statement ok
-DROP VIEW view_1_tab1_412
+DROP VIEW IF EXISTS view_1_tab1_412 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_412
+DROP VIEW IF EXISTS view_2_tab1_412 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_412
+DROP VIEW IF EXISTS view_3_tab1_412 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19389,13 +19389,13 @@ SELECT pk FROM tab2 WHERE col0 > 94
 9
 
 statement ok
-DROP VIEW view_1_tab2_412
+DROP VIEW IF EXISTS view_1_tab2_412 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_412
+DROP VIEW IF EXISTS view_2_tab2_412 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_412
+DROP VIEW IF EXISTS view_3_tab2_412 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19488,13 +19488,13 @@ SELECT pk FROM tab3 WHERE col0 > 94
 9
 
 statement ok
-DROP VIEW view_1_tab3_412
+DROP VIEW IF EXISTS view_1_tab3_412 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_412
+DROP VIEW IF EXISTS view_2_tab3_412 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_412
+DROP VIEW IF EXISTS view_3_tab3_412 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19587,13 +19587,13 @@ SELECT pk FROM tab4 WHERE col0 > 94
 9
 
 statement ok
-DROP VIEW view_1_tab4_412
+DROP VIEW IF EXISTS view_1_tab4_412 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_412
+DROP VIEW IF EXISTS view_2_tab4_412 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_412
+DROP VIEW IF EXISTS view_3_tab4_412 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19707,13 +19707,13 @@ SELECT pk FROM tab0 WHERE (col1 <= 40.38)
 9
 
 statement ok
-DROP VIEW view_1_tab0_413
+DROP VIEW IF EXISTS view_1_tab0_413 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_413
+DROP VIEW IF EXISTS view_2_tab0_413 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_413
+DROP VIEW IF EXISTS view_3_tab0_413 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19827,13 +19827,13 @@ SELECT pk FROM tab1 WHERE (col1 <= 40.38)
 9
 
 statement ok
-DROP VIEW view_1_tab1_413
+DROP VIEW IF EXISTS view_1_tab1_413 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_413
+DROP VIEW IF EXISTS view_2_tab1_413 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_413
+DROP VIEW IF EXISTS view_3_tab1_413 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19947,13 +19947,13 @@ SELECT pk FROM tab2 WHERE (col1 <= 40.38)
 9
 
 statement ok
-DROP VIEW view_1_tab2_413
+DROP VIEW IF EXISTS view_1_tab2_413 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_413
+DROP VIEW IF EXISTS view_2_tab2_413 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_413
+DROP VIEW IF EXISTS view_3_tab2_413 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20067,13 +20067,13 @@ SELECT pk FROM tab3 WHERE (col1 <= 40.38)
 9
 
 statement ok
-DROP VIEW view_1_tab3_413
+DROP VIEW IF EXISTS view_1_tab3_413 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_413
+DROP VIEW IF EXISTS view_2_tab3_413 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_413
+DROP VIEW IF EXISTS view_3_tab3_413 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20187,13 +20187,13 @@ SELECT pk FROM tab4 WHERE (col1 <= 40.38)
 9
 
 statement ok
-DROP VIEW view_1_tab4_413
+DROP VIEW IF EXISTS view_1_tab4_413 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_413
+DROP VIEW IF EXISTS view_2_tab4_413 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_413
+DROP VIEW IF EXISTS view_3_tab4_413 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20296,13 +20296,13 @@ SELECT pk FROM tab0 WHERE col1 < 57.24
 9
 
 statement ok
-DROP VIEW view_1_tab0_414
+DROP VIEW IF EXISTS view_1_tab0_414 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_414
+DROP VIEW IF EXISTS view_2_tab0_414 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_414
+DROP VIEW IF EXISTS view_3_tab0_414 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20405,13 +20405,13 @@ SELECT pk FROM tab1 WHERE col1 < 57.24
 9
 
 statement ok
-DROP VIEW view_1_tab1_414
+DROP VIEW IF EXISTS view_1_tab1_414 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_414
+DROP VIEW IF EXISTS view_2_tab1_414 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_414
+DROP VIEW IF EXISTS view_3_tab1_414 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20514,13 +20514,13 @@ SELECT pk FROM tab2 WHERE col1 < 57.24
 9
 
 statement ok
-DROP VIEW view_1_tab2_414
+DROP VIEW IF EXISTS view_1_tab2_414 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_414
+DROP VIEW IF EXISTS view_2_tab2_414 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_414
+DROP VIEW IF EXISTS view_3_tab2_414 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20623,13 +20623,13 @@ SELECT pk FROM tab3 WHERE col1 < 57.24
 9
 
 statement ok
-DROP VIEW view_1_tab3_414
+DROP VIEW IF EXISTS view_1_tab3_414 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_414
+DROP VIEW IF EXISTS view_2_tab3_414 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_414
+DROP VIEW IF EXISTS view_3_tab3_414 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20732,13 +20732,13 @@ SELECT pk FROM tab4 WHERE col1 < 57.24
 9
 
 statement ok
-DROP VIEW view_1_tab4_414
+DROP VIEW IF EXISTS view_1_tab4_414 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_414
+DROP VIEW IF EXISTS view_2_tab4_414 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_414
+DROP VIEW IF EXISTS view_3_tab4_414 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20824,13 +20824,13 @@ SELECT pk FROM tab0 WHERE col0 IN (SELECT col3 FROM tab0 WHERE ((((col0 > 71))))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_415
+DROP VIEW IF EXISTS view_1_tab0_415 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_415
+DROP VIEW IF EXISTS view_2_tab0_415 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_415
+DROP VIEW IF EXISTS view_3_tab0_415 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20916,13 +20916,13 @@ SELECT pk FROM tab1 WHERE col0 IN (SELECT col3 FROM tab1 WHERE ((((col0 > 71))))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_415
+DROP VIEW IF EXISTS view_1_tab1_415 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_415
+DROP VIEW IF EXISTS view_2_tab1_415 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_415
+DROP VIEW IF EXISTS view_3_tab1_415 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21008,13 +21008,13 @@ SELECT pk FROM tab2 WHERE col0 IN (SELECT col3 FROM tab2 WHERE ((((col0 > 71))))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_415
+DROP VIEW IF EXISTS view_1_tab2_415 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_415
+DROP VIEW IF EXISTS view_2_tab2_415 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_415
+DROP VIEW IF EXISTS view_3_tab2_415 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21100,13 +21100,13 @@ SELECT pk FROM tab3 WHERE col0 IN (SELECT col3 FROM tab3 WHERE ((((col0 > 71))))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_415
+DROP VIEW IF EXISTS view_1_tab3_415 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_415
+DROP VIEW IF EXISTS view_2_tab3_415 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_415
+DROP VIEW IF EXISTS view_3_tab3_415 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21192,13 +21192,13 @@ SELECT pk FROM tab4 WHERE col0 IN (SELECT col3 FROM tab4 WHERE ((((col0 > 71))))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_415
+DROP VIEW IF EXISTS view_1_tab4_415 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_415
+DROP VIEW IF EXISTS view_2_tab4_415 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_415
+DROP VIEW IF EXISTS view_3_tab4_415 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21291,13 +21291,13 @@ SELECT pk FROM tab0 WHERE col4 >= 23.12 AND (((((col3 <= 73) AND col0 >= 3 OR co
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab0_416
+DROP VIEW IF EXISTS view_1_tab0_416 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_416
+DROP VIEW IF EXISTS view_2_tab0_416 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_416
+DROP VIEW IF EXISTS view_3_tab0_416 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21390,13 +21390,13 @@ SELECT pk FROM tab1 WHERE col4 >= 23.12 AND (((((col3 <= 73) AND col0 >= 3 OR co
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab1_416
+DROP VIEW IF EXISTS view_1_tab1_416 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_416
+DROP VIEW IF EXISTS view_2_tab1_416 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_416
+DROP VIEW IF EXISTS view_3_tab1_416 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21489,13 +21489,13 @@ SELECT pk FROM tab2 WHERE col4 >= 23.12 AND (((((col3 <= 73) AND col0 >= 3 OR co
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab2_416
+DROP VIEW IF EXISTS view_1_tab2_416 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_416
+DROP VIEW IF EXISTS view_2_tab2_416 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_416
+DROP VIEW IF EXISTS view_3_tab2_416 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21588,13 +21588,13 @@ SELECT pk FROM tab3 WHERE col4 >= 23.12 AND (((((col3 <= 73) AND col0 >= 3 OR co
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab3_416
+DROP VIEW IF EXISTS view_1_tab3_416 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_416
+DROP VIEW IF EXISTS view_2_tab3_416 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_416
+DROP VIEW IF EXISTS view_3_tab3_416 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21687,13 +21687,13 @@ SELECT pk FROM tab4 WHERE col4 >= 23.12 AND (((((col3 <= 73) AND col0 >= 3 OR co
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab4_416
+DROP VIEW IF EXISTS view_1_tab4_416 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_416
+DROP VIEW IF EXISTS view_2_tab4_416 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_416
+DROP VIEW IF EXISTS view_3_tab4_416 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21811,13 +21811,13 @@ SELECT pk FROM tab0 WHERE col4 >= 12.94
 8
 
 statement ok
-DROP VIEW view_1_tab0_417
+DROP VIEW IF EXISTS view_1_tab0_417 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_417
+DROP VIEW IF EXISTS view_2_tab0_417 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_417
+DROP VIEW IF EXISTS view_3_tab0_417 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21935,13 +21935,13 @@ SELECT pk FROM tab1 WHERE col4 >= 12.94
 8
 
 statement ok
-DROP VIEW view_1_tab1_417
+DROP VIEW IF EXISTS view_1_tab1_417 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_417
+DROP VIEW IF EXISTS view_2_tab1_417 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_417
+DROP VIEW IF EXISTS view_3_tab1_417 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22059,13 +22059,13 @@ SELECT pk FROM tab2 WHERE col4 >= 12.94
 8
 
 statement ok
-DROP VIEW view_1_tab2_417
+DROP VIEW IF EXISTS view_1_tab2_417 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_417
+DROP VIEW IF EXISTS view_2_tab2_417 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_417
+DROP VIEW IF EXISTS view_3_tab2_417 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22183,13 +22183,13 @@ SELECT pk FROM tab3 WHERE col4 >= 12.94
 8
 
 statement ok
-DROP VIEW view_1_tab3_417
+DROP VIEW IF EXISTS view_1_tab3_417 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_417
+DROP VIEW IF EXISTS view_2_tab3_417 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_417
+DROP VIEW IF EXISTS view_3_tab3_417 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22307,13 +22307,13 @@ SELECT pk FROM tab4 WHERE col4 >= 12.94
 8
 
 statement ok
-DROP VIEW view_1_tab4_417
+DROP VIEW IF EXISTS view_1_tab4_417 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_417
+DROP VIEW IF EXISTS view_2_tab4_417 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_417
+DROP VIEW IF EXISTS view_3_tab4_417 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22413,13 +22413,13 @@ SELECT pk FROM tab0 WHERE (col1 < 28.37)
 7
 
 statement ok
-DROP VIEW view_1_tab0_418
+DROP VIEW IF EXISTS view_1_tab0_418 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_418
+DROP VIEW IF EXISTS view_2_tab0_418 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_418
+DROP VIEW IF EXISTS view_3_tab0_418 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22519,13 +22519,13 @@ SELECT pk FROM tab1 WHERE (col1 < 28.37)
 7
 
 statement ok
-DROP VIEW view_1_tab1_418
+DROP VIEW IF EXISTS view_1_tab1_418 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_418
+DROP VIEW IF EXISTS view_2_tab1_418 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_418
+DROP VIEW IF EXISTS view_3_tab1_418 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22625,13 +22625,13 @@ SELECT pk FROM tab2 WHERE (col1 < 28.37)
 7
 
 statement ok
-DROP VIEW view_1_tab2_418
+DROP VIEW IF EXISTS view_1_tab2_418 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_418
+DROP VIEW IF EXISTS view_2_tab2_418 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_418
+DROP VIEW IF EXISTS view_3_tab2_418 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22731,13 +22731,13 @@ SELECT pk FROM tab3 WHERE (col1 < 28.37)
 7
 
 statement ok
-DROP VIEW view_1_tab3_418
+DROP VIEW IF EXISTS view_1_tab3_418 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_418
+DROP VIEW IF EXISTS view_2_tab3_418 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_418
+DROP VIEW IF EXISTS view_3_tab3_418 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22837,13 +22837,13 @@ SELECT pk FROM tab4 WHERE (col1 < 28.37)
 7
 
 statement ok
-DROP VIEW view_1_tab4_418
+DROP VIEW IF EXISTS view_1_tab4_418 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_418
+DROP VIEW IF EXISTS view_2_tab4_418 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_418
+DROP VIEW IF EXISTS view_3_tab4_418 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22929,13 +22929,13 @@ SELECT pk FROM tab0 WHERE ((((col3 BETWEEN 91 AND 87))))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_419
+DROP VIEW IF EXISTS view_1_tab0_419 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_419
+DROP VIEW IF EXISTS view_2_tab0_419 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_419
+DROP VIEW IF EXISTS view_3_tab0_419 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23021,13 +23021,13 @@ SELECT pk FROM tab1 WHERE ((((col3 BETWEEN 91 AND 87))))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_419
+DROP VIEW IF EXISTS view_1_tab1_419 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_419
+DROP VIEW IF EXISTS view_2_tab1_419 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_419
+DROP VIEW IF EXISTS view_3_tab1_419 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23113,13 +23113,13 @@ SELECT pk FROM tab2 WHERE ((((col3 BETWEEN 91 AND 87))))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_419
+DROP VIEW IF EXISTS view_1_tab2_419 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_419
+DROP VIEW IF EXISTS view_2_tab2_419 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_419
+DROP VIEW IF EXISTS view_3_tab2_419 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23205,13 +23205,13 @@ SELECT pk FROM tab3 WHERE ((((col3 BETWEEN 91 AND 87))))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_419
+DROP VIEW IF EXISTS view_1_tab3_419 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_419
+DROP VIEW IF EXISTS view_2_tab3_419 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_419
+DROP VIEW IF EXISTS view_3_tab3_419 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23297,13 +23297,13 @@ SELECT pk FROM tab4 WHERE ((((col3 BETWEEN 91 AND 87))))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_419
+DROP VIEW IF EXISTS view_1_tab4_419 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_419
+DROP VIEW IF EXISTS view_2_tab4_419 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_419
+DROP VIEW IF EXISTS view_3_tab4_419 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23417,13 +23417,13 @@ SELECT pk FROM tab0 WHERE col4 > 18.48 AND (col4 <= 77.3) AND col3 > 22
 6
 
 statement ok
-DROP VIEW view_1_tab0_420
+DROP VIEW IF EXISTS view_1_tab0_420 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_420
+DROP VIEW IF EXISTS view_2_tab0_420 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_420
+DROP VIEW IF EXISTS view_3_tab0_420 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23537,13 +23537,13 @@ SELECT pk FROM tab1 WHERE col4 > 18.48 AND (col4 <= 77.3) AND col3 > 22
 6
 
 statement ok
-DROP VIEW view_1_tab1_420
+DROP VIEW IF EXISTS view_1_tab1_420 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_420
+DROP VIEW IF EXISTS view_2_tab1_420 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_420
+DROP VIEW IF EXISTS view_3_tab1_420 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23657,13 +23657,13 @@ SELECT pk FROM tab2 WHERE col4 > 18.48 AND (col4 <= 77.3) AND col3 > 22
 6
 
 statement ok
-DROP VIEW view_1_tab2_420
+DROP VIEW IF EXISTS view_1_tab2_420 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_420
+DROP VIEW IF EXISTS view_2_tab2_420 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_420
+DROP VIEW IF EXISTS view_3_tab2_420 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23777,13 +23777,13 @@ SELECT pk FROM tab3 WHERE col4 > 18.48 AND (col4 <= 77.3) AND col3 > 22
 6
 
 statement ok
-DROP VIEW view_1_tab3_420
+DROP VIEW IF EXISTS view_1_tab3_420 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_420
+DROP VIEW IF EXISTS view_2_tab3_420 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_420
+DROP VIEW IF EXISTS view_3_tab3_420 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23897,13 +23897,13 @@ SELECT pk FROM tab4 WHERE col4 > 18.48 AND (col4 <= 77.3) AND col3 > 22
 6
 
 statement ok
-DROP VIEW view_1_tab4_420
+DROP VIEW IF EXISTS view_1_tab4_420 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_420
+DROP VIEW IF EXISTS view_2_tab4_420 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_420
+DROP VIEW IF EXISTS view_3_tab4_420 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23996,13 +23996,13 @@ SELECT pk FROM tab0 WHERE col3 >= 4
 9 values hashing to 502f27eec143c19418cc601be1d35451
 
 statement ok
-DROP VIEW view_1_tab0_421
+DROP VIEW IF EXISTS view_1_tab0_421 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_421
+DROP VIEW IF EXISTS view_2_tab0_421 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_421
+DROP VIEW IF EXISTS view_3_tab0_421 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24095,13 +24095,13 @@ SELECT pk FROM tab1 WHERE col3 >= 4
 9 values hashing to 502f27eec143c19418cc601be1d35451
 
 statement ok
-DROP VIEW view_1_tab1_421
+DROP VIEW IF EXISTS view_1_tab1_421 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_421
+DROP VIEW IF EXISTS view_2_tab1_421 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_421
+DROP VIEW IF EXISTS view_3_tab1_421 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24194,13 +24194,13 @@ SELECT pk FROM tab2 WHERE col3 >= 4
 9 values hashing to 502f27eec143c19418cc601be1d35451
 
 statement ok
-DROP VIEW view_1_tab2_421
+DROP VIEW IF EXISTS view_1_tab2_421 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_421
+DROP VIEW IF EXISTS view_2_tab2_421 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_421
+DROP VIEW IF EXISTS view_3_tab2_421 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24293,13 +24293,13 @@ SELECT pk FROM tab3 WHERE col3 >= 4
 9 values hashing to 502f27eec143c19418cc601be1d35451
 
 statement ok
-DROP VIEW view_1_tab3_421
+DROP VIEW IF EXISTS view_1_tab3_421 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_421
+DROP VIEW IF EXISTS view_2_tab3_421 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_421
+DROP VIEW IF EXISTS view_3_tab3_421 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24392,13 +24392,13 @@ SELECT pk FROM tab4 WHERE col3 >= 4
 9 values hashing to 502f27eec143c19418cc601be1d35451
 
 statement ok
-DROP VIEW view_1_tab4_421
+DROP VIEW IF EXISTS view_1_tab4_421 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_421
+DROP VIEW IF EXISTS view_2_tab4_421 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_421
+DROP VIEW IF EXISTS view_3_tab4_421 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24484,13 +24484,13 @@ SELECT pk FROM tab0 WHERE ((col3 = 57))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_422
+DROP VIEW IF EXISTS view_1_tab0_422 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_422
+DROP VIEW IF EXISTS view_2_tab0_422 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_422
+DROP VIEW IF EXISTS view_3_tab0_422 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24576,13 +24576,13 @@ SELECT pk FROM tab1 WHERE ((col3 = 57))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_422
+DROP VIEW IF EXISTS view_1_tab1_422 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_422
+DROP VIEW IF EXISTS view_2_tab1_422 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_422
+DROP VIEW IF EXISTS view_3_tab1_422 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24668,13 +24668,13 @@ SELECT pk FROM tab2 WHERE ((col3 = 57))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_422
+DROP VIEW IF EXISTS view_1_tab2_422 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_422
+DROP VIEW IF EXISTS view_2_tab2_422 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_422
+DROP VIEW IF EXISTS view_3_tab2_422 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24760,13 +24760,13 @@ SELECT pk FROM tab3 WHERE ((col3 = 57))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_422
+DROP VIEW IF EXISTS view_1_tab3_422 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_422
+DROP VIEW IF EXISTS view_2_tab3_422 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_422
+DROP VIEW IF EXISTS view_3_tab3_422 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24852,13 +24852,13 @@ SELECT pk FROM tab4 WHERE ((col3 = 57))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_422
+DROP VIEW IF EXISTS view_1_tab4_422 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_422
+DROP VIEW IF EXISTS view_2_tab4_422 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_422
+DROP VIEW IF EXISTS view_3_tab4_422 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24944,13 +24944,13 @@ SELECT pk FROM tab0 WHERE ((col1 BETWEEN 55.18 AND 10.36 AND col3 >= 11))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_423
+DROP VIEW IF EXISTS view_1_tab0_423 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_423
+DROP VIEW IF EXISTS view_2_tab0_423 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_423
+DROP VIEW IF EXISTS view_3_tab0_423 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25036,13 +25036,13 @@ SELECT pk FROM tab1 WHERE ((col1 BETWEEN 55.18 AND 10.36 AND col3 >= 11))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_423
+DROP VIEW IF EXISTS view_1_tab1_423 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_423
+DROP VIEW IF EXISTS view_2_tab1_423 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_423
+DROP VIEW IF EXISTS view_3_tab1_423 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25128,13 +25128,13 @@ SELECT pk FROM tab2 WHERE ((col1 BETWEEN 55.18 AND 10.36 AND col3 >= 11))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_423
+DROP VIEW IF EXISTS view_1_tab2_423 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_423
+DROP VIEW IF EXISTS view_2_tab2_423 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_423
+DROP VIEW IF EXISTS view_3_tab2_423 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25220,13 +25220,13 @@ SELECT pk FROM tab3 WHERE ((col1 BETWEEN 55.18 AND 10.36 AND col3 >= 11))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_423
+DROP VIEW IF EXISTS view_1_tab3_423 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_423
+DROP VIEW IF EXISTS view_2_tab3_423 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_423
+DROP VIEW IF EXISTS view_3_tab3_423 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25312,13 +25312,13 @@ SELECT pk FROM tab4 WHERE ((col1 BETWEEN 55.18 AND 10.36 AND col3 >= 11))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_423
+DROP VIEW IF EXISTS view_1_tab4_423 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_423
+DROP VIEW IF EXISTS view_2_tab4_423 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_423
+DROP VIEW IF EXISTS view_3_tab4_423 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25404,13 +25404,13 @@ SELECT pk FROM tab0 WHERE ((col1 = 42.8))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_424
+DROP VIEW IF EXISTS view_1_tab0_424 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_424
+DROP VIEW IF EXISTS view_2_tab0_424 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_424
+DROP VIEW IF EXISTS view_3_tab0_424 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25496,13 +25496,13 @@ SELECT pk FROM tab1 WHERE ((col1 = 42.8))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_424
+DROP VIEW IF EXISTS view_1_tab1_424 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_424
+DROP VIEW IF EXISTS view_2_tab1_424 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_424
+DROP VIEW IF EXISTS view_3_tab1_424 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25588,13 +25588,13 @@ SELECT pk FROM tab2 WHERE ((col1 = 42.8))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_424
+DROP VIEW IF EXISTS view_1_tab2_424 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_424
+DROP VIEW IF EXISTS view_2_tab2_424 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_424
+DROP VIEW IF EXISTS view_3_tab2_424 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25680,13 +25680,13 @@ SELECT pk FROM tab3 WHERE ((col1 = 42.8))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_424
+DROP VIEW IF EXISTS view_1_tab3_424 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_424
+DROP VIEW IF EXISTS view_2_tab3_424 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_424
+DROP VIEW IF EXISTS view_3_tab3_424 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25772,13 +25772,13 @@ SELECT pk FROM tab4 WHERE ((col1 = 42.8))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_424
+DROP VIEW IF EXISTS view_1_tab4_424 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_424
+DROP VIEW IF EXISTS view_2_tab4_424 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_424
+DROP VIEW IF EXISTS view_3_tab4_424 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25864,13 +25864,13 @@ SELECT pk FROM tab0 WHERE col3 > 37 AND ((col3 BETWEEN 83 AND 89)) AND col0 > 23
 ----
 
 statement ok
-DROP VIEW view_1_tab0_425
+DROP VIEW IF EXISTS view_1_tab0_425 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_425
+DROP VIEW IF EXISTS view_2_tab0_425 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_425
+DROP VIEW IF EXISTS view_3_tab0_425 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25956,13 +25956,13 @@ SELECT pk FROM tab1 WHERE col3 > 37 AND ((col3 BETWEEN 83 AND 89)) AND col0 > 23
 ----
 
 statement ok
-DROP VIEW view_1_tab1_425
+DROP VIEW IF EXISTS view_1_tab1_425 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_425
+DROP VIEW IF EXISTS view_2_tab1_425 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_425
+DROP VIEW IF EXISTS view_3_tab1_425 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26048,13 +26048,13 @@ SELECT pk FROM tab2 WHERE col3 > 37 AND ((col3 BETWEEN 83 AND 89)) AND col0 > 23
 ----
 
 statement ok
-DROP VIEW view_1_tab2_425
+DROP VIEW IF EXISTS view_1_tab2_425 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_425
+DROP VIEW IF EXISTS view_2_tab2_425 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_425
+DROP VIEW IF EXISTS view_3_tab2_425 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26140,13 +26140,13 @@ SELECT pk FROM tab3 WHERE col3 > 37 AND ((col3 BETWEEN 83 AND 89)) AND col0 > 23
 ----
 
 statement ok
-DROP VIEW view_1_tab3_425
+DROP VIEW IF EXISTS view_1_tab3_425 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_425
+DROP VIEW IF EXISTS view_2_tab3_425 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_425
+DROP VIEW IF EXISTS view_3_tab3_425 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26232,13 +26232,13 @@ SELECT pk FROM tab4 WHERE col3 > 37 AND ((col3 BETWEEN 83 AND 89)) AND col0 > 23
 ----
 
 statement ok
-DROP VIEW view_1_tab4_425
+DROP VIEW IF EXISTS view_1_tab4_425 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_425
+DROP VIEW IF EXISTS view_2_tab4_425 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_425
+DROP VIEW IF EXISTS view_3_tab4_425 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26324,13 +26324,13 @@ SELECT pk FROM tab0 WHERE (col3 = 64)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_426
+DROP VIEW IF EXISTS view_1_tab0_426 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_426
+DROP VIEW IF EXISTS view_2_tab0_426 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_426
+DROP VIEW IF EXISTS view_3_tab0_426 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26416,13 +26416,13 @@ SELECT pk FROM tab1 WHERE (col3 = 64)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_426
+DROP VIEW IF EXISTS view_1_tab1_426 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_426
+DROP VIEW IF EXISTS view_2_tab1_426 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_426
+DROP VIEW IF EXISTS view_3_tab1_426 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26508,13 +26508,13 @@ SELECT pk FROM tab2 WHERE (col3 = 64)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_426
+DROP VIEW IF EXISTS view_1_tab2_426 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_426
+DROP VIEW IF EXISTS view_2_tab2_426 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_426
+DROP VIEW IF EXISTS view_3_tab2_426 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26600,13 +26600,13 @@ SELECT pk FROM tab3 WHERE (col3 = 64)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_426
+DROP VIEW IF EXISTS view_1_tab3_426 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_426
+DROP VIEW IF EXISTS view_2_tab3_426 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_426
+DROP VIEW IF EXISTS view_3_tab3_426 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26692,13 +26692,13 @@ SELECT pk FROM tab4 WHERE (col3 = 64)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_426
+DROP VIEW IF EXISTS view_1_tab4_426 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_426
+DROP VIEW IF EXISTS view_2_tab4_426 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_426
+DROP VIEW IF EXISTS view_3_tab4_426 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26817,13 +26817,13 @@ SELECT pk FROM tab0 WHERE ((col0 >= 15) AND (col3 = 64) AND col3 >= 78) OR (col3
 7
 
 statement ok
-DROP VIEW view_1_tab0_427
+DROP VIEW IF EXISTS view_1_tab0_427 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_427
+DROP VIEW IF EXISTS view_2_tab0_427 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_427
+DROP VIEW IF EXISTS view_3_tab0_427 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26942,13 +26942,13 @@ SELECT pk FROM tab1 WHERE ((col0 >= 15) AND (col3 = 64) AND col3 >= 78) OR (col3
 7
 
 statement ok
-DROP VIEW view_1_tab1_427
+DROP VIEW IF EXISTS view_1_tab1_427 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_427
+DROP VIEW IF EXISTS view_2_tab1_427 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_427
+DROP VIEW IF EXISTS view_3_tab1_427 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27067,13 +27067,13 @@ SELECT pk FROM tab2 WHERE ((col0 >= 15) AND (col3 = 64) AND col3 >= 78) OR (col3
 7
 
 statement ok
-DROP VIEW view_1_tab2_427
+DROP VIEW IF EXISTS view_1_tab2_427 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_427
+DROP VIEW IF EXISTS view_2_tab2_427 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_427
+DROP VIEW IF EXISTS view_3_tab2_427 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27192,13 +27192,13 @@ SELECT pk FROM tab3 WHERE ((col0 >= 15) AND (col3 = 64) AND col3 >= 78) OR (col3
 7
 
 statement ok
-DROP VIEW view_1_tab3_427
+DROP VIEW IF EXISTS view_1_tab3_427 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_427
+DROP VIEW IF EXISTS view_2_tab3_427 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_427
+DROP VIEW IF EXISTS view_3_tab3_427 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27317,13 +27317,13 @@ SELECT pk FROM tab4 WHERE ((col0 >= 15) AND (col3 = 64) AND col3 >= 78) OR (col3
 7
 
 statement ok
-DROP VIEW view_1_tab4_427
+DROP VIEW IF EXISTS view_1_tab4_427 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_427
+DROP VIEW IF EXISTS view_2_tab4_427 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_427
+DROP VIEW IF EXISTS view_3_tab4_427 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27423,13 +27423,13 @@ SELECT pk FROM tab0 WHERE col3 > 94 OR col1 IS NULL AND col0 >= 89 AND col1 < 1.
 9
 
 statement ok
-DROP VIEW view_1_tab0_428
+DROP VIEW IF EXISTS view_1_tab0_428 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_428
+DROP VIEW IF EXISTS view_2_tab0_428 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_428
+DROP VIEW IF EXISTS view_3_tab0_428 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27529,13 +27529,13 @@ SELECT pk FROM tab1 WHERE col3 > 94 OR col1 IS NULL AND col0 >= 89 AND col1 < 1.
 9
 
 statement ok
-DROP VIEW view_1_tab1_428
+DROP VIEW IF EXISTS view_1_tab1_428 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_428
+DROP VIEW IF EXISTS view_2_tab1_428 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_428
+DROP VIEW IF EXISTS view_3_tab1_428 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27635,13 +27635,13 @@ SELECT pk FROM tab2 WHERE col3 > 94 OR col1 IS NULL AND col0 >= 89 AND col1 < 1.
 9
 
 statement ok
-DROP VIEW view_1_tab2_428
+DROP VIEW IF EXISTS view_1_tab2_428 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_428
+DROP VIEW IF EXISTS view_2_tab2_428 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_428
+DROP VIEW IF EXISTS view_3_tab2_428 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27741,13 +27741,13 @@ SELECT pk FROM tab3 WHERE col3 > 94 OR col1 IS NULL AND col0 >= 89 AND col1 < 1.
 9
 
 statement ok
-DROP VIEW view_1_tab3_428
+DROP VIEW IF EXISTS view_1_tab3_428 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_428
+DROP VIEW IF EXISTS view_2_tab3_428 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_428
+DROP VIEW IF EXISTS view_3_tab3_428 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27847,13 +27847,13 @@ SELECT pk FROM tab4 WHERE col3 > 94 OR col1 IS NULL AND col0 >= 89 AND col1 < 1.
 9
 
 statement ok
-DROP VIEW view_1_tab4_428
+DROP VIEW IF EXISTS view_1_tab4_428 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_428
+DROP VIEW IF EXISTS view_2_tab4_428 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_428
+DROP VIEW IF EXISTS view_3_tab4_428 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27953,13 +27953,13 @@ SELECT pk FROM tab0 WHERE (col1 >= 43.61 AND col4 IN (42.11,97.9,46.38) OR col3 
 9
 
 statement ok
-DROP VIEW view_1_tab0_429
+DROP VIEW IF EXISTS view_1_tab0_429 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_429
+DROP VIEW IF EXISTS view_2_tab0_429 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_429
+DROP VIEW IF EXISTS view_3_tab0_429 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28059,13 +28059,13 @@ SELECT pk FROM tab1 WHERE (col1 >= 43.61 AND col4 IN (42.11,97.9,46.38) OR col3 
 9
 
 statement ok
-DROP VIEW view_1_tab1_429
+DROP VIEW IF EXISTS view_1_tab1_429 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_429
+DROP VIEW IF EXISTS view_2_tab1_429 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_429
+DROP VIEW IF EXISTS view_3_tab1_429 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28165,13 +28165,13 @@ SELECT pk FROM tab2 WHERE (col1 >= 43.61 AND col4 IN (42.11,97.9,46.38) OR col3 
 9
 
 statement ok
-DROP VIEW view_1_tab2_429
+DROP VIEW IF EXISTS view_1_tab2_429 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_429
+DROP VIEW IF EXISTS view_2_tab2_429 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_429
+DROP VIEW IF EXISTS view_3_tab2_429 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28271,13 +28271,13 @@ SELECT pk FROM tab3 WHERE (col1 >= 43.61 AND col4 IN (42.11,97.9,46.38) OR col3 
 9
 
 statement ok
-DROP VIEW view_1_tab3_429
+DROP VIEW IF EXISTS view_1_tab3_429 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_429
+DROP VIEW IF EXISTS view_2_tab3_429 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_429
+DROP VIEW IF EXISTS view_3_tab3_429 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28377,13 +28377,13 @@ SELECT pk FROM tab4 WHERE (col1 >= 43.61 AND col4 IN (42.11,97.9,46.38) OR col3 
 9
 
 statement ok
-DROP VIEW view_1_tab4_429
+DROP VIEW IF EXISTS view_1_tab4_429 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_429
+DROP VIEW IF EXISTS view_2_tab4_429 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_429
+DROP VIEW IF EXISTS view_3_tab4_429 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28469,13 +28469,13 @@ SELECT pk FROM tab0 WHERE col3 < 23 AND col3 > 15
 ----
 
 statement ok
-DROP VIEW view_1_tab0_430
+DROP VIEW IF EXISTS view_1_tab0_430 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_430
+DROP VIEW IF EXISTS view_2_tab0_430 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_430
+DROP VIEW IF EXISTS view_3_tab0_430 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28561,13 +28561,13 @@ SELECT pk FROM tab1 WHERE col3 < 23 AND col3 > 15
 ----
 
 statement ok
-DROP VIEW view_1_tab1_430
+DROP VIEW IF EXISTS view_1_tab1_430 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_430
+DROP VIEW IF EXISTS view_2_tab1_430 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_430
+DROP VIEW IF EXISTS view_3_tab1_430 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28653,13 +28653,13 @@ SELECT pk FROM tab2 WHERE col3 < 23 AND col3 > 15
 ----
 
 statement ok
-DROP VIEW view_1_tab2_430
+DROP VIEW IF EXISTS view_1_tab2_430 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_430
+DROP VIEW IF EXISTS view_2_tab2_430 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_430
+DROP VIEW IF EXISTS view_3_tab2_430 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28745,13 +28745,13 @@ SELECT pk FROM tab3 WHERE col3 < 23 AND col3 > 15
 ----
 
 statement ok
-DROP VIEW view_1_tab3_430
+DROP VIEW IF EXISTS view_1_tab3_430 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_430
+DROP VIEW IF EXISTS view_2_tab3_430 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_430
+DROP VIEW IF EXISTS view_3_tab3_430 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28837,13 +28837,13 @@ SELECT pk FROM tab4 WHERE col3 < 23 AND col3 > 15
 ----
 
 statement ok
-DROP VIEW view_1_tab4_430
+DROP VIEW IF EXISTS view_1_tab4_430 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_430
+DROP VIEW IF EXISTS view_2_tab4_430 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_430
+DROP VIEW IF EXISTS view_3_tab4_430 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28936,13 +28936,13 @@ SELECT pk FROM tab0 WHERE col3 < 39 OR col3 > 30 AND col3 > 7 AND col3 > 59 OR c
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab0_431
+DROP VIEW IF EXISTS view_1_tab0_431 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_431
+DROP VIEW IF EXISTS view_2_tab0_431 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_431
+DROP VIEW IF EXISTS view_3_tab0_431 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29035,13 +29035,13 @@ SELECT pk FROM tab1 WHERE col3 < 39 OR col3 > 30 AND col3 > 7 AND col3 > 59 OR c
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab1_431
+DROP VIEW IF EXISTS view_1_tab1_431 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_431
+DROP VIEW IF EXISTS view_2_tab1_431 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_431
+DROP VIEW IF EXISTS view_3_tab1_431 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29134,13 +29134,13 @@ SELECT pk FROM tab2 WHERE col3 < 39 OR col3 > 30 AND col3 > 7 AND col3 > 59 OR c
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab2_431
+DROP VIEW IF EXISTS view_1_tab2_431 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_431
+DROP VIEW IF EXISTS view_2_tab2_431 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_431
+DROP VIEW IF EXISTS view_3_tab2_431 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29233,13 +29233,13 @@ SELECT pk FROM tab3 WHERE col3 < 39 OR col3 > 30 AND col3 > 7 AND col3 > 59 OR c
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab3_431
+DROP VIEW IF EXISTS view_1_tab3_431 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_431
+DROP VIEW IF EXISTS view_2_tab3_431 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_431
+DROP VIEW IF EXISTS view_3_tab3_431 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29332,13 +29332,13 @@ SELECT pk FROM tab4 WHERE col3 < 39 OR col3 > 30 AND col3 > 7 AND col3 > 59 OR c
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab4_431
+DROP VIEW IF EXISTS view_1_tab4_431 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_431
+DROP VIEW IF EXISTS view_2_tab4_431 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_431
+DROP VIEW IF EXISTS view_3_tab4_431 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29431,13 +29431,13 @@ SELECT pk FROM tab0 WHERE (((col3 > 10) OR col3 = 35) AND ((col4 <= 2.42) OR col
 4
 
 statement ok
-DROP VIEW view_1_tab0_432
+DROP VIEW IF EXISTS view_1_tab0_432 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_432
+DROP VIEW IF EXISTS view_2_tab0_432 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_432
+DROP VIEW IF EXISTS view_3_tab0_432 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29530,13 +29530,13 @@ SELECT pk FROM tab1 WHERE (((col3 > 10) OR col3 = 35) AND ((col4 <= 2.42) OR col
 4
 
 statement ok
-DROP VIEW view_1_tab1_432
+DROP VIEW IF EXISTS view_1_tab1_432 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_432
+DROP VIEW IF EXISTS view_2_tab1_432 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_432
+DROP VIEW IF EXISTS view_3_tab1_432 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29629,13 +29629,13 @@ SELECT pk FROM tab2 WHERE (((col3 > 10) OR col3 = 35) AND ((col4 <= 2.42) OR col
 4
 
 statement ok
-DROP VIEW view_1_tab2_432
+DROP VIEW IF EXISTS view_1_tab2_432 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_432
+DROP VIEW IF EXISTS view_2_tab2_432 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_432
+DROP VIEW IF EXISTS view_3_tab2_432 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29728,13 +29728,13 @@ SELECT pk FROM tab3 WHERE (((col3 > 10) OR col3 = 35) AND ((col4 <= 2.42) OR col
 4
 
 statement ok
-DROP VIEW view_1_tab3_432
+DROP VIEW IF EXISTS view_1_tab3_432 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_432
+DROP VIEW IF EXISTS view_2_tab3_432 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_432
+DROP VIEW IF EXISTS view_3_tab3_432 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29827,13 +29827,13 @@ SELECT pk FROM tab4 WHERE (((col3 > 10) OR col3 = 35) AND ((col4 <= 2.42) OR col
 4
 
 statement ok
-DROP VIEW view_1_tab4_432
+DROP VIEW IF EXISTS view_1_tab4_432 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_432
+DROP VIEW IF EXISTS view_2_tab4_432 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_432
+DROP VIEW IF EXISTS view_3_tab4_432 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29936,13 +29936,13 @@ SELECT pk FROM tab0 WHERE col3 > 75 OR ((col1 >= 42.4 AND col3 < 58 AND col1 >= 
 9
 
 statement ok
-DROP VIEW view_1_tab0_433
+DROP VIEW IF EXISTS view_1_tab0_433 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_433
+DROP VIEW IF EXISTS view_2_tab0_433 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_433
+DROP VIEW IF EXISTS view_3_tab0_433 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30045,13 +30045,13 @@ SELECT pk FROM tab1 WHERE col3 > 75 OR ((col1 >= 42.4 AND col3 < 58 AND col1 >= 
 9
 
 statement ok
-DROP VIEW view_1_tab1_433
+DROP VIEW IF EXISTS view_1_tab1_433 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_433
+DROP VIEW IF EXISTS view_2_tab1_433 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_433
+DROP VIEW IF EXISTS view_3_tab1_433 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30154,13 +30154,13 @@ SELECT pk FROM tab2 WHERE col3 > 75 OR ((col1 >= 42.4 AND col3 < 58 AND col1 >= 
 9
 
 statement ok
-DROP VIEW view_1_tab2_433
+DROP VIEW IF EXISTS view_1_tab2_433 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_433
+DROP VIEW IF EXISTS view_2_tab2_433 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_433
+DROP VIEW IF EXISTS view_3_tab2_433 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30263,13 +30263,13 @@ SELECT pk FROM tab3 WHERE col3 > 75 OR ((col1 >= 42.4 AND col3 < 58 AND col1 >= 
 9
 
 statement ok
-DROP VIEW view_1_tab3_433
+DROP VIEW IF EXISTS view_1_tab3_433 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_433
+DROP VIEW IF EXISTS view_2_tab3_433 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_433
+DROP VIEW IF EXISTS view_3_tab3_433 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30372,13 +30372,13 @@ SELECT pk FROM tab4 WHERE col3 > 75 OR ((col1 >= 42.4 AND col3 < 58 AND col1 >= 
 9
 
 statement ok
-DROP VIEW view_1_tab4_433
+DROP VIEW IF EXISTS view_1_tab4_433 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_433
+DROP VIEW IF EXISTS view_2_tab4_433 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_433
+DROP VIEW IF EXISTS view_3_tab4_433 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30471,13 +30471,13 @@ SELECT pk FROM tab0 WHERE col0 < 16
 6
 
 statement ok
-DROP VIEW view_1_tab0_434
+DROP VIEW IF EXISTS view_1_tab0_434 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_434
+DROP VIEW IF EXISTS view_2_tab0_434 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_434
+DROP VIEW IF EXISTS view_3_tab0_434 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30570,13 +30570,13 @@ SELECT pk FROM tab1 WHERE col0 < 16
 6
 
 statement ok
-DROP VIEW view_1_tab1_434
+DROP VIEW IF EXISTS view_1_tab1_434 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_434
+DROP VIEW IF EXISTS view_2_tab1_434 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_434
+DROP VIEW IF EXISTS view_3_tab1_434 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30669,13 +30669,13 @@ SELECT pk FROM tab2 WHERE col0 < 16
 6
 
 statement ok
-DROP VIEW view_1_tab2_434
+DROP VIEW IF EXISTS view_1_tab2_434 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_434
+DROP VIEW IF EXISTS view_2_tab2_434 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_434
+DROP VIEW IF EXISTS view_3_tab2_434 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30768,13 +30768,13 @@ SELECT pk FROM tab3 WHERE col0 < 16
 6
 
 statement ok
-DROP VIEW view_1_tab3_434
+DROP VIEW IF EXISTS view_1_tab3_434 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_434
+DROP VIEW IF EXISTS view_2_tab3_434 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_434
+DROP VIEW IF EXISTS view_3_tab3_434 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30867,13 +30867,13 @@ SELECT pk FROM tab4 WHERE col0 < 16
 6
 
 statement ok
-DROP VIEW view_1_tab4_434
+DROP VIEW IF EXISTS view_1_tab4_434 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_434
+DROP VIEW IF EXISTS view_2_tab4_434 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_434
+DROP VIEW IF EXISTS view_3_tab4_434 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30959,13 +30959,13 @@ SELECT pk FROM tab0 WHERE col1 IN (69.5,58.51)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_435
+DROP VIEW IF EXISTS view_1_tab0_435 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_435
+DROP VIEW IF EXISTS view_2_tab0_435 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_435
+DROP VIEW IF EXISTS view_3_tab0_435 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31051,13 +31051,13 @@ SELECT pk FROM tab1 WHERE col1 IN (69.5,58.51)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_435
+DROP VIEW IF EXISTS view_1_tab1_435 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_435
+DROP VIEW IF EXISTS view_2_tab1_435 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_435
+DROP VIEW IF EXISTS view_3_tab1_435 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31143,13 +31143,13 @@ SELECT pk FROM tab2 WHERE col1 IN (69.5,58.51)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_435
+DROP VIEW IF EXISTS view_1_tab2_435 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_435
+DROP VIEW IF EXISTS view_2_tab2_435 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_435
+DROP VIEW IF EXISTS view_3_tab2_435 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31235,13 +31235,13 @@ SELECT pk FROM tab3 WHERE col1 IN (69.5,58.51)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_435
+DROP VIEW IF EXISTS view_1_tab3_435 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_435
+DROP VIEW IF EXISTS view_2_tab3_435 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_435
+DROP VIEW IF EXISTS view_3_tab3_435 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31327,13 +31327,13 @@ SELECT pk FROM tab4 WHERE col1 IN (69.5,58.51)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_435
+DROP VIEW IF EXISTS view_1_tab4_435 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_435
+DROP VIEW IF EXISTS view_2_tab4_435 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_435
+DROP VIEW IF EXISTS view_3_tab4_435 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31419,13 +31419,13 @@ SELECT pk FROM tab0 WHERE (((col4 < 72.6) AND (col3 > 20)) AND (col1 >= 91.89) A
 ----
 
 statement ok
-DROP VIEW view_1_tab0_436
+DROP VIEW IF EXISTS view_1_tab0_436 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_436
+DROP VIEW IF EXISTS view_2_tab0_436 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_436
+DROP VIEW IF EXISTS view_3_tab0_436 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31511,13 +31511,13 @@ SELECT pk FROM tab1 WHERE (((col4 < 72.6) AND (col3 > 20)) AND (col1 >= 91.89) A
 ----
 
 statement ok
-DROP VIEW view_1_tab1_436
+DROP VIEW IF EXISTS view_1_tab1_436 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_436
+DROP VIEW IF EXISTS view_2_tab1_436 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_436
+DROP VIEW IF EXISTS view_3_tab1_436 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31603,13 +31603,13 @@ SELECT pk FROM tab2 WHERE (((col4 < 72.6) AND (col3 > 20)) AND (col1 >= 91.89) A
 ----
 
 statement ok
-DROP VIEW view_1_tab2_436
+DROP VIEW IF EXISTS view_1_tab2_436 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_436
+DROP VIEW IF EXISTS view_2_tab2_436 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_436
+DROP VIEW IF EXISTS view_3_tab2_436 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31695,13 +31695,13 @@ SELECT pk FROM tab3 WHERE (((col4 < 72.6) AND (col3 > 20)) AND (col1 >= 91.89) A
 ----
 
 statement ok
-DROP VIEW view_1_tab3_436
+DROP VIEW IF EXISTS view_1_tab3_436 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_436
+DROP VIEW IF EXISTS view_2_tab3_436 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_436
+DROP VIEW IF EXISTS view_3_tab3_436 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31787,13 +31787,13 @@ SELECT pk FROM tab4 WHERE (((col4 < 72.6) AND (col3 > 20)) AND (col1 >= 91.89) A
 ----
 
 statement ok
-DROP VIEW view_1_tab4_436
+DROP VIEW IF EXISTS view_1_tab4_436 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_436
+DROP VIEW IF EXISTS view_2_tab4_436 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_436
+DROP VIEW IF EXISTS view_3_tab4_436 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31911,13 +31911,13 @@ SELECT pk FROM tab0 WHERE col3 > 24
 9
 
 statement ok
-DROP VIEW view_1_tab0_437
+DROP VIEW IF EXISTS view_1_tab0_437 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_437
+DROP VIEW IF EXISTS view_2_tab0_437 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_437
+DROP VIEW IF EXISTS view_3_tab0_437 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32035,13 +32035,13 @@ SELECT pk FROM tab1 WHERE col3 > 24
 9
 
 statement ok
-DROP VIEW view_1_tab1_437
+DROP VIEW IF EXISTS view_1_tab1_437 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_437
+DROP VIEW IF EXISTS view_2_tab1_437 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_437
+DROP VIEW IF EXISTS view_3_tab1_437 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32159,13 +32159,13 @@ SELECT pk FROM tab2 WHERE col3 > 24
 9
 
 statement ok
-DROP VIEW view_1_tab2_437
+DROP VIEW IF EXISTS view_1_tab2_437 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_437
+DROP VIEW IF EXISTS view_2_tab2_437 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_437
+DROP VIEW IF EXISTS view_3_tab2_437 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32283,13 +32283,13 @@ SELECT pk FROM tab3 WHERE col3 > 24
 9
 
 statement ok
-DROP VIEW view_1_tab3_437
+DROP VIEW IF EXISTS view_1_tab3_437 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_437
+DROP VIEW IF EXISTS view_2_tab3_437 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_437
+DROP VIEW IF EXISTS view_3_tab3_437 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32407,13 +32407,13 @@ SELECT pk FROM tab4 WHERE col3 > 24
 9
 
 statement ok
-DROP VIEW view_1_tab4_437
+DROP VIEW IF EXISTS view_1_tab4_437 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_437
+DROP VIEW IF EXISTS view_2_tab4_437 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_437
+DROP VIEW IF EXISTS view_3_tab4_437 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32499,13 +32499,13 @@ SELECT pk FROM tab0 WHERE col0 IN (12,26,79,10)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_438
+DROP VIEW IF EXISTS view_1_tab0_438 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_438
+DROP VIEW IF EXISTS view_2_tab0_438 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_438
+DROP VIEW IF EXISTS view_3_tab0_438 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32591,13 +32591,13 @@ SELECT pk FROM tab1 WHERE col0 IN (12,26,79,10)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_438
+DROP VIEW IF EXISTS view_1_tab1_438 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_438
+DROP VIEW IF EXISTS view_2_tab1_438 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_438
+DROP VIEW IF EXISTS view_3_tab1_438 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32683,13 +32683,13 @@ SELECT pk FROM tab2 WHERE col0 IN (12,26,79,10)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_438
+DROP VIEW IF EXISTS view_1_tab2_438 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_438
+DROP VIEW IF EXISTS view_2_tab2_438 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_438
+DROP VIEW IF EXISTS view_3_tab2_438 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32775,13 +32775,13 @@ SELECT pk FROM tab3 WHERE col0 IN (12,26,79,10)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_438
+DROP VIEW IF EXISTS view_1_tab3_438 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_438
+DROP VIEW IF EXISTS view_2_tab3_438 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_438
+DROP VIEW IF EXISTS view_3_tab3_438 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32867,13 +32867,13 @@ SELECT pk FROM tab4 WHERE col0 IN (12,26,79,10)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_438
+DROP VIEW IF EXISTS view_1_tab4_438 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_438
+DROP VIEW IF EXISTS view_2_tab4_438 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_438
+DROP VIEW IF EXISTS view_3_tab4_438 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32991,13 +32991,13 @@ SELECT pk FROM tab0 WHERE col3 < 91
 8
 
 statement ok
-DROP VIEW view_1_tab0_439
+DROP VIEW IF EXISTS view_1_tab0_439 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_439
+DROP VIEW IF EXISTS view_2_tab0_439 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_439
+DROP VIEW IF EXISTS view_3_tab0_439 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33115,13 +33115,13 @@ SELECT pk FROM tab1 WHERE col3 < 91
 8
 
 statement ok
-DROP VIEW view_1_tab1_439
+DROP VIEW IF EXISTS view_1_tab1_439 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_439
+DROP VIEW IF EXISTS view_2_tab1_439 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_439
+DROP VIEW IF EXISTS view_3_tab1_439 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33239,13 +33239,13 @@ SELECT pk FROM tab2 WHERE col3 < 91
 8
 
 statement ok
-DROP VIEW view_1_tab2_439
+DROP VIEW IF EXISTS view_1_tab2_439 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_439
+DROP VIEW IF EXISTS view_2_tab2_439 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_439
+DROP VIEW IF EXISTS view_3_tab2_439 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33363,13 +33363,13 @@ SELECT pk FROM tab3 WHERE col3 < 91
 8
 
 statement ok
-DROP VIEW view_1_tab3_439
+DROP VIEW IF EXISTS view_1_tab3_439 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_439
+DROP VIEW IF EXISTS view_2_tab3_439 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_439
+DROP VIEW IF EXISTS view_3_tab3_439 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33487,13 +33487,13 @@ SELECT pk FROM tab4 WHERE col3 < 91
 8
 
 statement ok
-DROP VIEW view_1_tab4_439
+DROP VIEW IF EXISTS view_1_tab4_439 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_439
+DROP VIEW IF EXISTS view_2_tab4_439 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_439
+DROP VIEW IF EXISTS view_3_tab4_439 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33579,13 +33579,13 @@ SELECT pk FROM tab0 WHERE ((col0 IS NULL) OR (col1 >= 98.92))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_440
+DROP VIEW IF EXISTS view_1_tab0_440 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_440
+DROP VIEW IF EXISTS view_2_tab0_440 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_440
+DROP VIEW IF EXISTS view_3_tab0_440 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33671,13 +33671,13 @@ SELECT pk FROM tab1 WHERE ((col0 IS NULL) OR (col1 >= 98.92))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_440
+DROP VIEW IF EXISTS view_1_tab1_440 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_440
+DROP VIEW IF EXISTS view_2_tab1_440 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_440
+DROP VIEW IF EXISTS view_3_tab1_440 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33763,13 +33763,13 @@ SELECT pk FROM tab2 WHERE ((col0 IS NULL) OR (col1 >= 98.92))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_440
+DROP VIEW IF EXISTS view_1_tab2_440 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_440
+DROP VIEW IF EXISTS view_2_tab2_440 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_440
+DROP VIEW IF EXISTS view_3_tab2_440 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33855,13 +33855,13 @@ SELECT pk FROM tab3 WHERE ((col0 IS NULL) OR (col1 >= 98.92))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_440
+DROP VIEW IF EXISTS view_1_tab3_440 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_440
+DROP VIEW IF EXISTS view_2_tab3_440 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_440
+DROP VIEW IF EXISTS view_3_tab3_440 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33947,13 +33947,13 @@ SELECT pk FROM tab4 WHERE ((col0 IS NULL) OR (col1 >= 98.92))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_440
+DROP VIEW IF EXISTS view_1_tab4_440 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_440
+DROP VIEW IF EXISTS view_2_tab4_440 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_440
+DROP VIEW IF EXISTS view_3_tab4_440 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34053,13 +34053,13 @@ SELECT pk FROM tab0 WHERE col3 < 33 AND col3 < 29
 7
 
 statement ok
-DROP VIEW view_1_tab0_441
+DROP VIEW IF EXISTS view_1_tab0_441 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_441
+DROP VIEW IF EXISTS view_2_tab0_441 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_441
+DROP VIEW IF EXISTS view_3_tab0_441 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34159,13 +34159,13 @@ SELECT pk FROM tab1 WHERE col3 < 33 AND col3 < 29
 7
 
 statement ok
-DROP VIEW view_1_tab1_441
+DROP VIEW IF EXISTS view_1_tab1_441 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_441
+DROP VIEW IF EXISTS view_2_tab1_441 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_441
+DROP VIEW IF EXISTS view_3_tab1_441 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34265,13 +34265,13 @@ SELECT pk FROM tab2 WHERE col3 < 33 AND col3 < 29
 7
 
 statement ok
-DROP VIEW view_1_tab2_441
+DROP VIEW IF EXISTS view_1_tab2_441 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_441
+DROP VIEW IF EXISTS view_2_tab2_441 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_441
+DROP VIEW IF EXISTS view_3_tab2_441 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34371,13 +34371,13 @@ SELECT pk FROM tab3 WHERE col3 < 33 AND col3 < 29
 7
 
 statement ok
-DROP VIEW view_1_tab3_441
+DROP VIEW IF EXISTS view_1_tab3_441 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_441
+DROP VIEW IF EXISTS view_2_tab3_441 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_441
+DROP VIEW IF EXISTS view_3_tab3_441 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34477,13 +34477,13 @@ SELECT pk FROM tab4 WHERE col3 < 33 AND col3 < 29
 7
 
 statement ok
-DROP VIEW view_1_tab4_441
+DROP VIEW IF EXISTS view_1_tab4_441 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_441
+DROP VIEW IF EXISTS view_2_tab4_441 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_441
+DROP VIEW IF EXISTS view_3_tab4_441 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34602,13 +34602,13 @@ SELECT pk FROM tab0 WHERE (col3 >= 40)
 9
 
 statement ok
-DROP VIEW view_1_tab0_442
+DROP VIEW IF EXISTS view_1_tab0_442 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_442
+DROP VIEW IF EXISTS view_2_tab0_442 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_442
+DROP VIEW IF EXISTS view_3_tab0_442 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34727,13 +34727,13 @@ SELECT pk FROM tab1 WHERE (col3 >= 40)
 9
 
 statement ok
-DROP VIEW view_1_tab1_442
+DROP VIEW IF EXISTS view_1_tab1_442 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_442
+DROP VIEW IF EXISTS view_2_tab1_442 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_442
+DROP VIEW IF EXISTS view_3_tab1_442 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34852,13 +34852,13 @@ SELECT pk FROM tab2 WHERE (col3 >= 40)
 9
 
 statement ok
-DROP VIEW view_1_tab2_442
+DROP VIEW IF EXISTS view_1_tab2_442 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_442
+DROP VIEW IF EXISTS view_2_tab2_442 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_442
+DROP VIEW IF EXISTS view_3_tab2_442 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34977,13 +34977,13 @@ SELECT pk FROM tab3 WHERE (col3 >= 40)
 9
 
 statement ok
-DROP VIEW view_1_tab3_442
+DROP VIEW IF EXISTS view_1_tab3_442 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_442
+DROP VIEW IF EXISTS view_2_tab3_442 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_442
+DROP VIEW IF EXISTS view_3_tab3_442 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35102,13 +35102,13 @@ SELECT pk FROM tab4 WHERE (col3 >= 40)
 9
 
 statement ok
-DROP VIEW view_1_tab4_442
+DROP VIEW IF EXISTS view_1_tab4_442 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_442
+DROP VIEW IF EXISTS view_2_tab4_442 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_442
+DROP VIEW IF EXISTS view_3_tab4_442 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35194,13 +35194,13 @@ SELECT pk FROM tab0 WHERE (((col4 > 98.77) OR ((col0 BETWEEN 62 AND 37 AND col3 
 ----
 
 statement ok
-DROP VIEW view_1_tab0_443
+DROP VIEW IF EXISTS view_1_tab0_443 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_443
+DROP VIEW IF EXISTS view_2_tab0_443 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_443
+DROP VIEW IF EXISTS view_3_tab0_443 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35286,13 +35286,13 @@ SELECT pk FROM tab1 WHERE (((col4 > 98.77) OR ((col0 BETWEEN 62 AND 37 AND col3 
 ----
 
 statement ok
-DROP VIEW view_1_tab1_443
+DROP VIEW IF EXISTS view_1_tab1_443 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_443
+DROP VIEW IF EXISTS view_2_tab1_443 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_443
+DROP VIEW IF EXISTS view_3_tab1_443 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35378,13 +35378,13 @@ SELECT pk FROM tab2 WHERE (((col4 > 98.77) OR ((col0 BETWEEN 62 AND 37 AND col3 
 ----
 
 statement ok
-DROP VIEW view_1_tab2_443
+DROP VIEW IF EXISTS view_1_tab2_443 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_443
+DROP VIEW IF EXISTS view_2_tab2_443 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_443
+DROP VIEW IF EXISTS view_3_tab2_443 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35470,13 +35470,13 @@ SELECT pk FROM tab3 WHERE (((col4 > 98.77) OR ((col0 BETWEEN 62 AND 37 AND col3 
 ----
 
 statement ok
-DROP VIEW view_1_tab3_443
+DROP VIEW IF EXISTS view_1_tab3_443 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_443
+DROP VIEW IF EXISTS view_2_tab3_443 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_443
+DROP VIEW IF EXISTS view_3_tab3_443 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35562,11 +35562,11 @@ SELECT pk FROM tab4 WHERE (((col4 > 98.77) OR ((col0 BETWEEN 62 AND 37 AND col3 
 ----
 
 statement ok
-DROP VIEW view_1_tab4_443
+DROP VIEW IF EXISTS view_1_tab4_443 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_443
+DROP VIEW IF EXISTS view_2_tab4_443 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_443
+DROP VIEW IF EXISTS view_3_tab4_443 CASCADE
 

--- a/test/index/view/10/slt_good_4.test
+++ b/test/index/view/10/slt_good_4.test
@@ -227,13 +227,13 @@ SELECT pk FROM tab0 WHERE (col1 < 55.67)
 9
 
 statement ok
-DROP VIEW view_1_tab0_444
+DROP VIEW IF EXISTS view_1_tab0_444 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_444
+DROP VIEW IF EXISTS view_2_tab0_444 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_444
+DROP VIEW IF EXISTS view_3_tab0_444 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -351,13 +351,13 @@ SELECT pk FROM tab1 WHERE (col1 < 55.67)
 9
 
 statement ok
-DROP VIEW view_1_tab1_444
+DROP VIEW IF EXISTS view_1_tab1_444 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_444
+DROP VIEW IF EXISTS view_2_tab1_444 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_444
+DROP VIEW IF EXISTS view_3_tab1_444 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -475,13 +475,13 @@ SELECT pk FROM tab2 WHERE (col1 < 55.67)
 9
 
 statement ok
-DROP VIEW view_1_tab2_444
+DROP VIEW IF EXISTS view_1_tab2_444 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_444
+DROP VIEW IF EXISTS view_2_tab2_444 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_444
+DROP VIEW IF EXISTS view_3_tab2_444 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -599,13 +599,13 @@ SELECT pk FROM tab3 WHERE (col1 < 55.67)
 9
 
 statement ok
-DROP VIEW view_1_tab3_444
+DROP VIEW IF EXISTS view_1_tab3_444 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_444
+DROP VIEW IF EXISTS view_2_tab3_444 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_444
+DROP VIEW IF EXISTS view_3_tab3_444 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -723,13 +723,13 @@ SELECT pk FROM tab4 WHERE (col1 < 55.67)
 9
 
 statement ok
-DROP VIEW view_1_tab4_444
+DROP VIEW IF EXISTS view_1_tab4_444 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_444
+DROP VIEW IF EXISTS view_2_tab4_444 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_444
+DROP VIEW IF EXISTS view_3_tab4_444 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -815,13 +815,13 @@ SELECT pk FROM tab0 WHERE col0 = 94
 ----
 
 statement ok
-DROP VIEW view_1_tab0_445
+DROP VIEW IF EXISTS view_1_tab0_445 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_445
+DROP VIEW IF EXISTS view_2_tab0_445 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_445
+DROP VIEW IF EXISTS view_3_tab0_445 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -907,13 +907,13 @@ SELECT pk FROM tab1 WHERE col0 = 94
 ----
 
 statement ok
-DROP VIEW view_1_tab1_445
+DROP VIEW IF EXISTS view_1_tab1_445 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_445
+DROP VIEW IF EXISTS view_2_tab1_445 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_445
+DROP VIEW IF EXISTS view_3_tab1_445 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -999,13 +999,13 @@ SELECT pk FROM tab2 WHERE col0 = 94
 ----
 
 statement ok
-DROP VIEW view_1_tab2_445
+DROP VIEW IF EXISTS view_1_tab2_445 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_445
+DROP VIEW IF EXISTS view_2_tab2_445 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_445
+DROP VIEW IF EXISTS view_3_tab2_445 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1091,13 +1091,13 @@ SELECT pk FROM tab3 WHERE col0 = 94
 ----
 
 statement ok
-DROP VIEW view_1_tab3_445
+DROP VIEW IF EXISTS view_1_tab3_445 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_445
+DROP VIEW IF EXISTS view_2_tab3_445 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_445
+DROP VIEW IF EXISTS view_3_tab3_445 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1183,13 +1183,13 @@ SELECT pk FROM tab4 WHERE col0 = 94
 ----
 
 statement ok
-DROP VIEW view_1_tab4_445
+DROP VIEW IF EXISTS view_1_tab4_445 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_445
+DROP VIEW IF EXISTS view_2_tab4_445 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_445
+DROP VIEW IF EXISTS view_3_tab4_445 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1282,13 +1282,13 @@ SELECT pk FROM tab0 WHERE (col3 >= 85) AND (col1 < 55.36) OR (col1 IN (91.93,48.
 9 values hashing to a09f741e1007d9cc99c658732e945c31
 
 statement ok
-DROP VIEW view_1_tab0_446
+DROP VIEW IF EXISTS view_1_tab0_446 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_446
+DROP VIEW IF EXISTS view_2_tab0_446 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_446
+DROP VIEW IF EXISTS view_3_tab0_446 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1381,13 +1381,13 @@ SELECT pk FROM tab1 WHERE (col3 >= 85) AND (col1 < 55.36) OR (col1 IN (91.93,48.
 9 values hashing to a09f741e1007d9cc99c658732e945c31
 
 statement ok
-DROP VIEW view_1_tab1_446
+DROP VIEW IF EXISTS view_1_tab1_446 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_446
+DROP VIEW IF EXISTS view_2_tab1_446 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_446
+DROP VIEW IF EXISTS view_3_tab1_446 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1480,13 +1480,13 @@ SELECT pk FROM tab2 WHERE (col3 >= 85) AND (col1 < 55.36) OR (col1 IN (91.93,48.
 9 values hashing to a09f741e1007d9cc99c658732e945c31
 
 statement ok
-DROP VIEW view_1_tab2_446
+DROP VIEW IF EXISTS view_1_tab2_446 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_446
+DROP VIEW IF EXISTS view_2_tab2_446 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_446
+DROP VIEW IF EXISTS view_3_tab2_446 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1579,13 +1579,13 @@ SELECT pk FROM tab3 WHERE (col3 >= 85) AND (col1 < 55.36) OR (col1 IN (91.93,48.
 9 values hashing to a09f741e1007d9cc99c658732e945c31
 
 statement ok
-DROP VIEW view_1_tab3_446
+DROP VIEW IF EXISTS view_1_tab3_446 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_446
+DROP VIEW IF EXISTS view_2_tab3_446 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_446
+DROP VIEW IF EXISTS view_3_tab3_446 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1678,13 +1678,13 @@ SELECT pk FROM tab4 WHERE (col3 >= 85) AND (col1 < 55.36) OR (col1 IN (91.93,48.
 9 values hashing to a09f741e1007d9cc99c658732e945c31
 
 statement ok
-DROP VIEW view_1_tab4_446
+DROP VIEW IF EXISTS view_1_tab4_446 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_446
+DROP VIEW IF EXISTS view_2_tab4_446 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_446
+DROP VIEW IF EXISTS view_3_tab4_446 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1777,13 +1777,13 @@ SELECT pk FROM tab0 WHERE ((col1 <= 24.59 AND col3 > 61))
 3
 
 statement ok
-DROP VIEW view_1_tab0_447
+DROP VIEW IF EXISTS view_1_tab0_447 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_447
+DROP VIEW IF EXISTS view_2_tab0_447 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_447
+DROP VIEW IF EXISTS view_3_tab0_447 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1876,13 +1876,13 @@ SELECT pk FROM tab1 WHERE ((col1 <= 24.59 AND col3 > 61))
 3
 
 statement ok
-DROP VIEW view_1_tab1_447
+DROP VIEW IF EXISTS view_1_tab1_447 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_447
+DROP VIEW IF EXISTS view_2_tab1_447 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_447
+DROP VIEW IF EXISTS view_3_tab1_447 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1975,13 +1975,13 @@ SELECT pk FROM tab2 WHERE ((col1 <= 24.59 AND col3 > 61))
 3
 
 statement ok
-DROP VIEW view_1_tab2_447
+DROP VIEW IF EXISTS view_1_tab2_447 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_447
+DROP VIEW IF EXISTS view_2_tab2_447 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_447
+DROP VIEW IF EXISTS view_3_tab2_447 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2074,13 +2074,13 @@ SELECT pk FROM tab3 WHERE ((col1 <= 24.59 AND col3 > 61))
 3
 
 statement ok
-DROP VIEW view_1_tab3_447
+DROP VIEW IF EXISTS view_1_tab3_447 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_447
+DROP VIEW IF EXISTS view_2_tab3_447 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_447
+DROP VIEW IF EXISTS view_3_tab3_447 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2173,13 +2173,13 @@ SELECT pk FROM tab4 WHERE ((col1 <= 24.59 AND col3 > 61))
 3
 
 statement ok
-DROP VIEW view_1_tab4_447
+DROP VIEW IF EXISTS view_1_tab4_447 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_447
+DROP VIEW IF EXISTS view_2_tab4_447 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_447
+DROP VIEW IF EXISTS view_3_tab4_447 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2282,13 +2282,13 @@ SELECT pk FROM tab0 WHERE ((col1 <= 25.93))
 9
 
 statement ok
-DROP VIEW view_1_tab0_448
+DROP VIEW IF EXISTS view_1_tab0_448 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_448
+DROP VIEW IF EXISTS view_2_tab0_448 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_448
+DROP VIEW IF EXISTS view_3_tab0_448 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2391,13 +2391,13 @@ SELECT pk FROM tab1 WHERE ((col1 <= 25.93))
 9
 
 statement ok
-DROP VIEW view_1_tab1_448
+DROP VIEW IF EXISTS view_1_tab1_448 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_448
+DROP VIEW IF EXISTS view_2_tab1_448 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_448
+DROP VIEW IF EXISTS view_3_tab1_448 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2500,13 +2500,13 @@ SELECT pk FROM tab2 WHERE ((col1 <= 25.93))
 9
 
 statement ok
-DROP VIEW view_1_tab2_448
+DROP VIEW IF EXISTS view_1_tab2_448 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_448
+DROP VIEW IF EXISTS view_2_tab2_448 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_448
+DROP VIEW IF EXISTS view_3_tab2_448 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2609,13 +2609,13 @@ SELECT pk FROM tab3 WHERE ((col1 <= 25.93))
 9
 
 statement ok
-DROP VIEW view_1_tab3_448
+DROP VIEW IF EXISTS view_1_tab3_448 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_448
+DROP VIEW IF EXISTS view_2_tab3_448 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_448
+DROP VIEW IF EXISTS view_3_tab3_448 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2718,13 +2718,13 @@ SELECT pk FROM tab4 WHERE ((col1 <= 25.93))
 9
 
 statement ok
-DROP VIEW view_1_tab4_448
+DROP VIEW IF EXISTS view_1_tab4_448 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_448
+DROP VIEW IF EXISTS view_2_tab4_448 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_448
+DROP VIEW IF EXISTS view_3_tab4_448 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2842,13 +2842,13 @@ SELECT pk FROM tab0 WHERE col1 >= 27.83 OR col0 IS NULL OR ((col3 >= 37)) AND ((
 9
 
 statement ok
-DROP VIEW view_1_tab0_449
+DROP VIEW IF EXISTS view_1_tab0_449 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_449
+DROP VIEW IF EXISTS view_2_tab0_449 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_449
+DROP VIEW IF EXISTS view_3_tab0_449 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2966,13 +2966,13 @@ SELECT pk FROM tab1 WHERE col1 >= 27.83 OR col0 IS NULL OR ((col3 >= 37)) AND ((
 9
 
 statement ok
-DROP VIEW view_1_tab1_449
+DROP VIEW IF EXISTS view_1_tab1_449 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_449
+DROP VIEW IF EXISTS view_2_tab1_449 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_449
+DROP VIEW IF EXISTS view_3_tab1_449 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3090,13 +3090,13 @@ SELECT pk FROM tab2 WHERE col1 >= 27.83 OR col0 IS NULL OR ((col3 >= 37)) AND ((
 9
 
 statement ok
-DROP VIEW view_1_tab2_449
+DROP VIEW IF EXISTS view_1_tab2_449 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_449
+DROP VIEW IF EXISTS view_2_tab2_449 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_449
+DROP VIEW IF EXISTS view_3_tab2_449 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3214,13 +3214,13 @@ SELECT pk FROM tab3 WHERE col1 >= 27.83 OR col0 IS NULL OR ((col3 >= 37)) AND ((
 9
 
 statement ok
-DROP VIEW view_1_tab3_449
+DROP VIEW IF EXISTS view_1_tab3_449 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_449
+DROP VIEW IF EXISTS view_2_tab3_449 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_449
+DROP VIEW IF EXISTS view_3_tab3_449 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3338,13 +3338,13 @@ SELECT pk FROM tab4 WHERE col1 >= 27.83 OR col0 IS NULL OR ((col3 >= 37)) AND ((
 9
 
 statement ok
-DROP VIEW view_1_tab4_449
+DROP VIEW IF EXISTS view_1_tab4_449 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_449
+DROP VIEW IF EXISTS view_2_tab4_449 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_449
+DROP VIEW IF EXISTS view_3_tab4_449 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3430,13 +3430,13 @@ SELECT pk FROM tab0 WHERE (col0 >= 25 AND col0 > 73 AND col3 = 70 AND col0 = 84 
 ----
 
 statement ok
-DROP VIEW view_1_tab0_450
+DROP VIEW IF EXISTS view_1_tab0_450 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_450
+DROP VIEW IF EXISTS view_2_tab0_450 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_450
+DROP VIEW IF EXISTS view_3_tab0_450 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3522,13 +3522,13 @@ SELECT pk FROM tab1 WHERE (col0 >= 25 AND col0 > 73 AND col3 = 70 AND col0 = 84 
 ----
 
 statement ok
-DROP VIEW view_1_tab1_450
+DROP VIEW IF EXISTS view_1_tab1_450 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_450
+DROP VIEW IF EXISTS view_2_tab1_450 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_450
+DROP VIEW IF EXISTS view_3_tab1_450 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3614,13 +3614,13 @@ SELECT pk FROM tab2 WHERE (col0 >= 25 AND col0 > 73 AND col3 = 70 AND col0 = 84 
 ----
 
 statement ok
-DROP VIEW view_1_tab2_450
+DROP VIEW IF EXISTS view_1_tab2_450 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_450
+DROP VIEW IF EXISTS view_2_tab2_450 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_450
+DROP VIEW IF EXISTS view_3_tab2_450 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3706,13 +3706,13 @@ SELECT pk FROM tab3 WHERE (col0 >= 25 AND col0 > 73 AND col3 = 70 AND col0 = 84 
 ----
 
 statement ok
-DROP VIEW view_1_tab3_450
+DROP VIEW IF EXISTS view_1_tab3_450 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_450
+DROP VIEW IF EXISTS view_2_tab3_450 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_450
+DROP VIEW IF EXISTS view_3_tab3_450 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3798,13 +3798,13 @@ SELECT pk FROM tab4 WHERE (col0 >= 25 AND col0 > 73 AND col3 = 70 AND col0 = 84 
 ----
 
 statement ok
-DROP VIEW view_1_tab4_450
+DROP VIEW IF EXISTS view_1_tab4_450 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_450
+DROP VIEW IF EXISTS view_2_tab4_450 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_450
+DROP VIEW IF EXISTS view_3_tab4_450 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3890,13 +3890,13 @@ SELECT pk FROM tab0 WHERE ((col1 < 89.94 AND col0 > 82 AND ((col0 BETWEEN 42 AND
 ----
 
 statement ok
-DROP VIEW view_1_tab0_451
+DROP VIEW IF EXISTS view_1_tab0_451 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_451
+DROP VIEW IF EXISTS view_2_tab0_451 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_451
+DROP VIEW IF EXISTS view_3_tab0_451 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3982,13 +3982,13 @@ SELECT pk FROM tab1 WHERE ((col1 < 89.94 AND col0 > 82 AND ((col0 BETWEEN 42 AND
 ----
 
 statement ok
-DROP VIEW view_1_tab1_451
+DROP VIEW IF EXISTS view_1_tab1_451 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_451
+DROP VIEW IF EXISTS view_2_tab1_451 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_451
+DROP VIEW IF EXISTS view_3_tab1_451 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4074,13 +4074,13 @@ SELECT pk FROM tab2 WHERE ((col1 < 89.94 AND col0 > 82 AND ((col0 BETWEEN 42 AND
 ----
 
 statement ok
-DROP VIEW view_1_tab2_451
+DROP VIEW IF EXISTS view_1_tab2_451 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_451
+DROP VIEW IF EXISTS view_2_tab2_451 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_451
+DROP VIEW IF EXISTS view_3_tab2_451 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4166,13 +4166,13 @@ SELECT pk FROM tab3 WHERE ((col1 < 89.94 AND col0 > 82 AND ((col0 BETWEEN 42 AND
 ----
 
 statement ok
-DROP VIEW view_1_tab3_451
+DROP VIEW IF EXISTS view_1_tab3_451 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_451
+DROP VIEW IF EXISTS view_2_tab3_451 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_451
+DROP VIEW IF EXISTS view_3_tab3_451 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4258,13 +4258,13 @@ SELECT pk FROM tab4 WHERE ((col1 < 89.94 AND col0 > 82 AND ((col0 BETWEEN 42 AND
 ----
 
 statement ok
-DROP VIEW view_1_tab4_451
+DROP VIEW IF EXISTS view_1_tab4_451 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_451
+DROP VIEW IF EXISTS view_2_tab4_451 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_451
+DROP VIEW IF EXISTS view_3_tab4_451 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4350,13 +4350,13 @@ SELECT pk FROM tab0 WHERE (col0 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_452
+DROP VIEW IF EXISTS view_1_tab0_452 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_452
+DROP VIEW IF EXISTS view_2_tab0_452 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_452
+DROP VIEW IF EXISTS view_3_tab0_452 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4442,13 +4442,13 @@ SELECT pk FROM tab1 WHERE (col0 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_452
+DROP VIEW IF EXISTS view_1_tab1_452 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_452
+DROP VIEW IF EXISTS view_2_tab1_452 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_452
+DROP VIEW IF EXISTS view_3_tab1_452 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4534,13 +4534,13 @@ SELECT pk FROM tab2 WHERE (col0 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_452
+DROP VIEW IF EXISTS view_1_tab2_452 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_452
+DROP VIEW IF EXISTS view_2_tab2_452 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_452
+DROP VIEW IF EXISTS view_3_tab2_452 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4626,13 +4626,13 @@ SELECT pk FROM tab3 WHERE (col0 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_452
+DROP VIEW IF EXISTS view_1_tab3_452 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_452
+DROP VIEW IF EXISTS view_2_tab3_452 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_452
+DROP VIEW IF EXISTS view_3_tab3_452 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4718,13 +4718,13 @@ SELECT pk FROM tab4 WHERE (col0 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_452
+DROP VIEW IF EXISTS view_1_tab4_452 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_452
+DROP VIEW IF EXISTS view_2_tab4_452 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_452
+DROP VIEW IF EXISTS view_3_tab4_452 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4817,13 +4817,13 @@ SELECT pk FROM tab0 WHERE (col0 < 84 OR col0 > 55) AND col0 > 53 AND col0 < 76 O
 9 values hashing to 771a06029c003358acd302c0ec942a73
 
 statement ok
-DROP VIEW view_1_tab0_453
+DROP VIEW IF EXISTS view_1_tab0_453 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_453
+DROP VIEW IF EXISTS view_2_tab0_453 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_453
+DROP VIEW IF EXISTS view_3_tab0_453 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4916,13 +4916,13 @@ SELECT pk FROM tab1 WHERE (col0 < 84 OR col0 > 55) AND col0 > 53 AND col0 < 76 O
 9 values hashing to 771a06029c003358acd302c0ec942a73
 
 statement ok
-DROP VIEW view_1_tab1_453
+DROP VIEW IF EXISTS view_1_tab1_453 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_453
+DROP VIEW IF EXISTS view_2_tab1_453 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_453
+DROP VIEW IF EXISTS view_3_tab1_453 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5015,13 +5015,13 @@ SELECT pk FROM tab2 WHERE (col0 < 84 OR col0 > 55) AND col0 > 53 AND col0 < 76 O
 9 values hashing to 771a06029c003358acd302c0ec942a73
 
 statement ok
-DROP VIEW view_1_tab2_453
+DROP VIEW IF EXISTS view_1_tab2_453 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_453
+DROP VIEW IF EXISTS view_2_tab2_453 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_453
+DROP VIEW IF EXISTS view_3_tab2_453 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5114,13 +5114,13 @@ SELECT pk FROM tab3 WHERE (col0 < 84 OR col0 > 55) AND col0 > 53 AND col0 < 76 O
 9 values hashing to 771a06029c003358acd302c0ec942a73
 
 statement ok
-DROP VIEW view_1_tab3_453
+DROP VIEW IF EXISTS view_1_tab3_453 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_453
+DROP VIEW IF EXISTS view_2_tab3_453 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_453
+DROP VIEW IF EXISTS view_3_tab3_453 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5213,13 +5213,13 @@ SELECT pk FROM tab4 WHERE (col0 < 84 OR col0 > 55) AND col0 > 53 AND col0 < 76 O
 9 values hashing to 771a06029c003358acd302c0ec942a73
 
 statement ok
-DROP VIEW view_1_tab4_453
+DROP VIEW IF EXISTS view_1_tab4_453 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_453
+DROP VIEW IF EXISTS view_2_tab4_453 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_453
+DROP VIEW IF EXISTS view_3_tab4_453 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5305,13 +5305,13 @@ SELECT pk FROM tab0 WHERE (col0 >= 43 AND (col0 <= 19))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_454
+DROP VIEW IF EXISTS view_1_tab0_454 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_454
+DROP VIEW IF EXISTS view_2_tab0_454 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_454
+DROP VIEW IF EXISTS view_3_tab0_454 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5397,13 +5397,13 @@ SELECT pk FROM tab1 WHERE (col0 >= 43 AND (col0 <= 19))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_454
+DROP VIEW IF EXISTS view_1_tab1_454 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_454
+DROP VIEW IF EXISTS view_2_tab1_454 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_454
+DROP VIEW IF EXISTS view_3_tab1_454 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5489,13 +5489,13 @@ SELECT pk FROM tab2 WHERE (col0 >= 43 AND (col0 <= 19))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_454
+DROP VIEW IF EXISTS view_1_tab2_454 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_454
+DROP VIEW IF EXISTS view_2_tab2_454 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_454
+DROP VIEW IF EXISTS view_3_tab2_454 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5581,13 +5581,13 @@ SELECT pk FROM tab3 WHERE (col0 >= 43 AND (col0 <= 19))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_454
+DROP VIEW IF EXISTS view_1_tab3_454 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_454
+DROP VIEW IF EXISTS view_2_tab3_454 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_454
+DROP VIEW IF EXISTS view_3_tab3_454 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5673,13 +5673,13 @@ SELECT pk FROM tab4 WHERE (col0 >= 43 AND (col0 <= 19))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_454
+DROP VIEW IF EXISTS view_1_tab4_454 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_454
+DROP VIEW IF EXISTS view_2_tab4_454 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_454
+DROP VIEW IF EXISTS view_3_tab4_454 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5765,13 +5765,13 @@ SELECT pk FROM tab0 WHERE (col4 = 28.57)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_455
+DROP VIEW IF EXISTS view_1_tab0_455 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_455
+DROP VIEW IF EXISTS view_2_tab0_455 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_455
+DROP VIEW IF EXISTS view_3_tab0_455 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5857,13 +5857,13 @@ SELECT pk FROM tab1 WHERE (col4 = 28.57)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_455
+DROP VIEW IF EXISTS view_1_tab1_455 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_455
+DROP VIEW IF EXISTS view_2_tab1_455 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_455
+DROP VIEW IF EXISTS view_3_tab1_455 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5949,13 +5949,13 @@ SELECT pk FROM tab2 WHERE (col4 = 28.57)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_455
+DROP VIEW IF EXISTS view_1_tab2_455 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_455
+DROP VIEW IF EXISTS view_2_tab2_455 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_455
+DROP VIEW IF EXISTS view_3_tab2_455 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6041,13 +6041,13 @@ SELECT pk FROM tab3 WHERE (col4 = 28.57)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_455
+DROP VIEW IF EXISTS view_1_tab3_455 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_455
+DROP VIEW IF EXISTS view_2_tab3_455 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_455
+DROP VIEW IF EXISTS view_3_tab3_455 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6133,13 +6133,13 @@ SELECT pk FROM tab4 WHERE (col4 = 28.57)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_455
+DROP VIEW IF EXISTS view_1_tab4_455 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_455
+DROP VIEW IF EXISTS view_2_tab4_455 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_455
+DROP VIEW IF EXISTS view_3_tab4_455 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6228,13 +6228,13 @@ SELECT pk FROM tab0 WHERE (col3 > 64) AND col0 = 64 OR (col0 > 1)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_456
+DROP VIEW IF EXISTS view_1_tab0_456 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_456
+DROP VIEW IF EXISTS view_2_tab0_456 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_456
+DROP VIEW IF EXISTS view_3_tab0_456 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6323,13 +6323,13 @@ SELECT pk FROM tab1 WHERE (col3 > 64) AND col0 = 64 OR (col0 > 1)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_456
+DROP VIEW IF EXISTS view_1_tab1_456 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_456
+DROP VIEW IF EXISTS view_2_tab1_456 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_456
+DROP VIEW IF EXISTS view_3_tab1_456 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6418,13 +6418,13 @@ SELECT pk FROM tab2 WHERE (col3 > 64) AND col0 = 64 OR (col0 > 1)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_456
+DROP VIEW IF EXISTS view_1_tab2_456 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_456
+DROP VIEW IF EXISTS view_2_tab2_456 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_456
+DROP VIEW IF EXISTS view_3_tab2_456 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6513,13 +6513,13 @@ SELECT pk FROM tab3 WHERE (col3 > 64) AND col0 = 64 OR (col0 > 1)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_456
+DROP VIEW IF EXISTS view_1_tab3_456 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_456
+DROP VIEW IF EXISTS view_2_tab3_456 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_456
+DROP VIEW IF EXISTS view_3_tab3_456 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6608,13 +6608,13 @@ SELECT pk FROM tab4 WHERE (col3 > 64) AND col0 = 64 OR (col0 > 1)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_456
+DROP VIEW IF EXISTS view_1_tab4_456 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_456
+DROP VIEW IF EXISTS view_2_tab4_456 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_456
+DROP VIEW IF EXISTS view_3_tab4_456 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6732,13 +6732,13 @@ SELECT pk FROM tab0 WHERE (col1 < 62.40)
 9
 
 statement ok
-DROP VIEW view_1_tab0_457
+DROP VIEW IF EXISTS view_1_tab0_457 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_457
+DROP VIEW IF EXISTS view_2_tab0_457 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_457
+DROP VIEW IF EXISTS view_3_tab0_457 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6856,13 +6856,13 @@ SELECT pk FROM tab1 WHERE (col1 < 62.40)
 9
 
 statement ok
-DROP VIEW view_1_tab1_457
+DROP VIEW IF EXISTS view_1_tab1_457 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_457
+DROP VIEW IF EXISTS view_2_tab1_457 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_457
+DROP VIEW IF EXISTS view_3_tab1_457 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6980,13 +6980,13 @@ SELECT pk FROM tab2 WHERE (col1 < 62.40)
 9
 
 statement ok
-DROP VIEW view_1_tab2_457
+DROP VIEW IF EXISTS view_1_tab2_457 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_457
+DROP VIEW IF EXISTS view_2_tab2_457 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_457
+DROP VIEW IF EXISTS view_3_tab2_457 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7104,13 +7104,13 @@ SELECT pk FROM tab3 WHERE (col1 < 62.40)
 9
 
 statement ok
-DROP VIEW view_1_tab3_457
+DROP VIEW IF EXISTS view_1_tab3_457 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_457
+DROP VIEW IF EXISTS view_2_tab3_457 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_457
+DROP VIEW IF EXISTS view_3_tab3_457 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7228,13 +7228,13 @@ SELECT pk FROM tab4 WHERE (col1 < 62.40)
 9
 
 statement ok
-DROP VIEW view_1_tab4_457
+DROP VIEW IF EXISTS view_1_tab4_457 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_457
+DROP VIEW IF EXISTS view_2_tab4_457 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_457
+DROP VIEW IF EXISTS view_3_tab4_457 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7320,13 +7320,13 @@ SELECT pk FROM tab0 WHERE (col4 > 55.18 AND (col0 >= 64) OR col0 > 23 AND (((col
 ----
 
 statement ok
-DROP VIEW view_1_tab0_458
+DROP VIEW IF EXISTS view_1_tab0_458 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_458
+DROP VIEW IF EXISTS view_2_tab0_458 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_458
+DROP VIEW IF EXISTS view_3_tab0_458 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7412,13 +7412,13 @@ SELECT pk FROM tab1 WHERE (col4 > 55.18 AND (col0 >= 64) OR col0 > 23 AND (((col
 ----
 
 statement ok
-DROP VIEW view_1_tab1_458
+DROP VIEW IF EXISTS view_1_tab1_458 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_458
+DROP VIEW IF EXISTS view_2_tab1_458 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_458
+DROP VIEW IF EXISTS view_3_tab1_458 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7504,13 +7504,13 @@ SELECT pk FROM tab2 WHERE (col4 > 55.18 AND (col0 >= 64) OR col0 > 23 AND (((col
 ----
 
 statement ok
-DROP VIEW view_1_tab2_458
+DROP VIEW IF EXISTS view_1_tab2_458 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_458
+DROP VIEW IF EXISTS view_2_tab2_458 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_458
+DROP VIEW IF EXISTS view_3_tab2_458 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7596,13 +7596,13 @@ SELECT pk FROM tab3 WHERE (col4 > 55.18 AND (col0 >= 64) OR col0 > 23 AND (((col
 ----
 
 statement ok
-DROP VIEW view_1_tab3_458
+DROP VIEW IF EXISTS view_1_tab3_458 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_458
+DROP VIEW IF EXISTS view_2_tab3_458 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_458
+DROP VIEW IF EXISTS view_3_tab3_458 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7688,13 +7688,13 @@ SELECT pk FROM tab4 WHERE (col4 > 55.18 AND (col0 >= 64) OR col0 > 23 AND (((col
 ----
 
 statement ok
-DROP VIEW view_1_tab4_458
+DROP VIEW IF EXISTS view_1_tab4_458 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_458
+DROP VIEW IF EXISTS view_2_tab4_458 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_458
+DROP VIEW IF EXISTS view_3_tab4_458 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7780,13 +7780,13 @@ SELECT pk FROM tab0 WHERE col0 IN (16,25,69,26,34,77)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_459
+DROP VIEW IF EXISTS view_1_tab0_459 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_459
+DROP VIEW IF EXISTS view_2_tab0_459 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_459
+DROP VIEW IF EXISTS view_3_tab0_459 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7872,13 +7872,13 @@ SELECT pk FROM tab1 WHERE col0 IN (16,25,69,26,34,77)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_459
+DROP VIEW IF EXISTS view_1_tab1_459 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_459
+DROP VIEW IF EXISTS view_2_tab1_459 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_459
+DROP VIEW IF EXISTS view_3_tab1_459 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7964,13 +7964,13 @@ SELECT pk FROM tab2 WHERE col0 IN (16,25,69,26,34,77)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_459
+DROP VIEW IF EXISTS view_1_tab2_459 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_459
+DROP VIEW IF EXISTS view_2_tab2_459 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_459
+DROP VIEW IF EXISTS view_3_tab2_459 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8056,13 +8056,13 @@ SELECT pk FROM tab3 WHERE col0 IN (16,25,69,26,34,77)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_459
+DROP VIEW IF EXISTS view_1_tab3_459 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_459
+DROP VIEW IF EXISTS view_2_tab3_459 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_459
+DROP VIEW IF EXISTS view_3_tab3_459 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8148,13 +8148,13 @@ SELECT pk FROM tab4 WHERE col0 IN (16,25,69,26,34,77)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_459
+DROP VIEW IF EXISTS view_1_tab4_459 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_459
+DROP VIEW IF EXISTS view_2_tab4_459 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_459
+DROP VIEW IF EXISTS view_3_tab4_459 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8254,13 +8254,13 @@ SELECT pk FROM tab0 WHERE col4 >= 93.25
 8
 
 statement ok
-DROP VIEW view_1_tab0_460
+DROP VIEW IF EXISTS view_1_tab0_460 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_460
+DROP VIEW IF EXISTS view_2_tab0_460 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_460
+DROP VIEW IF EXISTS view_3_tab0_460 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8360,13 +8360,13 @@ SELECT pk FROM tab1 WHERE col4 >= 93.25
 8
 
 statement ok
-DROP VIEW view_1_tab1_460
+DROP VIEW IF EXISTS view_1_tab1_460 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_460
+DROP VIEW IF EXISTS view_2_tab1_460 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_460
+DROP VIEW IF EXISTS view_3_tab1_460 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8466,13 +8466,13 @@ SELECT pk FROM tab2 WHERE col4 >= 93.25
 8
 
 statement ok
-DROP VIEW view_1_tab2_460
+DROP VIEW IF EXISTS view_1_tab2_460 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_460
+DROP VIEW IF EXISTS view_2_tab2_460 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_460
+DROP VIEW IF EXISTS view_3_tab2_460 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8572,13 +8572,13 @@ SELECT pk FROM tab3 WHERE col4 >= 93.25
 8
 
 statement ok
-DROP VIEW view_1_tab3_460
+DROP VIEW IF EXISTS view_1_tab3_460 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_460
+DROP VIEW IF EXISTS view_2_tab3_460 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_460
+DROP VIEW IF EXISTS view_3_tab3_460 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8678,13 +8678,13 @@ SELECT pk FROM tab4 WHERE col4 >= 93.25
 8
 
 statement ok
-DROP VIEW view_1_tab4_460
+DROP VIEW IF EXISTS view_1_tab4_460 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_460
+DROP VIEW IF EXISTS view_2_tab4_460 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_460
+DROP VIEW IF EXISTS view_3_tab4_460 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8773,13 +8773,13 @@ SELECT pk FROM tab0 WHERE ((col3 > 73) OR col3 < 77)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_461
+DROP VIEW IF EXISTS view_1_tab0_461 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_461
+DROP VIEW IF EXISTS view_2_tab0_461 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_461
+DROP VIEW IF EXISTS view_3_tab0_461 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8868,13 +8868,13 @@ SELECT pk FROM tab1 WHERE ((col3 > 73) OR col3 < 77)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_461
+DROP VIEW IF EXISTS view_1_tab1_461 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_461
+DROP VIEW IF EXISTS view_2_tab1_461 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_461
+DROP VIEW IF EXISTS view_3_tab1_461 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8963,13 +8963,13 @@ SELECT pk FROM tab2 WHERE ((col3 > 73) OR col3 < 77)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_461
+DROP VIEW IF EXISTS view_1_tab2_461 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_461
+DROP VIEW IF EXISTS view_2_tab2_461 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_461
+DROP VIEW IF EXISTS view_3_tab2_461 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9058,13 +9058,13 @@ SELECT pk FROM tab3 WHERE ((col3 > 73) OR col3 < 77)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_461
+DROP VIEW IF EXISTS view_1_tab3_461 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_461
+DROP VIEW IF EXISTS view_2_tab3_461 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_461
+DROP VIEW IF EXISTS view_3_tab3_461 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9153,13 +9153,13 @@ SELECT pk FROM tab4 WHERE ((col3 > 73) OR col3 < 77)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_461
+DROP VIEW IF EXISTS view_1_tab4_461 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_461
+DROP VIEW IF EXISTS view_2_tab4_461 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_461
+DROP VIEW IF EXISTS view_3_tab4_461 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9266,13 +9266,13 @@ SELECT pk FROM tab0 WHERE col4 >= 83.48
 8
 
 statement ok
-DROP VIEW view_1_tab0_462
+DROP VIEW IF EXISTS view_1_tab0_462 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_462
+DROP VIEW IF EXISTS view_2_tab0_462 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_462
+DROP VIEW IF EXISTS view_3_tab0_462 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9379,13 +9379,13 @@ SELECT pk FROM tab1 WHERE col4 >= 83.48
 8
 
 statement ok
-DROP VIEW view_1_tab1_462
+DROP VIEW IF EXISTS view_1_tab1_462 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_462
+DROP VIEW IF EXISTS view_2_tab1_462 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_462
+DROP VIEW IF EXISTS view_3_tab1_462 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9492,13 +9492,13 @@ SELECT pk FROM tab2 WHERE col4 >= 83.48
 8
 
 statement ok
-DROP VIEW view_1_tab2_462
+DROP VIEW IF EXISTS view_1_tab2_462 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_462
+DROP VIEW IF EXISTS view_2_tab2_462 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_462
+DROP VIEW IF EXISTS view_3_tab2_462 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9605,13 +9605,13 @@ SELECT pk FROM tab3 WHERE col4 >= 83.48
 8
 
 statement ok
-DROP VIEW view_1_tab3_462
+DROP VIEW IF EXISTS view_1_tab3_462 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_462
+DROP VIEW IF EXISTS view_2_tab3_462 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_462
+DROP VIEW IF EXISTS view_3_tab3_462 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9718,13 +9718,13 @@ SELECT pk FROM tab4 WHERE col4 >= 83.48
 8
 
 statement ok
-DROP VIEW view_1_tab4_462
+DROP VIEW IF EXISTS view_1_tab4_462 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_462
+DROP VIEW IF EXISTS view_2_tab4_462 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_462
+DROP VIEW IF EXISTS view_3_tab4_462 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9843,13 +9843,13 @@ SELECT pk FROM tab0 WHERE col0 > 27 OR col3 > 67 AND col3 IS NULL OR (col0 IN (4
 9
 
 statement ok
-DROP VIEW view_1_tab0_463
+DROP VIEW IF EXISTS view_1_tab0_463 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_463
+DROP VIEW IF EXISTS view_2_tab0_463 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_463
+DROP VIEW IF EXISTS view_3_tab0_463 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9968,13 +9968,13 @@ SELECT pk FROM tab1 WHERE col0 > 27 OR col3 > 67 AND col3 IS NULL OR (col0 IN (4
 9
 
 statement ok
-DROP VIEW view_1_tab1_463
+DROP VIEW IF EXISTS view_1_tab1_463 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_463
+DROP VIEW IF EXISTS view_2_tab1_463 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_463
+DROP VIEW IF EXISTS view_3_tab1_463 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10093,13 +10093,13 @@ SELECT pk FROM tab2 WHERE col0 > 27 OR col3 > 67 AND col3 IS NULL OR (col0 IN (4
 9
 
 statement ok
-DROP VIEW view_1_tab2_463
+DROP VIEW IF EXISTS view_1_tab2_463 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_463
+DROP VIEW IF EXISTS view_2_tab2_463 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_463
+DROP VIEW IF EXISTS view_3_tab2_463 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10218,13 +10218,13 @@ SELECT pk FROM tab3 WHERE col0 > 27 OR col3 > 67 AND col3 IS NULL OR (col0 IN (4
 9
 
 statement ok
-DROP VIEW view_1_tab3_463
+DROP VIEW IF EXISTS view_1_tab3_463 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_463
+DROP VIEW IF EXISTS view_2_tab3_463 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_463
+DROP VIEW IF EXISTS view_3_tab3_463 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10343,13 +10343,13 @@ SELECT pk FROM tab4 WHERE col0 > 27 OR col3 > 67 AND col3 IS NULL OR (col0 IN (4
 9
 
 statement ok
-DROP VIEW view_1_tab4_463
+DROP VIEW IF EXISTS view_1_tab4_463 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_463
+DROP VIEW IF EXISTS view_2_tab4_463 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_463
+DROP VIEW IF EXISTS view_3_tab4_463 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10435,13 +10435,13 @@ SELECT pk FROM tab0 WHERE col0 = 79
 ----
 
 statement ok
-DROP VIEW view_1_tab0_464
+DROP VIEW IF EXISTS view_1_tab0_464 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_464
+DROP VIEW IF EXISTS view_2_tab0_464 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_464
+DROP VIEW IF EXISTS view_3_tab0_464 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10527,13 +10527,13 @@ SELECT pk FROM tab1 WHERE col0 = 79
 ----
 
 statement ok
-DROP VIEW view_1_tab1_464
+DROP VIEW IF EXISTS view_1_tab1_464 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_464
+DROP VIEW IF EXISTS view_2_tab1_464 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_464
+DROP VIEW IF EXISTS view_3_tab1_464 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10619,13 +10619,13 @@ SELECT pk FROM tab2 WHERE col0 = 79
 ----
 
 statement ok
-DROP VIEW view_1_tab2_464
+DROP VIEW IF EXISTS view_1_tab2_464 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_464
+DROP VIEW IF EXISTS view_2_tab2_464 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_464
+DROP VIEW IF EXISTS view_3_tab2_464 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10711,13 +10711,13 @@ SELECT pk FROM tab3 WHERE col0 = 79
 ----
 
 statement ok
-DROP VIEW view_1_tab3_464
+DROP VIEW IF EXISTS view_1_tab3_464 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_464
+DROP VIEW IF EXISTS view_2_tab3_464 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_464
+DROP VIEW IF EXISTS view_3_tab3_464 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10803,13 +10803,13 @@ SELECT pk FROM tab4 WHERE col0 = 79
 ----
 
 statement ok
-DROP VIEW view_1_tab4_464
+DROP VIEW IF EXISTS view_1_tab4_464 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_464
+DROP VIEW IF EXISTS view_2_tab4_464 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_464
+DROP VIEW IF EXISTS view_3_tab4_464 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10929,13 +10929,13 @@ SELECT pk FROM tab0 WHERE ((col4 > 39.73))
 8
 
 statement ok
-DROP VIEW view_1_tab0_465
+DROP VIEW IF EXISTS view_1_tab0_465 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_465
+DROP VIEW IF EXISTS view_2_tab0_465 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_465
+DROP VIEW IF EXISTS view_3_tab0_465 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11055,13 +11055,13 @@ SELECT pk FROM tab1 WHERE ((col4 > 39.73))
 8
 
 statement ok
-DROP VIEW view_1_tab1_465
+DROP VIEW IF EXISTS view_1_tab1_465 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_465
+DROP VIEW IF EXISTS view_2_tab1_465 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_465
+DROP VIEW IF EXISTS view_3_tab1_465 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11181,13 +11181,13 @@ SELECT pk FROM tab2 WHERE ((col4 > 39.73))
 8
 
 statement ok
-DROP VIEW view_1_tab2_465
+DROP VIEW IF EXISTS view_1_tab2_465 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_465
+DROP VIEW IF EXISTS view_2_tab2_465 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_465
+DROP VIEW IF EXISTS view_3_tab2_465 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11307,13 +11307,13 @@ SELECT pk FROM tab3 WHERE ((col4 > 39.73))
 8
 
 statement ok
-DROP VIEW view_1_tab3_465
+DROP VIEW IF EXISTS view_1_tab3_465 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_465
+DROP VIEW IF EXISTS view_2_tab3_465 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_465
+DROP VIEW IF EXISTS view_3_tab3_465 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11433,13 +11433,13 @@ SELECT pk FROM tab4 WHERE ((col4 > 39.73))
 8
 
 statement ok
-DROP VIEW view_1_tab4_465
+DROP VIEW IF EXISTS view_1_tab4_465 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_465
+DROP VIEW IF EXISTS view_2_tab4_465 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_465
+DROP VIEW IF EXISTS view_3_tab4_465 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11525,13 +11525,13 @@ SELECT pk FROM tab0 WHERE ((col0 = 27)) AND col0 > 35 AND col4 > 45.46 OR (col4 
 ----
 
 statement ok
-DROP VIEW view_1_tab0_466
+DROP VIEW IF EXISTS view_1_tab0_466 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_466
+DROP VIEW IF EXISTS view_2_tab0_466 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_466
+DROP VIEW IF EXISTS view_3_tab0_466 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11617,13 +11617,13 @@ SELECT pk FROM tab1 WHERE ((col0 = 27)) AND col0 > 35 AND col4 > 45.46 OR (col4 
 ----
 
 statement ok
-DROP VIEW view_1_tab1_466
+DROP VIEW IF EXISTS view_1_tab1_466 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_466
+DROP VIEW IF EXISTS view_2_tab1_466 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_466
+DROP VIEW IF EXISTS view_3_tab1_466 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11709,13 +11709,13 @@ SELECT pk FROM tab2 WHERE ((col0 = 27)) AND col0 > 35 AND col4 > 45.46 OR (col4 
 ----
 
 statement ok
-DROP VIEW view_1_tab2_466
+DROP VIEW IF EXISTS view_1_tab2_466 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_466
+DROP VIEW IF EXISTS view_2_tab2_466 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_466
+DROP VIEW IF EXISTS view_3_tab2_466 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11801,13 +11801,13 @@ SELECT pk FROM tab3 WHERE ((col0 = 27)) AND col0 > 35 AND col4 > 45.46 OR (col4 
 ----
 
 statement ok
-DROP VIEW view_1_tab3_466
+DROP VIEW IF EXISTS view_1_tab3_466 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_466
+DROP VIEW IF EXISTS view_2_tab3_466 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_466
+DROP VIEW IF EXISTS view_3_tab3_466 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11893,13 +11893,13 @@ SELECT pk FROM tab4 WHERE ((col0 = 27)) AND col0 > 35 AND col4 > 45.46 OR (col4 
 ----
 
 statement ok
-DROP VIEW view_1_tab4_466
+DROP VIEW IF EXISTS view_1_tab4_466 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_466
+DROP VIEW IF EXISTS view_2_tab4_466 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_466
+DROP VIEW IF EXISTS view_3_tab4_466 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11999,13 +11999,13 @@ SELECT pk FROM tab0 WHERE col1 > 57.87
 5
 
 statement ok
-DROP VIEW view_1_tab0_467
+DROP VIEW IF EXISTS view_1_tab0_467 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_467
+DROP VIEW IF EXISTS view_2_tab0_467 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_467
+DROP VIEW IF EXISTS view_3_tab0_467 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12105,13 +12105,13 @@ SELECT pk FROM tab1 WHERE col1 > 57.87
 5
 
 statement ok
-DROP VIEW view_1_tab1_467
+DROP VIEW IF EXISTS view_1_tab1_467 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_467
+DROP VIEW IF EXISTS view_2_tab1_467 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_467
+DROP VIEW IF EXISTS view_3_tab1_467 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12211,13 +12211,13 @@ SELECT pk FROM tab2 WHERE col1 > 57.87
 5
 
 statement ok
-DROP VIEW view_1_tab2_467
+DROP VIEW IF EXISTS view_1_tab2_467 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_467
+DROP VIEW IF EXISTS view_2_tab2_467 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_467
+DROP VIEW IF EXISTS view_3_tab2_467 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12317,13 +12317,13 @@ SELECT pk FROM tab3 WHERE col1 > 57.87
 5
 
 statement ok
-DROP VIEW view_1_tab3_467
+DROP VIEW IF EXISTS view_1_tab3_467 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_467
+DROP VIEW IF EXISTS view_2_tab3_467 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_467
+DROP VIEW IF EXISTS view_3_tab3_467 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12423,13 +12423,13 @@ SELECT pk FROM tab4 WHERE col1 > 57.87
 5
 
 statement ok
-DROP VIEW view_1_tab4_467
+DROP VIEW IF EXISTS view_1_tab4_467 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_467
+DROP VIEW IF EXISTS view_2_tab4_467 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_467
+DROP VIEW IF EXISTS view_3_tab4_467 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12515,13 +12515,13 @@ SELECT pk FROM tab0 WHERE col0 > 69
 ----
 
 statement ok
-DROP VIEW view_1_tab0_468
+DROP VIEW IF EXISTS view_1_tab0_468 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_468
+DROP VIEW IF EXISTS view_2_tab0_468 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_468
+DROP VIEW IF EXISTS view_3_tab0_468 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12607,13 +12607,13 @@ SELECT pk FROM tab1 WHERE col0 > 69
 ----
 
 statement ok
-DROP VIEW view_1_tab1_468
+DROP VIEW IF EXISTS view_1_tab1_468 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_468
+DROP VIEW IF EXISTS view_2_tab1_468 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_468
+DROP VIEW IF EXISTS view_3_tab1_468 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12699,13 +12699,13 @@ SELECT pk FROM tab2 WHERE col0 > 69
 ----
 
 statement ok
-DROP VIEW view_1_tab2_468
+DROP VIEW IF EXISTS view_1_tab2_468 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_468
+DROP VIEW IF EXISTS view_2_tab2_468 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_468
+DROP VIEW IF EXISTS view_3_tab2_468 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12791,13 +12791,13 @@ SELECT pk FROM tab3 WHERE col0 > 69
 ----
 
 statement ok
-DROP VIEW view_1_tab3_468
+DROP VIEW IF EXISTS view_1_tab3_468 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_468
+DROP VIEW IF EXISTS view_2_tab3_468 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_468
+DROP VIEW IF EXISTS view_3_tab3_468 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12883,13 +12883,13 @@ SELECT pk FROM tab4 WHERE col0 > 69
 ----
 
 statement ok
-DROP VIEW view_1_tab4_468
+DROP VIEW IF EXISTS view_1_tab4_468 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_468
+DROP VIEW IF EXISTS view_2_tab4_468 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_468
+DROP VIEW IF EXISTS view_3_tab4_468 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12982,13 +12982,13 @@ SELECT pk FROM tab0 WHERE (((col0 > 98) AND ((col0 >= 78)) AND col3 >= 90)) OR (
 1
 
 statement ok
-DROP VIEW view_1_tab0_469
+DROP VIEW IF EXISTS view_1_tab0_469 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_469
+DROP VIEW IF EXISTS view_2_tab0_469 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_469
+DROP VIEW IF EXISTS view_3_tab0_469 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13081,13 +13081,13 @@ SELECT pk FROM tab1 WHERE (((col0 > 98) AND ((col0 >= 78)) AND col3 >= 90)) OR (
 1
 
 statement ok
-DROP VIEW view_1_tab1_469
+DROP VIEW IF EXISTS view_1_tab1_469 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_469
+DROP VIEW IF EXISTS view_2_tab1_469 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_469
+DROP VIEW IF EXISTS view_3_tab1_469 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13180,13 +13180,13 @@ SELECT pk FROM tab2 WHERE (((col0 > 98) AND ((col0 >= 78)) AND col3 >= 90)) OR (
 1
 
 statement ok
-DROP VIEW view_1_tab2_469
+DROP VIEW IF EXISTS view_1_tab2_469 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_469
+DROP VIEW IF EXISTS view_2_tab2_469 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_469
+DROP VIEW IF EXISTS view_3_tab2_469 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13279,13 +13279,13 @@ SELECT pk FROM tab3 WHERE (((col0 > 98) AND ((col0 >= 78)) AND col3 >= 90)) OR (
 1
 
 statement ok
-DROP VIEW view_1_tab3_469
+DROP VIEW IF EXISTS view_1_tab3_469 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_469
+DROP VIEW IF EXISTS view_2_tab3_469 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_469
+DROP VIEW IF EXISTS view_3_tab3_469 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13378,13 +13378,13 @@ SELECT pk FROM tab4 WHERE (((col0 > 98) AND ((col0 >= 78)) AND col3 >= 90)) OR (
 1
 
 statement ok
-DROP VIEW view_1_tab4_469
+DROP VIEW IF EXISTS view_1_tab4_469 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_469
+DROP VIEW IF EXISTS view_2_tab4_469 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_469
+DROP VIEW IF EXISTS view_3_tab4_469 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13470,13 +13470,13 @@ SELECT pk FROM tab0 WHERE col0 >= 81
 ----
 
 statement ok
-DROP VIEW view_1_tab0_470
+DROP VIEW IF EXISTS view_1_tab0_470 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_470
+DROP VIEW IF EXISTS view_2_tab0_470 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_470
+DROP VIEW IF EXISTS view_3_tab0_470 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13562,13 +13562,13 @@ SELECT pk FROM tab1 WHERE col0 >= 81
 ----
 
 statement ok
-DROP VIEW view_1_tab1_470
+DROP VIEW IF EXISTS view_1_tab1_470 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_470
+DROP VIEW IF EXISTS view_2_tab1_470 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_470
+DROP VIEW IF EXISTS view_3_tab1_470 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13654,13 +13654,13 @@ SELECT pk FROM tab2 WHERE col0 >= 81
 ----
 
 statement ok
-DROP VIEW view_1_tab2_470
+DROP VIEW IF EXISTS view_1_tab2_470 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_470
+DROP VIEW IF EXISTS view_2_tab2_470 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_470
+DROP VIEW IF EXISTS view_3_tab2_470 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13746,13 +13746,13 @@ SELECT pk FROM tab3 WHERE col0 >= 81
 ----
 
 statement ok
-DROP VIEW view_1_tab3_470
+DROP VIEW IF EXISTS view_1_tab3_470 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_470
+DROP VIEW IF EXISTS view_2_tab3_470 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_470
+DROP VIEW IF EXISTS view_3_tab3_470 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13838,13 +13838,13 @@ SELECT pk FROM tab4 WHERE col0 >= 81
 ----
 
 statement ok
-DROP VIEW view_1_tab4_470
+DROP VIEW IF EXISTS view_1_tab4_470 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_470
+DROP VIEW IF EXISTS view_2_tab4_470 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_470
+DROP VIEW IF EXISTS view_3_tab4_470 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13944,13 +13944,13 @@ SELECT pk FROM tab0 WHERE col0 < 10
 6
 
 statement ok
-DROP VIEW view_1_tab0_471
+DROP VIEW IF EXISTS view_1_tab0_471 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_471
+DROP VIEW IF EXISTS view_2_tab0_471 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_471
+DROP VIEW IF EXISTS view_3_tab0_471 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14050,13 +14050,13 @@ SELECT pk FROM tab1 WHERE col0 < 10
 6
 
 statement ok
-DROP VIEW view_1_tab1_471
+DROP VIEW IF EXISTS view_1_tab1_471 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_471
+DROP VIEW IF EXISTS view_2_tab1_471 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_471
+DROP VIEW IF EXISTS view_3_tab1_471 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14156,13 +14156,13 @@ SELECT pk FROM tab2 WHERE col0 < 10
 6
 
 statement ok
-DROP VIEW view_1_tab2_471
+DROP VIEW IF EXISTS view_1_tab2_471 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_471
+DROP VIEW IF EXISTS view_2_tab2_471 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_471
+DROP VIEW IF EXISTS view_3_tab2_471 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14262,13 +14262,13 @@ SELECT pk FROM tab3 WHERE col0 < 10
 6
 
 statement ok
-DROP VIEW view_1_tab3_471
+DROP VIEW IF EXISTS view_1_tab3_471 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_471
+DROP VIEW IF EXISTS view_2_tab3_471 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_471
+DROP VIEW IF EXISTS view_3_tab3_471 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14368,13 +14368,13 @@ SELECT pk FROM tab4 WHERE col0 < 10
 6
 
 statement ok
-DROP VIEW view_1_tab4_471
+DROP VIEW IF EXISTS view_1_tab4_471 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_471
+DROP VIEW IF EXISTS view_2_tab4_471 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_471
+DROP VIEW IF EXISTS view_3_tab4_471 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14460,13 +14460,13 @@ SELECT pk FROM tab0 WHERE (col3 < 99 AND col1 = 64.91) AND ((col0 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_472
+DROP VIEW IF EXISTS view_1_tab0_472 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_472
+DROP VIEW IF EXISTS view_2_tab0_472 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_472
+DROP VIEW IF EXISTS view_3_tab0_472 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14552,13 +14552,13 @@ SELECT pk FROM tab1 WHERE (col3 < 99 AND col1 = 64.91) AND ((col0 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_472
+DROP VIEW IF EXISTS view_1_tab1_472 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_472
+DROP VIEW IF EXISTS view_2_tab1_472 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_472
+DROP VIEW IF EXISTS view_3_tab1_472 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14644,13 +14644,13 @@ SELECT pk FROM tab2 WHERE (col3 < 99 AND col1 = 64.91) AND ((col0 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_472
+DROP VIEW IF EXISTS view_1_tab2_472 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_472
+DROP VIEW IF EXISTS view_2_tab2_472 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_472
+DROP VIEW IF EXISTS view_3_tab2_472 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14736,13 +14736,13 @@ SELECT pk FROM tab3 WHERE (col3 < 99 AND col1 = 64.91) AND ((col0 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_472
+DROP VIEW IF EXISTS view_1_tab3_472 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_472
+DROP VIEW IF EXISTS view_2_tab3_472 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_472
+DROP VIEW IF EXISTS view_3_tab3_472 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14828,13 +14828,13 @@ SELECT pk FROM tab4 WHERE (col3 < 99 AND col1 = 64.91) AND ((col0 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_472
+DROP VIEW IF EXISTS view_1_tab4_472 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_472
+DROP VIEW IF EXISTS view_2_tab4_472 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_472
+DROP VIEW IF EXISTS view_3_tab4_472 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14937,13 +14937,13 @@ SELECT pk FROM tab0 WHERE col4 < 55.35
 9
 
 statement ok
-DROP VIEW view_1_tab0_473
+DROP VIEW IF EXISTS view_1_tab0_473 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_473
+DROP VIEW IF EXISTS view_2_tab0_473 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_473
+DROP VIEW IF EXISTS view_3_tab0_473 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15046,13 +15046,13 @@ SELECT pk FROM tab1 WHERE col4 < 55.35
 9
 
 statement ok
-DROP VIEW view_1_tab1_473
+DROP VIEW IF EXISTS view_1_tab1_473 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_473
+DROP VIEW IF EXISTS view_2_tab1_473 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_473
+DROP VIEW IF EXISTS view_3_tab1_473 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15155,13 +15155,13 @@ SELECT pk FROM tab2 WHERE col4 < 55.35
 9
 
 statement ok
-DROP VIEW view_1_tab2_473
+DROP VIEW IF EXISTS view_1_tab2_473 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_473
+DROP VIEW IF EXISTS view_2_tab2_473 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_473
+DROP VIEW IF EXISTS view_3_tab2_473 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15264,13 +15264,13 @@ SELECT pk FROM tab3 WHERE col4 < 55.35
 9
 
 statement ok
-DROP VIEW view_1_tab3_473
+DROP VIEW IF EXISTS view_1_tab3_473 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_473
+DROP VIEW IF EXISTS view_2_tab3_473 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_473
+DROP VIEW IF EXISTS view_3_tab3_473 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15373,13 +15373,13 @@ SELECT pk FROM tab4 WHERE col4 < 55.35
 9
 
 statement ok
-DROP VIEW view_1_tab4_473
+DROP VIEW IF EXISTS view_1_tab4_473 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_473
+DROP VIEW IF EXISTS view_2_tab4_473 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_473
+DROP VIEW IF EXISTS view_3_tab4_473 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15465,13 +15465,13 @@ SELECT pk FROM tab0 WHERE (col3 <= 42) AND (col4 IS NULL) AND (col0 < 25)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_474
+DROP VIEW IF EXISTS view_1_tab0_474 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_474
+DROP VIEW IF EXISTS view_2_tab0_474 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_474
+DROP VIEW IF EXISTS view_3_tab0_474 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15557,13 +15557,13 @@ SELECT pk FROM tab1 WHERE (col3 <= 42) AND (col4 IS NULL) AND (col0 < 25)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_474
+DROP VIEW IF EXISTS view_1_tab1_474 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_474
+DROP VIEW IF EXISTS view_2_tab1_474 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_474
+DROP VIEW IF EXISTS view_3_tab1_474 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15649,13 +15649,13 @@ SELECT pk FROM tab2 WHERE (col3 <= 42) AND (col4 IS NULL) AND (col0 < 25)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_474
+DROP VIEW IF EXISTS view_1_tab2_474 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_474
+DROP VIEW IF EXISTS view_2_tab2_474 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_474
+DROP VIEW IF EXISTS view_3_tab2_474 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15741,13 +15741,13 @@ SELECT pk FROM tab3 WHERE (col3 <= 42) AND (col4 IS NULL) AND (col0 < 25)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_474
+DROP VIEW IF EXISTS view_1_tab3_474 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_474
+DROP VIEW IF EXISTS view_2_tab3_474 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_474
+DROP VIEW IF EXISTS view_3_tab3_474 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15833,13 +15833,13 @@ SELECT pk FROM tab4 WHERE (col3 <= 42) AND (col4 IS NULL) AND (col0 < 25)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_474
+DROP VIEW IF EXISTS view_1_tab4_474 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_474
+DROP VIEW IF EXISTS view_2_tab4_474 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_474
+DROP VIEW IF EXISTS view_3_tab4_474 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15925,13 +15925,13 @@ SELECT pk FROM tab0 WHERE col1 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab0_475
+DROP VIEW IF EXISTS view_1_tab0_475 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_475
+DROP VIEW IF EXISTS view_2_tab0_475 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_475
+DROP VIEW IF EXISTS view_3_tab0_475 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16017,13 +16017,13 @@ SELECT pk FROM tab1 WHERE col1 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab1_475
+DROP VIEW IF EXISTS view_1_tab1_475 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_475
+DROP VIEW IF EXISTS view_2_tab1_475 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_475
+DROP VIEW IF EXISTS view_3_tab1_475 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16109,13 +16109,13 @@ SELECT pk FROM tab2 WHERE col1 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab2_475
+DROP VIEW IF EXISTS view_1_tab2_475 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_475
+DROP VIEW IF EXISTS view_2_tab2_475 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_475
+DROP VIEW IF EXISTS view_3_tab2_475 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16201,13 +16201,13 @@ SELECT pk FROM tab3 WHERE col1 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab3_475
+DROP VIEW IF EXISTS view_1_tab3_475 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_475
+DROP VIEW IF EXISTS view_2_tab3_475 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_475
+DROP VIEW IF EXISTS view_3_tab3_475 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16293,13 +16293,13 @@ SELECT pk FROM tab4 WHERE col1 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab4_475
+DROP VIEW IF EXISTS view_1_tab4_475 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_475
+DROP VIEW IF EXISTS view_2_tab4_475 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_475
+DROP VIEW IF EXISTS view_3_tab4_475 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16402,13 +16402,13 @@ SELECT pk FROM tab0 WHERE col4 > 65.10
 8
 
 statement ok
-DROP VIEW view_1_tab0_476
+DROP VIEW IF EXISTS view_1_tab0_476 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_476
+DROP VIEW IF EXISTS view_2_tab0_476 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_476
+DROP VIEW IF EXISTS view_3_tab0_476 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16511,13 +16511,13 @@ SELECT pk FROM tab1 WHERE col4 > 65.10
 8
 
 statement ok
-DROP VIEW view_1_tab1_476
+DROP VIEW IF EXISTS view_1_tab1_476 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_476
+DROP VIEW IF EXISTS view_2_tab1_476 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_476
+DROP VIEW IF EXISTS view_3_tab1_476 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16620,13 +16620,13 @@ SELECT pk FROM tab2 WHERE col4 > 65.10
 8
 
 statement ok
-DROP VIEW view_1_tab2_476
+DROP VIEW IF EXISTS view_1_tab2_476 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_476
+DROP VIEW IF EXISTS view_2_tab2_476 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_476
+DROP VIEW IF EXISTS view_3_tab2_476 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16729,13 +16729,13 @@ SELECT pk FROM tab3 WHERE col4 > 65.10
 8
 
 statement ok
-DROP VIEW view_1_tab3_476
+DROP VIEW IF EXISTS view_1_tab3_476 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_476
+DROP VIEW IF EXISTS view_2_tab3_476 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_476
+DROP VIEW IF EXISTS view_3_tab3_476 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16838,13 +16838,13 @@ SELECT pk FROM tab4 WHERE col4 > 65.10
 8
 
 statement ok
-DROP VIEW view_1_tab4_476
+DROP VIEW IF EXISTS view_1_tab4_476 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_476
+DROP VIEW IF EXISTS view_2_tab4_476 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_476
+DROP VIEW IF EXISTS view_3_tab4_476 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16947,13 +16947,13 @@ SELECT pk FROM tab0 WHERE col1 < 29.2
 9
 
 statement ok
-DROP VIEW view_1_tab0_477
+DROP VIEW IF EXISTS view_1_tab0_477 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_477
+DROP VIEW IF EXISTS view_2_tab0_477 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_477
+DROP VIEW IF EXISTS view_3_tab0_477 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17056,13 +17056,13 @@ SELECT pk FROM tab1 WHERE col1 < 29.2
 9
 
 statement ok
-DROP VIEW view_1_tab1_477
+DROP VIEW IF EXISTS view_1_tab1_477 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_477
+DROP VIEW IF EXISTS view_2_tab1_477 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_477
+DROP VIEW IF EXISTS view_3_tab1_477 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17165,13 +17165,13 @@ SELECT pk FROM tab2 WHERE col1 < 29.2
 9
 
 statement ok
-DROP VIEW view_1_tab2_477
+DROP VIEW IF EXISTS view_1_tab2_477 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_477
+DROP VIEW IF EXISTS view_2_tab2_477 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_477
+DROP VIEW IF EXISTS view_3_tab2_477 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17274,13 +17274,13 @@ SELECT pk FROM tab3 WHERE col1 < 29.2
 9
 
 statement ok
-DROP VIEW view_1_tab3_477
+DROP VIEW IF EXISTS view_1_tab3_477 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_477
+DROP VIEW IF EXISTS view_2_tab3_477 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_477
+DROP VIEW IF EXISTS view_3_tab3_477 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17383,13 +17383,13 @@ SELECT pk FROM tab4 WHERE col1 < 29.2
 9
 
 statement ok
-DROP VIEW view_1_tab4_477
+DROP VIEW IF EXISTS view_1_tab4_477 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_477
+DROP VIEW IF EXISTS view_2_tab4_477 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_477
+DROP VIEW IF EXISTS view_3_tab4_477 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17475,13 +17475,13 @@ SELECT pk FROM tab0 WHERE col1 = 6.62
 ----
 
 statement ok
-DROP VIEW view_1_tab0_478
+DROP VIEW IF EXISTS view_1_tab0_478 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_478
+DROP VIEW IF EXISTS view_2_tab0_478 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_478
+DROP VIEW IF EXISTS view_3_tab0_478 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17567,13 +17567,13 @@ SELECT pk FROM tab1 WHERE col1 = 6.62
 ----
 
 statement ok
-DROP VIEW view_1_tab1_478
+DROP VIEW IF EXISTS view_1_tab1_478 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_478
+DROP VIEW IF EXISTS view_2_tab1_478 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_478
+DROP VIEW IF EXISTS view_3_tab1_478 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17659,13 +17659,13 @@ SELECT pk FROM tab2 WHERE col1 = 6.62
 ----
 
 statement ok
-DROP VIEW view_1_tab2_478
+DROP VIEW IF EXISTS view_1_tab2_478 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_478
+DROP VIEW IF EXISTS view_2_tab2_478 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_478
+DROP VIEW IF EXISTS view_3_tab2_478 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17751,13 +17751,13 @@ SELECT pk FROM tab3 WHERE col1 = 6.62
 ----
 
 statement ok
-DROP VIEW view_1_tab3_478
+DROP VIEW IF EXISTS view_1_tab3_478 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_478
+DROP VIEW IF EXISTS view_2_tab3_478 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_478
+DROP VIEW IF EXISTS view_3_tab3_478 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17843,13 +17843,13 @@ SELECT pk FROM tab4 WHERE col1 = 6.62
 ----
 
 statement ok
-DROP VIEW view_1_tab4_478
+DROP VIEW IF EXISTS view_1_tab4_478 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_478
+DROP VIEW IF EXISTS view_2_tab4_478 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_478
+DROP VIEW IF EXISTS view_3_tab4_478 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17968,13 +17968,13 @@ SELECT pk FROM tab0 WHERE col3 < 66
 9
 
 statement ok
-DROP VIEW view_1_tab0_479
+DROP VIEW IF EXISTS view_1_tab0_479 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_479
+DROP VIEW IF EXISTS view_2_tab0_479 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_479
+DROP VIEW IF EXISTS view_3_tab0_479 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18093,13 +18093,13 @@ SELECT pk FROM tab1 WHERE col3 < 66
 9
 
 statement ok
-DROP VIEW view_1_tab1_479
+DROP VIEW IF EXISTS view_1_tab1_479 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_479
+DROP VIEW IF EXISTS view_2_tab1_479 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_479
+DROP VIEW IF EXISTS view_3_tab1_479 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18218,13 +18218,13 @@ SELECT pk FROM tab2 WHERE col3 < 66
 9
 
 statement ok
-DROP VIEW view_1_tab2_479
+DROP VIEW IF EXISTS view_1_tab2_479 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_479
+DROP VIEW IF EXISTS view_2_tab2_479 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_479
+DROP VIEW IF EXISTS view_3_tab2_479 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18343,13 +18343,13 @@ SELECT pk FROM tab3 WHERE col3 < 66
 9
 
 statement ok
-DROP VIEW view_1_tab3_479
+DROP VIEW IF EXISTS view_1_tab3_479 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_479
+DROP VIEW IF EXISTS view_2_tab3_479 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_479
+DROP VIEW IF EXISTS view_3_tab3_479 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18468,13 +18468,13 @@ SELECT pk FROM tab4 WHERE col3 < 66
 9
 
 statement ok
-DROP VIEW view_1_tab4_479
+DROP VIEW IF EXISTS view_1_tab4_479 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_479
+DROP VIEW IF EXISTS view_2_tab4_479 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_479
+DROP VIEW IF EXISTS view_3_tab4_479 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18560,13 +18560,13 @@ SELECT pk FROM tab0 WHERE col0 IS NULL AND col4 < 45.69
 ----
 
 statement ok
-DROP VIEW view_1_tab0_480
+DROP VIEW IF EXISTS view_1_tab0_480 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_480
+DROP VIEW IF EXISTS view_2_tab0_480 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_480
+DROP VIEW IF EXISTS view_3_tab0_480 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18652,13 +18652,13 @@ SELECT pk FROM tab1 WHERE col0 IS NULL AND col4 < 45.69
 ----
 
 statement ok
-DROP VIEW view_1_tab1_480
+DROP VIEW IF EXISTS view_1_tab1_480 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_480
+DROP VIEW IF EXISTS view_2_tab1_480 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_480
+DROP VIEW IF EXISTS view_3_tab1_480 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18744,13 +18744,13 @@ SELECT pk FROM tab2 WHERE col0 IS NULL AND col4 < 45.69
 ----
 
 statement ok
-DROP VIEW view_1_tab2_480
+DROP VIEW IF EXISTS view_1_tab2_480 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_480
+DROP VIEW IF EXISTS view_2_tab2_480 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_480
+DROP VIEW IF EXISTS view_3_tab2_480 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18836,13 +18836,13 @@ SELECT pk FROM tab3 WHERE col0 IS NULL AND col4 < 45.69
 ----
 
 statement ok
-DROP VIEW view_1_tab3_480
+DROP VIEW IF EXISTS view_1_tab3_480 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_480
+DROP VIEW IF EXISTS view_2_tab3_480 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_480
+DROP VIEW IF EXISTS view_3_tab3_480 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18928,13 +18928,13 @@ SELECT pk FROM tab4 WHERE col0 IS NULL AND col4 < 45.69
 ----
 
 statement ok
-DROP VIEW view_1_tab4_480
+DROP VIEW IF EXISTS view_1_tab4_480 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_480
+DROP VIEW IF EXISTS view_2_tab4_480 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_480
+DROP VIEW IF EXISTS view_3_tab4_480 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19027,13 +19027,13 @@ SELECT pk FROM tab0 WHERE (col0 = 52)
 7
 
 statement ok
-DROP VIEW view_1_tab0_481
+DROP VIEW IF EXISTS view_1_tab0_481 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_481
+DROP VIEW IF EXISTS view_2_tab0_481 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_481
+DROP VIEW IF EXISTS view_3_tab0_481 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19126,13 +19126,13 @@ SELECT pk FROM tab1 WHERE (col0 = 52)
 7
 
 statement ok
-DROP VIEW view_1_tab1_481
+DROP VIEW IF EXISTS view_1_tab1_481 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_481
+DROP VIEW IF EXISTS view_2_tab1_481 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_481
+DROP VIEW IF EXISTS view_3_tab1_481 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19225,13 +19225,13 @@ SELECT pk FROM tab2 WHERE (col0 = 52)
 7
 
 statement ok
-DROP VIEW view_1_tab2_481
+DROP VIEW IF EXISTS view_1_tab2_481 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_481
+DROP VIEW IF EXISTS view_2_tab2_481 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_481
+DROP VIEW IF EXISTS view_3_tab2_481 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19324,13 +19324,13 @@ SELECT pk FROM tab3 WHERE (col0 = 52)
 7
 
 statement ok
-DROP VIEW view_1_tab3_481
+DROP VIEW IF EXISTS view_1_tab3_481 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_481
+DROP VIEW IF EXISTS view_2_tab3_481 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_481
+DROP VIEW IF EXISTS view_3_tab3_481 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19423,13 +19423,13 @@ SELECT pk FROM tab4 WHERE (col0 = 52)
 7
 
 statement ok
-DROP VIEW view_1_tab4_481
+DROP VIEW IF EXISTS view_1_tab4_481 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_481
+DROP VIEW IF EXISTS view_2_tab4_481 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_481
+DROP VIEW IF EXISTS view_3_tab4_481 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19549,13 +19549,13 @@ SELECT pk FROM tab0 WHERE (((col0 <= 42))) OR (col0 <= 96) AND (col4 > 76.78) AN
 8
 
 statement ok
-DROP VIEW view_1_tab0_482
+DROP VIEW IF EXISTS view_1_tab0_482 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_482
+DROP VIEW IF EXISTS view_2_tab0_482 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_482
+DROP VIEW IF EXISTS view_3_tab0_482 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19675,13 +19675,13 @@ SELECT pk FROM tab1 WHERE (((col0 <= 42))) OR (col0 <= 96) AND (col4 > 76.78) AN
 8
 
 statement ok
-DROP VIEW view_1_tab1_482
+DROP VIEW IF EXISTS view_1_tab1_482 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_482
+DROP VIEW IF EXISTS view_2_tab1_482 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_482
+DROP VIEW IF EXISTS view_3_tab1_482 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19801,13 +19801,13 @@ SELECT pk FROM tab2 WHERE (((col0 <= 42))) OR (col0 <= 96) AND (col4 > 76.78) AN
 8
 
 statement ok
-DROP VIEW view_1_tab2_482
+DROP VIEW IF EXISTS view_1_tab2_482 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_482
+DROP VIEW IF EXISTS view_2_tab2_482 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_482
+DROP VIEW IF EXISTS view_3_tab2_482 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19927,13 +19927,13 @@ SELECT pk FROM tab3 WHERE (((col0 <= 42))) OR (col0 <= 96) AND (col4 > 76.78) AN
 8
 
 statement ok
-DROP VIEW view_1_tab3_482
+DROP VIEW IF EXISTS view_1_tab3_482 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_482
+DROP VIEW IF EXISTS view_2_tab3_482 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_482
+DROP VIEW IF EXISTS view_3_tab3_482 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20053,13 +20053,13 @@ SELECT pk FROM tab4 WHERE (((col0 <= 42))) OR (col0 <= 96) AND (col4 > 76.78) AN
 8
 
 statement ok
-DROP VIEW view_1_tab4_482
+DROP VIEW IF EXISTS view_1_tab4_482 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_482
+DROP VIEW IF EXISTS view_2_tab4_482 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_482
+DROP VIEW IF EXISTS view_3_tab4_482 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20145,13 +20145,13 @@ SELECT pk FROM tab0 WHERE ((col0 IN (95,95,92,84,89,95)))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_483
+DROP VIEW IF EXISTS view_1_tab0_483 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_483
+DROP VIEW IF EXISTS view_2_tab0_483 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_483
+DROP VIEW IF EXISTS view_3_tab0_483 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20237,13 +20237,13 @@ SELECT pk FROM tab1 WHERE ((col0 IN (95,95,92,84,89,95)))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_483
+DROP VIEW IF EXISTS view_1_tab1_483 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_483
+DROP VIEW IF EXISTS view_2_tab1_483 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_483
+DROP VIEW IF EXISTS view_3_tab1_483 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20329,13 +20329,13 @@ SELECT pk FROM tab2 WHERE ((col0 IN (95,95,92,84,89,95)))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_483
+DROP VIEW IF EXISTS view_1_tab2_483 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_483
+DROP VIEW IF EXISTS view_2_tab2_483 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_483
+DROP VIEW IF EXISTS view_3_tab2_483 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20421,13 +20421,13 @@ SELECT pk FROM tab3 WHERE ((col0 IN (95,95,92,84,89,95)))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_483
+DROP VIEW IF EXISTS view_1_tab3_483 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_483
+DROP VIEW IF EXISTS view_2_tab3_483 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_483
+DROP VIEW IF EXISTS view_3_tab3_483 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20513,13 +20513,13 @@ SELECT pk FROM tab4 WHERE ((col0 IN (95,95,92,84,89,95)))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_483
+DROP VIEW IF EXISTS view_1_tab4_483 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_483
+DROP VIEW IF EXISTS view_2_tab4_483 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_483
+DROP VIEW IF EXISTS view_3_tab4_483 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20608,13 +20608,13 @@ SELECT pk FROM tab0 WHERE (col0 <= 77) OR (col0 < 43 AND (col3 > 64)) AND (col1 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_484
+DROP VIEW IF EXISTS view_1_tab0_484 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_484
+DROP VIEW IF EXISTS view_2_tab0_484 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_484
+DROP VIEW IF EXISTS view_3_tab0_484 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20703,13 +20703,13 @@ SELECT pk FROM tab1 WHERE (col0 <= 77) OR (col0 < 43 AND (col3 > 64)) AND (col1 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_484
+DROP VIEW IF EXISTS view_1_tab1_484 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_484
+DROP VIEW IF EXISTS view_2_tab1_484 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_484
+DROP VIEW IF EXISTS view_3_tab1_484 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20798,13 +20798,13 @@ SELECT pk FROM tab2 WHERE (col0 <= 77) OR (col0 < 43 AND (col3 > 64)) AND (col1 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_484
+DROP VIEW IF EXISTS view_1_tab2_484 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_484
+DROP VIEW IF EXISTS view_2_tab2_484 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_484
+DROP VIEW IF EXISTS view_3_tab2_484 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20893,13 +20893,13 @@ SELECT pk FROM tab3 WHERE (col0 <= 77) OR (col0 < 43 AND (col3 > 64)) AND (col1 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_484
+DROP VIEW IF EXISTS view_1_tab3_484 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_484
+DROP VIEW IF EXISTS view_2_tab3_484 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_484
+DROP VIEW IF EXISTS view_3_tab3_484 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20988,13 +20988,13 @@ SELECT pk FROM tab4 WHERE (col0 <= 77) OR (col0 < 43 AND (col3 > 64)) AND (col1 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_484
+DROP VIEW IF EXISTS view_1_tab4_484 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_484
+DROP VIEW IF EXISTS view_2_tab4_484 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_484
+DROP VIEW IF EXISTS view_3_tab4_484 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21080,13 +21080,13 @@ SELECT pk FROM tab0 WHERE (((col3 < 25 OR ((col4 = 87.66 AND col1 >= 56.75 AND (
 ----
 
 statement ok
-DROP VIEW view_1_tab0_485
+DROP VIEW IF EXISTS view_1_tab0_485 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_485
+DROP VIEW IF EXISTS view_2_tab0_485 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_485
+DROP VIEW IF EXISTS view_3_tab0_485 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21172,13 +21172,13 @@ SELECT pk FROM tab1 WHERE (((col3 < 25 OR ((col4 = 87.66 AND col1 >= 56.75 AND (
 ----
 
 statement ok
-DROP VIEW view_1_tab1_485
+DROP VIEW IF EXISTS view_1_tab1_485 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_485
+DROP VIEW IF EXISTS view_2_tab1_485 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_485
+DROP VIEW IF EXISTS view_3_tab1_485 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21264,13 +21264,13 @@ SELECT pk FROM tab2 WHERE (((col3 < 25 OR ((col4 = 87.66 AND col1 >= 56.75 AND (
 ----
 
 statement ok
-DROP VIEW view_1_tab2_485
+DROP VIEW IF EXISTS view_1_tab2_485 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_485
+DROP VIEW IF EXISTS view_2_tab2_485 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_485
+DROP VIEW IF EXISTS view_3_tab2_485 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21356,13 +21356,13 @@ SELECT pk FROM tab3 WHERE (((col3 < 25 OR ((col4 = 87.66 AND col1 >= 56.75 AND (
 ----
 
 statement ok
-DROP VIEW view_1_tab3_485
+DROP VIEW IF EXISTS view_1_tab3_485 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_485
+DROP VIEW IF EXISTS view_2_tab3_485 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_485
+DROP VIEW IF EXISTS view_3_tab3_485 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21448,13 +21448,13 @@ SELECT pk FROM tab4 WHERE (((col3 < 25 OR ((col4 = 87.66 AND col1 >= 56.75 AND (
 ----
 
 statement ok
-DROP VIEW view_1_tab4_485
+DROP VIEW IF EXISTS view_1_tab4_485 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_485
+DROP VIEW IF EXISTS view_2_tab4_485 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_485
+DROP VIEW IF EXISTS view_3_tab4_485 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21554,13 +21554,13 @@ SELECT pk FROM tab0 WHERE (((col3 < 8) OR col0 > 17)) AND col3 >= 78
 7
 
 statement ok
-DROP VIEW view_1_tab0_486
+DROP VIEW IF EXISTS view_1_tab0_486 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_486
+DROP VIEW IF EXISTS view_2_tab0_486 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_486
+DROP VIEW IF EXISTS view_3_tab0_486 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21660,13 +21660,13 @@ SELECT pk FROM tab1 WHERE (((col3 < 8) OR col0 > 17)) AND col3 >= 78
 7
 
 statement ok
-DROP VIEW view_1_tab1_486
+DROP VIEW IF EXISTS view_1_tab1_486 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_486
+DROP VIEW IF EXISTS view_2_tab1_486 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_486
+DROP VIEW IF EXISTS view_3_tab1_486 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21766,13 +21766,13 @@ SELECT pk FROM tab2 WHERE (((col3 < 8) OR col0 > 17)) AND col3 >= 78
 7
 
 statement ok
-DROP VIEW view_1_tab2_486
+DROP VIEW IF EXISTS view_1_tab2_486 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_486
+DROP VIEW IF EXISTS view_2_tab2_486 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_486
+DROP VIEW IF EXISTS view_3_tab2_486 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21872,13 +21872,13 @@ SELECT pk FROM tab3 WHERE (((col3 < 8) OR col0 > 17)) AND col3 >= 78
 7
 
 statement ok
-DROP VIEW view_1_tab3_486
+DROP VIEW IF EXISTS view_1_tab3_486 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_486
+DROP VIEW IF EXISTS view_2_tab3_486 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_486
+DROP VIEW IF EXISTS view_3_tab3_486 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21978,13 +21978,13 @@ SELECT pk FROM tab4 WHERE (((col3 < 8) OR col0 > 17)) AND col3 >= 78
 7
 
 statement ok
-DROP VIEW view_1_tab4_486
+DROP VIEW IF EXISTS view_1_tab4_486 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_486
+DROP VIEW IF EXISTS view_2_tab4_486 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_486
+DROP VIEW IF EXISTS view_3_tab4_486 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22084,13 +22084,13 @@ SELECT pk FROM tab0 WHERE col1 >= 52.32
 5
 
 statement ok
-DROP VIEW view_1_tab0_487
+DROP VIEW IF EXISTS view_1_tab0_487 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_487
+DROP VIEW IF EXISTS view_2_tab0_487 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_487
+DROP VIEW IF EXISTS view_3_tab0_487 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22190,13 +22190,13 @@ SELECT pk FROM tab1 WHERE col1 >= 52.32
 5
 
 statement ok
-DROP VIEW view_1_tab1_487
+DROP VIEW IF EXISTS view_1_tab1_487 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_487
+DROP VIEW IF EXISTS view_2_tab1_487 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_487
+DROP VIEW IF EXISTS view_3_tab1_487 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22296,13 +22296,13 @@ SELECT pk FROM tab2 WHERE col1 >= 52.32
 5
 
 statement ok
-DROP VIEW view_1_tab2_487
+DROP VIEW IF EXISTS view_1_tab2_487 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_487
+DROP VIEW IF EXISTS view_2_tab2_487 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_487
+DROP VIEW IF EXISTS view_3_tab2_487 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22402,13 +22402,13 @@ SELECT pk FROM tab3 WHERE col1 >= 52.32
 5
 
 statement ok
-DROP VIEW view_1_tab3_487
+DROP VIEW IF EXISTS view_1_tab3_487 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_487
+DROP VIEW IF EXISTS view_2_tab3_487 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_487
+DROP VIEW IF EXISTS view_3_tab3_487 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22508,13 +22508,13 @@ SELECT pk FROM tab4 WHERE col1 >= 52.32
 5
 
 statement ok
-DROP VIEW view_1_tab4_487
+DROP VIEW IF EXISTS view_1_tab4_487 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_487
+DROP VIEW IF EXISTS view_2_tab4_487 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_487
+DROP VIEW IF EXISTS view_3_tab4_487 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22621,13 +22621,13 @@ SELECT pk FROM tab0 WHERE col3 BETWEEN 79 AND 96
 7
 
 statement ok
-DROP VIEW view_1_tab0_488
+DROP VIEW IF EXISTS view_1_tab0_488 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_488
+DROP VIEW IF EXISTS view_2_tab0_488 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_488
+DROP VIEW IF EXISTS view_3_tab0_488 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22734,13 +22734,13 @@ SELECT pk FROM tab1 WHERE col3 BETWEEN 79 AND 96
 7
 
 statement ok
-DROP VIEW view_1_tab1_488
+DROP VIEW IF EXISTS view_1_tab1_488 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_488
+DROP VIEW IF EXISTS view_2_tab1_488 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_488
+DROP VIEW IF EXISTS view_3_tab1_488 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22847,13 +22847,13 @@ SELECT pk FROM tab2 WHERE col3 BETWEEN 79 AND 96
 7
 
 statement ok
-DROP VIEW view_1_tab2_488
+DROP VIEW IF EXISTS view_1_tab2_488 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_488
+DROP VIEW IF EXISTS view_2_tab2_488 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_488
+DROP VIEW IF EXISTS view_3_tab2_488 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22960,13 +22960,13 @@ SELECT pk FROM tab3 WHERE col3 BETWEEN 79 AND 96
 7
 
 statement ok
-DROP VIEW view_1_tab3_488
+DROP VIEW IF EXISTS view_1_tab3_488 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_488
+DROP VIEW IF EXISTS view_2_tab3_488 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_488
+DROP VIEW IF EXISTS view_3_tab3_488 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23073,13 +23073,13 @@ SELECT pk FROM tab4 WHERE col3 BETWEEN 79 AND 96
 7
 
 statement ok
-DROP VIEW view_1_tab4_488
+DROP VIEW IF EXISTS view_1_tab4_488 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_488
+DROP VIEW IF EXISTS view_2_tab4_488 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_488
+DROP VIEW IF EXISTS view_3_tab4_488 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23168,13 +23168,13 @@ SELECT pk FROM tab0 WHERE (col3 > 48 AND (col0 < 43 AND col0 IS NULL OR col3 > 8
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_489
+DROP VIEW IF EXISTS view_1_tab0_489 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_489
+DROP VIEW IF EXISTS view_2_tab0_489 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_489
+DROP VIEW IF EXISTS view_3_tab0_489 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23263,13 +23263,13 @@ SELECT pk FROM tab1 WHERE (col3 > 48 AND (col0 < 43 AND col0 IS NULL OR col3 > 8
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_489
+DROP VIEW IF EXISTS view_1_tab1_489 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_489
+DROP VIEW IF EXISTS view_2_tab1_489 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_489
+DROP VIEW IF EXISTS view_3_tab1_489 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23358,13 +23358,13 @@ SELECT pk FROM tab2 WHERE (col3 > 48 AND (col0 < 43 AND col0 IS NULL OR col3 > 8
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_489
+DROP VIEW IF EXISTS view_1_tab2_489 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_489
+DROP VIEW IF EXISTS view_2_tab2_489 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_489
+DROP VIEW IF EXISTS view_3_tab2_489 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23453,13 +23453,13 @@ SELECT pk FROM tab3 WHERE (col3 > 48 AND (col0 < 43 AND col0 IS NULL OR col3 > 8
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_489
+DROP VIEW IF EXISTS view_1_tab3_489 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_489
+DROP VIEW IF EXISTS view_2_tab3_489 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_489
+DROP VIEW IF EXISTS view_3_tab3_489 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23548,13 +23548,13 @@ SELECT pk FROM tab4 WHERE (col3 > 48 AND (col0 < 43 AND col0 IS NULL OR col3 > 8
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_489
+DROP VIEW IF EXISTS view_1_tab4_489 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_489
+DROP VIEW IF EXISTS view_2_tab4_489 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_489
+DROP VIEW IF EXISTS view_3_tab4_489 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23640,13 +23640,13 @@ SELECT pk FROM tab0 WHERE col3 = 10
 ----
 
 statement ok
-DROP VIEW view_1_tab0_490
+DROP VIEW IF EXISTS view_1_tab0_490 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_490
+DROP VIEW IF EXISTS view_2_tab0_490 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_490
+DROP VIEW IF EXISTS view_3_tab0_490 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23732,13 +23732,13 @@ SELECT pk FROM tab1 WHERE col3 = 10
 ----
 
 statement ok
-DROP VIEW view_1_tab1_490
+DROP VIEW IF EXISTS view_1_tab1_490 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_490
+DROP VIEW IF EXISTS view_2_tab1_490 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_490
+DROP VIEW IF EXISTS view_3_tab1_490 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23824,13 +23824,13 @@ SELECT pk FROM tab2 WHERE col3 = 10
 ----
 
 statement ok
-DROP VIEW view_1_tab2_490
+DROP VIEW IF EXISTS view_1_tab2_490 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_490
+DROP VIEW IF EXISTS view_2_tab2_490 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_490
+DROP VIEW IF EXISTS view_3_tab2_490 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23916,13 +23916,13 @@ SELECT pk FROM tab3 WHERE col3 = 10
 ----
 
 statement ok
-DROP VIEW view_1_tab3_490
+DROP VIEW IF EXISTS view_1_tab3_490 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_490
+DROP VIEW IF EXISTS view_2_tab3_490 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_490
+DROP VIEW IF EXISTS view_3_tab3_490 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24008,13 +24008,13 @@ SELECT pk FROM tab4 WHERE col3 = 10
 ----
 
 statement ok
-DROP VIEW view_1_tab4_490
+DROP VIEW IF EXISTS view_1_tab4_490 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_490
+DROP VIEW IF EXISTS view_2_tab4_490 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_490
+DROP VIEW IF EXISTS view_3_tab4_490 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24134,13 +24134,13 @@ SELECT pk FROM tab0 WHERE col0 >= 35
 9
 
 statement ok
-DROP VIEW view_1_tab0_491
+DROP VIEW IF EXISTS view_1_tab0_491 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_491
+DROP VIEW IF EXISTS view_2_tab0_491 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_491
+DROP VIEW IF EXISTS view_3_tab0_491 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24260,13 +24260,13 @@ SELECT pk FROM tab1 WHERE col0 >= 35
 9
 
 statement ok
-DROP VIEW view_1_tab1_491
+DROP VIEW IF EXISTS view_1_tab1_491 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_491
+DROP VIEW IF EXISTS view_2_tab1_491 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_491
+DROP VIEW IF EXISTS view_3_tab1_491 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24386,13 +24386,13 @@ SELECT pk FROM tab2 WHERE col0 >= 35
 9
 
 statement ok
-DROP VIEW view_1_tab2_491
+DROP VIEW IF EXISTS view_1_tab2_491 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_491
+DROP VIEW IF EXISTS view_2_tab2_491 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_491
+DROP VIEW IF EXISTS view_3_tab2_491 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24512,13 +24512,13 @@ SELECT pk FROM tab3 WHERE col0 >= 35
 9
 
 statement ok
-DROP VIEW view_1_tab3_491
+DROP VIEW IF EXISTS view_1_tab3_491 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_491
+DROP VIEW IF EXISTS view_2_tab3_491 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_491
+DROP VIEW IF EXISTS view_3_tab3_491 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24638,13 +24638,13 @@ SELECT pk FROM tab4 WHERE col0 >= 35
 9
 
 statement ok
-DROP VIEW view_1_tab4_491
+DROP VIEW IF EXISTS view_1_tab4_491 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_491
+DROP VIEW IF EXISTS view_2_tab4_491 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_491
+DROP VIEW IF EXISTS view_3_tab4_491 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24762,13 +24762,13 @@ SELECT pk FROM tab0 WHERE col3 <= 83 OR col0 IS NULL AND col0 < 9
 9
 
 statement ok
-DROP VIEW view_1_tab0_492
+DROP VIEW IF EXISTS view_1_tab0_492 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_492
+DROP VIEW IF EXISTS view_2_tab0_492 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_492
+DROP VIEW IF EXISTS view_3_tab0_492 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24886,13 +24886,13 @@ SELECT pk FROM tab1 WHERE col3 <= 83 OR col0 IS NULL AND col0 < 9
 9
 
 statement ok
-DROP VIEW view_1_tab1_492
+DROP VIEW IF EXISTS view_1_tab1_492 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_492
+DROP VIEW IF EXISTS view_2_tab1_492 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_492
+DROP VIEW IF EXISTS view_3_tab1_492 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25010,13 +25010,13 @@ SELECT pk FROM tab2 WHERE col3 <= 83 OR col0 IS NULL AND col0 < 9
 9
 
 statement ok
-DROP VIEW view_1_tab2_492
+DROP VIEW IF EXISTS view_1_tab2_492 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_492
+DROP VIEW IF EXISTS view_2_tab2_492 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_492
+DROP VIEW IF EXISTS view_3_tab2_492 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25134,13 +25134,13 @@ SELECT pk FROM tab3 WHERE col3 <= 83 OR col0 IS NULL AND col0 < 9
 9
 
 statement ok
-DROP VIEW view_1_tab3_492
+DROP VIEW IF EXISTS view_1_tab3_492 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_492
+DROP VIEW IF EXISTS view_2_tab3_492 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_492
+DROP VIEW IF EXISTS view_3_tab3_492 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25258,13 +25258,13 @@ SELECT pk FROM tab4 WHERE col3 <= 83 OR col0 IS NULL AND col0 < 9
 9
 
 statement ok
-DROP VIEW view_1_tab4_492
+DROP VIEW IF EXISTS view_1_tab4_492 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_492
+DROP VIEW IF EXISTS view_2_tab4_492 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_492
+DROP VIEW IF EXISTS view_3_tab4_492 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25383,13 +25383,13 @@ SELECT pk FROM tab0 WHERE col3 >= 35
 9
 
 statement ok
-DROP VIEW view_1_tab0_493
+DROP VIEW IF EXISTS view_1_tab0_493 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_493
+DROP VIEW IF EXISTS view_2_tab0_493 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_493
+DROP VIEW IF EXISTS view_3_tab0_493 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25508,13 +25508,13 @@ SELECT pk FROM tab1 WHERE col3 >= 35
 9
 
 statement ok
-DROP VIEW view_1_tab1_493
+DROP VIEW IF EXISTS view_1_tab1_493 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_493
+DROP VIEW IF EXISTS view_2_tab1_493 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_493
+DROP VIEW IF EXISTS view_3_tab1_493 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25633,13 +25633,13 @@ SELECT pk FROM tab2 WHERE col3 >= 35
 9
 
 statement ok
-DROP VIEW view_1_tab2_493
+DROP VIEW IF EXISTS view_1_tab2_493 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_493
+DROP VIEW IF EXISTS view_2_tab2_493 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_493
+DROP VIEW IF EXISTS view_3_tab2_493 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25758,13 +25758,13 @@ SELECT pk FROM tab3 WHERE col3 >= 35
 9
 
 statement ok
-DROP VIEW view_1_tab3_493
+DROP VIEW IF EXISTS view_1_tab3_493 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_493
+DROP VIEW IF EXISTS view_2_tab3_493 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_493
+DROP VIEW IF EXISTS view_3_tab3_493 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25883,13 +25883,13 @@ SELECT pk FROM tab4 WHERE col3 >= 35
 9
 
 statement ok
-DROP VIEW view_1_tab4_493
+DROP VIEW IF EXISTS view_1_tab4_493 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_493
+DROP VIEW IF EXISTS view_2_tab4_493 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_493
+DROP VIEW IF EXISTS view_3_tab4_493 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25989,13 +25989,13 @@ SELECT pk FROM tab0 WHERE (col1 > 58.64)
 5
 
 statement ok
-DROP VIEW view_1_tab0_494
+DROP VIEW IF EXISTS view_1_tab0_494 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_494
+DROP VIEW IF EXISTS view_2_tab0_494 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_494
+DROP VIEW IF EXISTS view_3_tab0_494 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26095,13 +26095,13 @@ SELECT pk FROM tab1 WHERE (col1 > 58.64)
 5
 
 statement ok
-DROP VIEW view_1_tab1_494
+DROP VIEW IF EXISTS view_1_tab1_494 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_494
+DROP VIEW IF EXISTS view_2_tab1_494 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_494
+DROP VIEW IF EXISTS view_3_tab1_494 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26201,13 +26201,13 @@ SELECT pk FROM tab2 WHERE (col1 > 58.64)
 5
 
 statement ok
-DROP VIEW view_1_tab2_494
+DROP VIEW IF EXISTS view_1_tab2_494 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_494
+DROP VIEW IF EXISTS view_2_tab2_494 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_494
+DROP VIEW IF EXISTS view_3_tab2_494 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26307,13 +26307,13 @@ SELECT pk FROM tab3 WHERE (col1 > 58.64)
 5
 
 statement ok
-DROP VIEW view_1_tab3_494
+DROP VIEW IF EXISTS view_1_tab3_494 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_494
+DROP VIEW IF EXISTS view_2_tab3_494 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_494
+DROP VIEW IF EXISTS view_3_tab3_494 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26413,13 +26413,13 @@ SELECT pk FROM tab4 WHERE (col1 > 58.64)
 5
 
 statement ok
-DROP VIEW view_1_tab4_494
+DROP VIEW IF EXISTS view_1_tab4_494 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_494
+DROP VIEW IF EXISTS view_2_tab4_494 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_494
+DROP VIEW IF EXISTS view_3_tab4_494 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26522,13 +26522,13 @@ SELECT pk FROM tab0 WHERE col3 <= 41
 9
 
 statement ok
-DROP VIEW view_1_tab0_495
+DROP VIEW IF EXISTS view_1_tab0_495 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_495
+DROP VIEW IF EXISTS view_2_tab0_495 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_495
+DROP VIEW IF EXISTS view_3_tab0_495 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26631,13 +26631,13 @@ SELECT pk FROM tab1 WHERE col3 <= 41
 9
 
 statement ok
-DROP VIEW view_1_tab1_495
+DROP VIEW IF EXISTS view_1_tab1_495 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_495
+DROP VIEW IF EXISTS view_2_tab1_495 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_495
+DROP VIEW IF EXISTS view_3_tab1_495 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26740,13 +26740,13 @@ SELECT pk FROM tab2 WHERE col3 <= 41
 9
 
 statement ok
-DROP VIEW view_1_tab2_495
+DROP VIEW IF EXISTS view_1_tab2_495 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_495
+DROP VIEW IF EXISTS view_2_tab2_495 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_495
+DROP VIEW IF EXISTS view_3_tab2_495 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26849,13 +26849,13 @@ SELECT pk FROM tab3 WHERE col3 <= 41
 9
 
 statement ok
-DROP VIEW view_1_tab3_495
+DROP VIEW IF EXISTS view_1_tab3_495 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_495
+DROP VIEW IF EXISTS view_2_tab3_495 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_495
+DROP VIEW IF EXISTS view_3_tab3_495 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26958,13 +26958,13 @@ SELECT pk FROM tab4 WHERE col3 <= 41
 9
 
 statement ok
-DROP VIEW view_1_tab4_495
+DROP VIEW IF EXISTS view_1_tab4_495 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_495
+DROP VIEW IF EXISTS view_2_tab4_495 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_495
+DROP VIEW IF EXISTS view_3_tab4_495 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27050,13 +27050,13 @@ SELECT pk FROM tab0 WHERE col0 = 56 OR col0 >= 47 AND (((col0 > 62))) AND col3 <
 ----
 
 statement ok
-DROP VIEW view_1_tab0_496
+DROP VIEW IF EXISTS view_1_tab0_496 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_496
+DROP VIEW IF EXISTS view_2_tab0_496 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_496
+DROP VIEW IF EXISTS view_3_tab0_496 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27142,13 +27142,13 @@ SELECT pk FROM tab1 WHERE col0 = 56 OR col0 >= 47 AND (((col0 > 62))) AND col3 <
 ----
 
 statement ok
-DROP VIEW view_1_tab1_496
+DROP VIEW IF EXISTS view_1_tab1_496 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_496
+DROP VIEW IF EXISTS view_2_tab1_496 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_496
+DROP VIEW IF EXISTS view_3_tab1_496 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27234,13 +27234,13 @@ SELECT pk FROM tab2 WHERE col0 = 56 OR col0 >= 47 AND (((col0 > 62))) AND col3 <
 ----
 
 statement ok
-DROP VIEW view_1_tab2_496
+DROP VIEW IF EXISTS view_1_tab2_496 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_496
+DROP VIEW IF EXISTS view_2_tab2_496 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_496
+DROP VIEW IF EXISTS view_3_tab2_496 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27326,13 +27326,13 @@ SELECT pk FROM tab3 WHERE col0 = 56 OR col0 >= 47 AND (((col0 > 62))) AND col3 <
 ----
 
 statement ok
-DROP VIEW view_1_tab3_496
+DROP VIEW IF EXISTS view_1_tab3_496 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_496
+DROP VIEW IF EXISTS view_2_tab3_496 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_496
+DROP VIEW IF EXISTS view_3_tab3_496 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27418,13 +27418,13 @@ SELECT pk FROM tab4 WHERE col0 = 56 OR col0 >= 47 AND (((col0 > 62))) AND col3 <
 ----
 
 statement ok
-DROP VIEW view_1_tab4_496
+DROP VIEW IF EXISTS view_1_tab4_496 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_496
+DROP VIEW IF EXISTS view_2_tab4_496 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_496
+DROP VIEW IF EXISTS view_3_tab4_496 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27531,13 +27531,13 @@ SELECT pk FROM tab0 WHERE col3 <= 35
 8
 
 statement ok
-DROP VIEW view_1_tab0_497
+DROP VIEW IF EXISTS view_1_tab0_497 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_497
+DROP VIEW IF EXISTS view_2_tab0_497 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_497
+DROP VIEW IF EXISTS view_3_tab0_497 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27644,13 +27644,13 @@ SELECT pk FROM tab1 WHERE col3 <= 35
 8
 
 statement ok
-DROP VIEW view_1_tab1_497
+DROP VIEW IF EXISTS view_1_tab1_497 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_497
+DROP VIEW IF EXISTS view_2_tab1_497 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_497
+DROP VIEW IF EXISTS view_3_tab1_497 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27757,13 +27757,13 @@ SELECT pk FROM tab2 WHERE col3 <= 35
 8
 
 statement ok
-DROP VIEW view_1_tab2_497
+DROP VIEW IF EXISTS view_1_tab2_497 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_497
+DROP VIEW IF EXISTS view_2_tab2_497 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_497
+DROP VIEW IF EXISTS view_3_tab2_497 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27870,13 +27870,13 @@ SELECT pk FROM tab3 WHERE col3 <= 35
 8
 
 statement ok
-DROP VIEW view_1_tab3_497
+DROP VIEW IF EXISTS view_1_tab3_497 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_497
+DROP VIEW IF EXISTS view_2_tab3_497 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_497
+DROP VIEW IF EXISTS view_3_tab3_497 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27983,13 +27983,13 @@ SELECT pk FROM tab4 WHERE col3 <= 35
 8
 
 statement ok
-DROP VIEW view_1_tab4_497
+DROP VIEW IF EXISTS view_1_tab4_497 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_497
+DROP VIEW IF EXISTS view_2_tab4_497 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_497
+DROP VIEW IF EXISTS view_3_tab4_497 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28092,13 +28092,13 @@ SELECT pk FROM tab0 WHERE col0 < 42
 8
 
 statement ok
-DROP VIEW view_1_tab0_499
+DROP VIEW IF EXISTS view_1_tab0_499 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_499
+DROP VIEW IF EXISTS view_2_tab0_499 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_499
+DROP VIEW IF EXISTS view_3_tab0_499 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28201,13 +28201,13 @@ SELECT pk FROM tab1 WHERE col0 < 42
 8
 
 statement ok
-DROP VIEW view_1_tab1_499
+DROP VIEW IF EXISTS view_1_tab1_499 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_499
+DROP VIEW IF EXISTS view_2_tab1_499 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_499
+DROP VIEW IF EXISTS view_3_tab1_499 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28310,13 +28310,13 @@ SELECT pk FROM tab2 WHERE col0 < 42
 8
 
 statement ok
-DROP VIEW view_1_tab2_499
+DROP VIEW IF EXISTS view_1_tab2_499 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_499
+DROP VIEW IF EXISTS view_2_tab2_499 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_499
+DROP VIEW IF EXISTS view_3_tab2_499 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28419,13 +28419,13 @@ SELECT pk FROM tab3 WHERE col0 < 42
 8
 
 statement ok
-DROP VIEW view_1_tab3_499
+DROP VIEW IF EXISTS view_1_tab3_499 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_499
+DROP VIEW IF EXISTS view_2_tab3_499 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_499
+DROP VIEW IF EXISTS view_3_tab3_499 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28528,13 +28528,13 @@ SELECT pk FROM tab4 WHERE col0 < 42
 8
 
 statement ok
-DROP VIEW view_1_tab4_499
+DROP VIEW IF EXISTS view_1_tab4_499 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_499
+DROP VIEW IF EXISTS view_2_tab4_499 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_499
+DROP VIEW IF EXISTS view_3_tab4_499 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28627,13 +28627,13 @@ SELECT pk FROM tab0 WHERE col3 >= 17
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab0_501
+DROP VIEW IF EXISTS view_1_tab0_501 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_501
+DROP VIEW IF EXISTS view_2_tab0_501 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_501
+DROP VIEW IF EXISTS view_3_tab0_501 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28726,13 +28726,13 @@ SELECT pk FROM tab1 WHERE col3 >= 17
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab1_501
+DROP VIEW IF EXISTS view_1_tab1_501 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_501
+DROP VIEW IF EXISTS view_2_tab1_501 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_501
+DROP VIEW IF EXISTS view_3_tab1_501 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28825,13 +28825,13 @@ SELECT pk FROM tab2 WHERE col3 >= 17
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab2_501
+DROP VIEW IF EXISTS view_1_tab2_501 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_501
+DROP VIEW IF EXISTS view_2_tab2_501 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_501
+DROP VIEW IF EXISTS view_3_tab2_501 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28924,13 +28924,13 @@ SELECT pk FROM tab3 WHERE col3 >= 17
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab3_501
+DROP VIEW IF EXISTS view_1_tab3_501 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_501
+DROP VIEW IF EXISTS view_2_tab3_501 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_501
+DROP VIEW IF EXISTS view_3_tab3_501 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29023,13 +29023,13 @@ SELECT pk FROM tab4 WHERE col3 >= 17
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab4_501
+DROP VIEW IF EXISTS view_1_tab4_501 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_501
+DROP VIEW IF EXISTS view_2_tab4_501 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_501
+DROP VIEW IF EXISTS view_3_tab4_501 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29136,13 +29136,13 @@ SELECT pk FROM tab0 WHERE col3 > 81
 7
 
 statement ok
-DROP VIEW view_1_tab0_502
+DROP VIEW IF EXISTS view_1_tab0_502 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_502
+DROP VIEW IF EXISTS view_2_tab0_502 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_502
+DROP VIEW IF EXISTS view_3_tab0_502 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29249,13 +29249,13 @@ SELECT pk FROM tab1 WHERE col3 > 81
 7
 
 statement ok
-DROP VIEW view_1_tab1_502
+DROP VIEW IF EXISTS view_1_tab1_502 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_502
+DROP VIEW IF EXISTS view_2_tab1_502 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_502
+DROP VIEW IF EXISTS view_3_tab1_502 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29362,13 +29362,13 @@ SELECT pk FROM tab2 WHERE col3 > 81
 7
 
 statement ok
-DROP VIEW view_1_tab2_502
+DROP VIEW IF EXISTS view_1_tab2_502 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_502
+DROP VIEW IF EXISTS view_2_tab2_502 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_502
+DROP VIEW IF EXISTS view_3_tab2_502 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29475,13 +29475,13 @@ SELECT pk FROM tab3 WHERE col3 > 81
 7
 
 statement ok
-DROP VIEW view_1_tab3_502
+DROP VIEW IF EXISTS view_1_tab3_502 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_502
+DROP VIEW IF EXISTS view_2_tab3_502 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_502
+DROP VIEW IF EXISTS view_3_tab3_502 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29588,13 +29588,13 @@ SELECT pk FROM tab4 WHERE col3 > 81
 7
 
 statement ok
-DROP VIEW view_1_tab4_502
+DROP VIEW IF EXISTS view_1_tab4_502 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_502
+DROP VIEW IF EXISTS view_2_tab4_502 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_502
+DROP VIEW IF EXISTS view_3_tab4_502 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29713,13 +29713,13 @@ SELECT pk FROM tab0 WHERE col1 <= 39.69
 9
 
 statement ok
-DROP VIEW view_1_tab0_503
+DROP VIEW IF EXISTS view_1_tab0_503 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_503
+DROP VIEW IF EXISTS view_2_tab0_503 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_503
+DROP VIEW IF EXISTS view_3_tab0_503 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29838,13 +29838,13 @@ SELECT pk FROM tab1 WHERE col1 <= 39.69
 9
 
 statement ok
-DROP VIEW view_1_tab1_503
+DROP VIEW IF EXISTS view_1_tab1_503 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_503
+DROP VIEW IF EXISTS view_2_tab1_503 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_503
+DROP VIEW IF EXISTS view_3_tab1_503 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29963,13 +29963,13 @@ SELECT pk FROM tab2 WHERE col1 <= 39.69
 9
 
 statement ok
-DROP VIEW view_1_tab2_503
+DROP VIEW IF EXISTS view_1_tab2_503 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_503
+DROP VIEW IF EXISTS view_2_tab2_503 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_503
+DROP VIEW IF EXISTS view_3_tab2_503 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30088,13 +30088,13 @@ SELECT pk FROM tab3 WHERE col1 <= 39.69
 9
 
 statement ok
-DROP VIEW view_1_tab3_503
+DROP VIEW IF EXISTS view_1_tab3_503 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_503
+DROP VIEW IF EXISTS view_2_tab3_503 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_503
+DROP VIEW IF EXISTS view_3_tab3_503 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30213,13 +30213,13 @@ SELECT pk FROM tab4 WHERE col1 <= 39.69
 9
 
 statement ok
-DROP VIEW view_1_tab4_503
+DROP VIEW IF EXISTS view_1_tab4_503 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_503
+DROP VIEW IF EXISTS view_2_tab4_503 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_503
+DROP VIEW IF EXISTS view_3_tab4_503 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30308,13 +30308,13 @@ SELECT pk FROM tab0 WHERE col3 < 99
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_504
+DROP VIEW IF EXISTS view_1_tab0_504 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_504
+DROP VIEW IF EXISTS view_2_tab0_504 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_504
+DROP VIEW IF EXISTS view_3_tab0_504 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30403,13 +30403,13 @@ SELECT pk FROM tab1 WHERE col3 < 99
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_504
+DROP VIEW IF EXISTS view_1_tab1_504 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_504
+DROP VIEW IF EXISTS view_2_tab1_504 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_504
+DROP VIEW IF EXISTS view_3_tab1_504 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30498,13 +30498,13 @@ SELECT pk FROM tab2 WHERE col3 < 99
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_504
+DROP VIEW IF EXISTS view_1_tab2_504 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_504
+DROP VIEW IF EXISTS view_2_tab2_504 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_504
+DROP VIEW IF EXISTS view_3_tab2_504 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30593,13 +30593,13 @@ SELECT pk FROM tab3 WHERE col3 < 99
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_504
+DROP VIEW IF EXISTS view_1_tab3_504 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_504
+DROP VIEW IF EXISTS view_2_tab3_504 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_504
+DROP VIEW IF EXISTS view_3_tab3_504 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30688,13 +30688,13 @@ SELECT pk FROM tab4 WHERE col3 < 99
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_504
+DROP VIEW IF EXISTS view_1_tab4_504 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_504
+DROP VIEW IF EXISTS view_2_tab4_504 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_504
+DROP VIEW IF EXISTS view_3_tab4_504 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30780,13 +30780,13 @@ SELECT pk FROM tab0 WHERE col0 >= 23 AND (col1 = 69.86)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_505
+DROP VIEW IF EXISTS view_1_tab0_505 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_505
+DROP VIEW IF EXISTS view_2_tab0_505 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_505
+DROP VIEW IF EXISTS view_3_tab0_505 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30872,13 +30872,13 @@ SELECT pk FROM tab1 WHERE col0 >= 23 AND (col1 = 69.86)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_505
+DROP VIEW IF EXISTS view_1_tab1_505 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_505
+DROP VIEW IF EXISTS view_2_tab1_505 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_505
+DROP VIEW IF EXISTS view_3_tab1_505 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30964,13 +30964,13 @@ SELECT pk FROM tab2 WHERE col0 >= 23 AND (col1 = 69.86)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_505
+DROP VIEW IF EXISTS view_1_tab2_505 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_505
+DROP VIEW IF EXISTS view_2_tab2_505 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_505
+DROP VIEW IF EXISTS view_3_tab2_505 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31056,13 +31056,13 @@ SELECT pk FROM tab3 WHERE col0 >= 23 AND (col1 = 69.86)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_505
+DROP VIEW IF EXISTS view_1_tab3_505 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_505
+DROP VIEW IF EXISTS view_2_tab3_505 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_505
+DROP VIEW IF EXISTS view_3_tab3_505 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31148,13 +31148,13 @@ SELECT pk FROM tab4 WHERE col0 >= 23 AND (col1 = 69.86)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_505
+DROP VIEW IF EXISTS view_1_tab4_505 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_505
+DROP VIEW IF EXISTS view_2_tab4_505 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_505
+DROP VIEW IF EXISTS view_3_tab4_505 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31261,13 +31261,13 @@ SELECT pk FROM tab0 WHERE col0 > 16 AND (col4 > 55.94)
 8
 
 statement ok
-DROP VIEW view_1_tab0_506
+DROP VIEW IF EXISTS view_1_tab0_506 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_506
+DROP VIEW IF EXISTS view_2_tab0_506 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_506
+DROP VIEW IF EXISTS view_3_tab0_506 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31374,13 +31374,13 @@ SELECT pk FROM tab1 WHERE col0 > 16 AND (col4 > 55.94)
 8
 
 statement ok
-DROP VIEW view_1_tab1_506
+DROP VIEW IF EXISTS view_1_tab1_506 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_506
+DROP VIEW IF EXISTS view_2_tab1_506 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_506
+DROP VIEW IF EXISTS view_3_tab1_506 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31487,13 +31487,13 @@ SELECT pk FROM tab2 WHERE col0 > 16 AND (col4 > 55.94)
 8
 
 statement ok
-DROP VIEW view_1_tab2_506
+DROP VIEW IF EXISTS view_1_tab2_506 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_506
+DROP VIEW IF EXISTS view_2_tab2_506 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_506
+DROP VIEW IF EXISTS view_3_tab2_506 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31600,13 +31600,13 @@ SELECT pk FROM tab3 WHERE col0 > 16 AND (col4 > 55.94)
 8
 
 statement ok
-DROP VIEW view_1_tab3_506
+DROP VIEW IF EXISTS view_1_tab3_506 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_506
+DROP VIEW IF EXISTS view_2_tab3_506 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_506
+DROP VIEW IF EXISTS view_3_tab3_506 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31713,13 +31713,13 @@ SELECT pk FROM tab4 WHERE col0 > 16 AND (col4 > 55.94)
 8
 
 statement ok
-DROP VIEW view_1_tab4_506
+DROP VIEW IF EXISTS view_1_tab4_506 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_506
+DROP VIEW IF EXISTS view_2_tab4_506 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_506
+DROP VIEW IF EXISTS view_3_tab4_506 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31808,13 +31808,13 @@ SELECT pk FROM tab0 WHERE col0 >= 5 OR col0 BETWEEN 94 AND 34 OR col0 > 41 AND (
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_507
+DROP VIEW IF EXISTS view_1_tab0_507 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_507
+DROP VIEW IF EXISTS view_2_tab0_507 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_507
+DROP VIEW IF EXISTS view_3_tab0_507 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31903,13 +31903,13 @@ SELECT pk FROM tab1 WHERE col0 >= 5 OR col0 BETWEEN 94 AND 34 OR col0 > 41 AND (
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_507
+DROP VIEW IF EXISTS view_1_tab1_507 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_507
+DROP VIEW IF EXISTS view_2_tab1_507 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_507
+DROP VIEW IF EXISTS view_3_tab1_507 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31998,13 +31998,13 @@ SELECT pk FROM tab2 WHERE col0 >= 5 OR col0 BETWEEN 94 AND 34 OR col0 > 41 AND (
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_507
+DROP VIEW IF EXISTS view_1_tab2_507 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_507
+DROP VIEW IF EXISTS view_2_tab2_507 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_507
+DROP VIEW IF EXISTS view_3_tab2_507 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32093,13 +32093,13 @@ SELECT pk FROM tab3 WHERE col0 >= 5 OR col0 BETWEEN 94 AND 34 OR col0 > 41 AND (
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_507
+DROP VIEW IF EXISTS view_1_tab3_507 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_507
+DROP VIEW IF EXISTS view_2_tab3_507 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_507
+DROP VIEW IF EXISTS view_3_tab3_507 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32188,13 +32188,13 @@ SELECT pk FROM tab4 WHERE col0 >= 5 OR col0 BETWEEN 94 AND 34 OR col0 > 41 AND (
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_507
+DROP VIEW IF EXISTS view_1_tab4_507 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_507
+DROP VIEW IF EXISTS view_2_tab4_507 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_507
+DROP VIEW IF EXISTS view_3_tab4_507 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32280,13 +32280,13 @@ SELECT pk FROM tab0 WHERE ((((col0 > 91 OR col1 > 30.39) OR (col3 > 59)) AND col
 ----
 
 statement ok
-DROP VIEW view_1_tab0_508
+DROP VIEW IF EXISTS view_1_tab0_508 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_508
+DROP VIEW IF EXISTS view_2_tab0_508 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_508
+DROP VIEW IF EXISTS view_3_tab0_508 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32372,13 +32372,13 @@ SELECT pk FROM tab1 WHERE ((((col0 > 91 OR col1 > 30.39) OR (col3 > 59)) AND col
 ----
 
 statement ok
-DROP VIEW view_1_tab1_508
+DROP VIEW IF EXISTS view_1_tab1_508 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_508
+DROP VIEW IF EXISTS view_2_tab1_508 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_508
+DROP VIEW IF EXISTS view_3_tab1_508 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32464,13 +32464,13 @@ SELECT pk FROM tab2 WHERE ((((col0 > 91 OR col1 > 30.39) OR (col3 > 59)) AND col
 ----
 
 statement ok
-DROP VIEW view_1_tab2_508
+DROP VIEW IF EXISTS view_1_tab2_508 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_508
+DROP VIEW IF EXISTS view_2_tab2_508 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_508
+DROP VIEW IF EXISTS view_3_tab2_508 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32556,13 +32556,13 @@ SELECT pk FROM tab3 WHERE ((((col0 > 91 OR col1 > 30.39) OR (col3 > 59)) AND col
 ----
 
 statement ok
-DROP VIEW view_1_tab3_508
+DROP VIEW IF EXISTS view_1_tab3_508 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_508
+DROP VIEW IF EXISTS view_2_tab3_508 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_508
+DROP VIEW IF EXISTS view_3_tab3_508 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32648,13 +32648,13 @@ SELECT pk FROM tab4 WHERE ((((col0 > 91 OR col1 > 30.39) OR (col3 > 59)) AND col
 ----
 
 statement ok
-DROP VIEW view_1_tab4_508
+DROP VIEW IF EXISTS view_1_tab4_508 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_508
+DROP VIEW IF EXISTS view_2_tab4_508 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_508
+DROP VIEW IF EXISTS view_3_tab4_508 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32740,13 +32740,13 @@ SELECT pk FROM tab0 WHERE col0 = 49 AND (col0 < 48) AND col3 > 94 OR col3 IS NUL
 ----
 
 statement ok
-DROP VIEW view_1_tab0_509
+DROP VIEW IF EXISTS view_1_tab0_509 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_509
+DROP VIEW IF EXISTS view_2_tab0_509 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_509
+DROP VIEW IF EXISTS view_3_tab0_509 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32832,13 +32832,13 @@ SELECT pk FROM tab1 WHERE col0 = 49 AND (col0 < 48) AND col3 > 94 OR col3 IS NUL
 ----
 
 statement ok
-DROP VIEW view_1_tab1_509
+DROP VIEW IF EXISTS view_1_tab1_509 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_509
+DROP VIEW IF EXISTS view_2_tab1_509 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_509
+DROP VIEW IF EXISTS view_3_tab1_509 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32924,13 +32924,13 @@ SELECT pk FROM tab2 WHERE col0 = 49 AND (col0 < 48) AND col3 > 94 OR col3 IS NUL
 ----
 
 statement ok
-DROP VIEW view_1_tab2_509
+DROP VIEW IF EXISTS view_1_tab2_509 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_509
+DROP VIEW IF EXISTS view_2_tab2_509 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_509
+DROP VIEW IF EXISTS view_3_tab2_509 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33016,13 +33016,13 @@ SELECT pk FROM tab3 WHERE col0 = 49 AND (col0 < 48) AND col3 > 94 OR col3 IS NUL
 ----
 
 statement ok
-DROP VIEW view_1_tab3_509
+DROP VIEW IF EXISTS view_1_tab3_509 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_509
+DROP VIEW IF EXISTS view_2_tab3_509 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_509
+DROP VIEW IF EXISTS view_3_tab3_509 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33108,13 +33108,13 @@ SELECT pk FROM tab4 WHERE col0 = 49 AND (col0 < 48) AND col3 > 94 OR col3 IS NUL
 ----
 
 statement ok
-DROP VIEW view_1_tab4_509
+DROP VIEW IF EXISTS view_1_tab4_509 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_509
+DROP VIEW IF EXISTS view_2_tab4_509 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_509
+DROP VIEW IF EXISTS view_3_tab4_509 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33200,13 +33200,13 @@ SELECT pk FROM tab0 WHERE col0 > 70 OR col1 BETWEEN 55.19 AND 13.87
 ----
 
 statement ok
-DROP VIEW view_1_tab0_510
+DROP VIEW IF EXISTS view_1_tab0_510 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_510
+DROP VIEW IF EXISTS view_2_tab0_510 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_510
+DROP VIEW IF EXISTS view_3_tab0_510 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33292,13 +33292,13 @@ SELECT pk FROM tab1 WHERE col0 > 70 OR col1 BETWEEN 55.19 AND 13.87
 ----
 
 statement ok
-DROP VIEW view_1_tab1_510
+DROP VIEW IF EXISTS view_1_tab1_510 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_510
+DROP VIEW IF EXISTS view_2_tab1_510 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_510
+DROP VIEW IF EXISTS view_3_tab1_510 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33384,13 +33384,13 @@ SELECT pk FROM tab2 WHERE col0 > 70 OR col1 BETWEEN 55.19 AND 13.87
 ----
 
 statement ok
-DROP VIEW view_1_tab2_510
+DROP VIEW IF EXISTS view_1_tab2_510 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_510
+DROP VIEW IF EXISTS view_2_tab2_510 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_510
+DROP VIEW IF EXISTS view_3_tab2_510 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33476,13 +33476,13 @@ SELECT pk FROM tab3 WHERE col0 > 70 OR col1 BETWEEN 55.19 AND 13.87
 ----
 
 statement ok
-DROP VIEW view_1_tab3_510
+DROP VIEW IF EXISTS view_1_tab3_510 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_510
+DROP VIEW IF EXISTS view_2_tab3_510 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_510
+DROP VIEW IF EXISTS view_3_tab3_510 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33568,13 +33568,13 @@ SELECT pk FROM tab4 WHERE col0 > 70 OR col1 BETWEEN 55.19 AND 13.87
 ----
 
 statement ok
-DROP VIEW view_1_tab4_510
+DROP VIEW IF EXISTS view_1_tab4_510 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_510
+DROP VIEW IF EXISTS view_2_tab4_510 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_510
+DROP VIEW IF EXISTS view_3_tab4_510 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33660,13 +33660,13 @@ SELECT pk FROM tab0 WHERE col0 > 73
 ----
 
 statement ok
-DROP VIEW view_1_tab0_511
+DROP VIEW IF EXISTS view_1_tab0_511 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_511
+DROP VIEW IF EXISTS view_2_tab0_511 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_511
+DROP VIEW IF EXISTS view_3_tab0_511 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33752,13 +33752,13 @@ SELECT pk FROM tab1 WHERE col0 > 73
 ----
 
 statement ok
-DROP VIEW view_1_tab1_511
+DROP VIEW IF EXISTS view_1_tab1_511 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_511
+DROP VIEW IF EXISTS view_2_tab1_511 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_511
+DROP VIEW IF EXISTS view_3_tab1_511 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33844,13 +33844,13 @@ SELECT pk FROM tab2 WHERE col0 > 73
 ----
 
 statement ok
-DROP VIEW view_1_tab2_511
+DROP VIEW IF EXISTS view_1_tab2_511 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_511
+DROP VIEW IF EXISTS view_2_tab2_511 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_511
+DROP VIEW IF EXISTS view_3_tab2_511 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33936,13 +33936,13 @@ SELECT pk FROM tab3 WHERE col0 > 73
 ----
 
 statement ok
-DROP VIEW view_1_tab3_511
+DROP VIEW IF EXISTS view_1_tab3_511 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_511
+DROP VIEW IF EXISTS view_2_tab3_511 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_511
+DROP VIEW IF EXISTS view_3_tab3_511 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34028,13 +34028,13 @@ SELECT pk FROM tab4 WHERE col0 > 73
 ----
 
 statement ok
-DROP VIEW view_1_tab4_511
+DROP VIEW IF EXISTS view_1_tab4_511 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_511
+DROP VIEW IF EXISTS view_2_tab4_511 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_511
+DROP VIEW IF EXISTS view_3_tab4_511 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34154,13 +34154,13 @@ SELECT pk FROM tab0 WHERE col3 <= 50
 9
 
 statement ok
-DROP VIEW view_1_tab0_512
+DROP VIEW IF EXISTS view_1_tab0_512 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_512
+DROP VIEW IF EXISTS view_2_tab0_512 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_512
+DROP VIEW IF EXISTS view_3_tab0_512 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34280,13 +34280,13 @@ SELECT pk FROM tab1 WHERE col3 <= 50
 9
 
 statement ok
-DROP VIEW view_1_tab1_512
+DROP VIEW IF EXISTS view_1_tab1_512 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_512
+DROP VIEW IF EXISTS view_2_tab1_512 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_512
+DROP VIEW IF EXISTS view_3_tab1_512 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34406,13 +34406,13 @@ SELECT pk FROM tab2 WHERE col3 <= 50
 9
 
 statement ok
-DROP VIEW view_1_tab2_512
+DROP VIEW IF EXISTS view_1_tab2_512 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_512
+DROP VIEW IF EXISTS view_2_tab2_512 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_512
+DROP VIEW IF EXISTS view_3_tab2_512 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34532,13 +34532,13 @@ SELECT pk FROM tab3 WHERE col3 <= 50
 9
 
 statement ok
-DROP VIEW view_1_tab3_512
+DROP VIEW IF EXISTS view_1_tab3_512 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_512
+DROP VIEW IF EXISTS view_2_tab3_512 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_512
+DROP VIEW IF EXISTS view_3_tab3_512 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34658,13 +34658,13 @@ SELECT pk FROM tab4 WHERE col3 <= 50
 9
 
 statement ok
-DROP VIEW view_1_tab4_512
+DROP VIEW IF EXISTS view_1_tab4_512 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_512
+DROP VIEW IF EXISTS view_2_tab4_512 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_512
+DROP VIEW IF EXISTS view_3_tab4_512 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34782,13 +34782,13 @@ SELECT pk FROM tab0 WHERE col1 < 51.81 AND (col3 < 48 OR col0 >= 67 AND col0 = 9
 9
 
 statement ok
-DROP VIEW view_1_tab0_513
+DROP VIEW IF EXISTS view_1_tab0_513 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_513
+DROP VIEW IF EXISTS view_2_tab0_513 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_513
+DROP VIEW IF EXISTS view_3_tab0_513 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34906,13 +34906,13 @@ SELECT pk FROM tab1 WHERE col1 < 51.81 AND (col3 < 48 OR col0 >= 67 AND col0 = 9
 9
 
 statement ok
-DROP VIEW view_1_tab1_513
+DROP VIEW IF EXISTS view_1_tab1_513 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_513
+DROP VIEW IF EXISTS view_2_tab1_513 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_513
+DROP VIEW IF EXISTS view_3_tab1_513 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35030,13 +35030,13 @@ SELECT pk FROM tab2 WHERE col1 < 51.81 AND (col3 < 48 OR col0 >= 67 AND col0 = 9
 9
 
 statement ok
-DROP VIEW view_1_tab2_513
+DROP VIEW IF EXISTS view_1_tab2_513 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_513
+DROP VIEW IF EXISTS view_2_tab2_513 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_513
+DROP VIEW IF EXISTS view_3_tab2_513 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35154,13 +35154,13 @@ SELECT pk FROM tab3 WHERE col1 < 51.81 AND (col3 < 48 OR col0 >= 67 AND col0 = 9
 9
 
 statement ok
-DROP VIEW view_1_tab3_513
+DROP VIEW IF EXISTS view_1_tab3_513 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_513
+DROP VIEW IF EXISTS view_2_tab3_513 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_513
+DROP VIEW IF EXISTS view_3_tab3_513 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35278,13 +35278,13 @@ SELECT pk FROM tab4 WHERE col1 < 51.81 AND (col3 < 48 OR col0 >= 67 AND col0 = 9
 9
 
 statement ok
-DROP VIEW view_1_tab4_513
+DROP VIEW IF EXISTS view_1_tab4_513 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_513
+DROP VIEW IF EXISTS view_2_tab4_513 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_513
+DROP VIEW IF EXISTS view_3_tab4_513 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35373,13 +35373,13 @@ SELECT pk FROM tab0 WHERE (col0 <= 89)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_514
+DROP VIEW IF EXISTS view_1_tab0_514 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_514
+DROP VIEW IF EXISTS view_2_tab0_514 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_514
+DROP VIEW IF EXISTS view_3_tab0_514 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35468,13 +35468,13 @@ SELECT pk FROM tab1 WHERE (col0 <= 89)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_514
+DROP VIEW IF EXISTS view_1_tab1_514 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_514
+DROP VIEW IF EXISTS view_2_tab1_514 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_514
+DROP VIEW IF EXISTS view_3_tab1_514 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35563,13 +35563,13 @@ SELECT pk FROM tab2 WHERE (col0 <= 89)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_514
+DROP VIEW IF EXISTS view_1_tab2_514 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_514
+DROP VIEW IF EXISTS view_2_tab2_514 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_514
+DROP VIEW IF EXISTS view_3_tab2_514 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35658,13 +35658,13 @@ SELECT pk FROM tab3 WHERE (col0 <= 89)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_514
+DROP VIEW IF EXISTS view_1_tab3_514 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_514
+DROP VIEW IF EXISTS view_2_tab3_514 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_514
+DROP VIEW IF EXISTS view_3_tab3_514 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35753,13 +35753,13 @@ SELECT pk FROM tab4 WHERE (col0 <= 89)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_514
+DROP VIEW IF EXISTS view_1_tab4_514 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_514
+DROP VIEW IF EXISTS view_2_tab4_514 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_514
+DROP VIEW IF EXISTS view_3_tab4_514 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35852,13 +35852,13 @@ SELECT pk FROM tab0 WHERE col3 > 20
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab0_515
+DROP VIEW IF EXISTS view_1_tab0_515 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_515
+DROP VIEW IF EXISTS view_2_tab0_515 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_515
+DROP VIEW IF EXISTS view_3_tab0_515 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35951,13 +35951,13 @@ SELECT pk FROM tab1 WHERE col3 > 20
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab1_515
+DROP VIEW IF EXISTS view_1_tab1_515 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_515
+DROP VIEW IF EXISTS view_2_tab1_515 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_515
+DROP VIEW IF EXISTS view_3_tab1_515 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36050,13 +36050,13 @@ SELECT pk FROM tab2 WHERE col3 > 20
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab2_515
+DROP VIEW IF EXISTS view_1_tab2_515 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_515
+DROP VIEW IF EXISTS view_2_tab2_515 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_515
+DROP VIEW IF EXISTS view_3_tab2_515 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36149,13 +36149,13 @@ SELECT pk FROM tab3 WHERE col3 > 20
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab3_515
+DROP VIEW IF EXISTS view_1_tab3_515 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_515
+DROP VIEW IF EXISTS view_2_tab3_515 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_515
+DROP VIEW IF EXISTS view_3_tab3_515 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36248,13 +36248,13 @@ SELECT pk FROM tab4 WHERE col3 > 20
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab4_515
+DROP VIEW IF EXISTS view_1_tab4_515 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_515
+DROP VIEW IF EXISTS view_2_tab4_515 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_515
+DROP VIEW IF EXISTS view_3_tab4_515 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36354,13 +36354,13 @@ SELECT pk FROM tab0 WHERE (col3 < 29)
 5
 
 statement ok
-DROP VIEW view_1_tab0_516
+DROP VIEW IF EXISTS view_1_tab0_516 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_516
+DROP VIEW IF EXISTS view_2_tab0_516 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_516
+DROP VIEW IF EXISTS view_3_tab0_516 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36460,13 +36460,13 @@ SELECT pk FROM tab1 WHERE (col3 < 29)
 5
 
 statement ok
-DROP VIEW view_1_tab1_516
+DROP VIEW IF EXISTS view_1_tab1_516 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_516
+DROP VIEW IF EXISTS view_2_tab1_516 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_516
+DROP VIEW IF EXISTS view_3_tab1_516 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36566,13 +36566,13 @@ SELECT pk FROM tab2 WHERE (col3 < 29)
 5
 
 statement ok
-DROP VIEW view_1_tab2_516
+DROP VIEW IF EXISTS view_1_tab2_516 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_516
+DROP VIEW IF EXISTS view_2_tab2_516 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_516
+DROP VIEW IF EXISTS view_3_tab2_516 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36672,13 +36672,13 @@ SELECT pk FROM tab3 WHERE (col3 < 29)
 5
 
 statement ok
-DROP VIEW view_1_tab3_516
+DROP VIEW IF EXISTS view_1_tab3_516 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_516
+DROP VIEW IF EXISTS view_2_tab3_516 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_516
+DROP VIEW IF EXISTS view_3_tab3_516 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36778,13 +36778,13 @@ SELECT pk FROM tab4 WHERE (col3 < 29)
 5
 
 statement ok
-DROP VIEW view_1_tab4_516
+DROP VIEW IF EXISTS view_1_tab4_516 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_516
+DROP VIEW IF EXISTS view_2_tab4_516 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_516
+DROP VIEW IF EXISTS view_3_tab4_516 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36873,13 +36873,13 @@ SELECT pk FROM tab0 WHERE (((((col0 >= 21 OR ((((((col0 > 27) AND ((col0 = 24)) 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_517
+DROP VIEW IF EXISTS view_1_tab0_517 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_517
+DROP VIEW IF EXISTS view_2_tab0_517 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_517
+DROP VIEW IF EXISTS view_3_tab0_517 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36968,13 +36968,13 @@ SELECT pk FROM tab1 WHERE (((((col0 >= 21 OR ((((((col0 > 27) AND ((col0 = 24)) 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_517
+DROP VIEW IF EXISTS view_1_tab1_517 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_517
+DROP VIEW IF EXISTS view_2_tab1_517 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_517
+DROP VIEW IF EXISTS view_3_tab1_517 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37063,13 +37063,13 @@ SELECT pk FROM tab2 WHERE (((((col0 >= 21 OR ((((((col0 > 27) AND ((col0 = 24)) 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_517
+DROP VIEW IF EXISTS view_1_tab2_517 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_517
+DROP VIEW IF EXISTS view_2_tab2_517 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_517
+DROP VIEW IF EXISTS view_3_tab2_517 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37158,13 +37158,13 @@ SELECT pk FROM tab3 WHERE (((((col0 >= 21 OR ((((((col0 > 27) AND ((col0 = 24)) 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_517
+DROP VIEW IF EXISTS view_1_tab3_517 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_517
+DROP VIEW IF EXISTS view_2_tab3_517 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_517
+DROP VIEW IF EXISTS view_3_tab3_517 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37253,13 +37253,13 @@ SELECT pk FROM tab4 WHERE (((((col0 >= 21 OR ((((((col0 > 27) AND ((col0 = 24)) 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_517
+DROP VIEW IF EXISTS view_1_tab4_517 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_517
+DROP VIEW IF EXISTS view_2_tab4_517 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_517
+DROP VIEW IF EXISTS view_3_tab4_517 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37366,13 +37366,13 @@ SELECT pk FROM tab0 WHERE ((col3 IN (17)) OR col0 IS NULL AND (col0 >= 26 OR col
 7
 
 statement ok
-DROP VIEW view_1_tab0_518
+DROP VIEW IF EXISTS view_1_tab0_518 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_518
+DROP VIEW IF EXISTS view_2_tab0_518 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_518
+DROP VIEW IF EXISTS view_3_tab0_518 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37479,13 +37479,13 @@ SELECT pk FROM tab1 WHERE ((col3 IN (17)) OR col0 IS NULL AND (col0 >= 26 OR col
 7
 
 statement ok
-DROP VIEW view_1_tab1_518
+DROP VIEW IF EXISTS view_1_tab1_518 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_518
+DROP VIEW IF EXISTS view_2_tab1_518 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_518
+DROP VIEW IF EXISTS view_3_tab1_518 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37592,13 +37592,13 @@ SELECT pk FROM tab2 WHERE ((col3 IN (17)) OR col0 IS NULL AND (col0 >= 26 OR col
 7
 
 statement ok
-DROP VIEW view_1_tab2_518
+DROP VIEW IF EXISTS view_1_tab2_518 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_518
+DROP VIEW IF EXISTS view_2_tab2_518 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_518
+DROP VIEW IF EXISTS view_3_tab2_518 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37705,13 +37705,13 @@ SELECT pk FROM tab3 WHERE ((col3 IN (17)) OR col0 IS NULL AND (col0 >= 26 OR col
 7
 
 statement ok
-DROP VIEW view_1_tab3_518
+DROP VIEW IF EXISTS view_1_tab3_518 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_518
+DROP VIEW IF EXISTS view_2_tab3_518 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_518
+DROP VIEW IF EXISTS view_3_tab3_518 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37818,13 +37818,13 @@ SELECT pk FROM tab4 WHERE ((col3 IN (17)) OR col0 IS NULL AND (col0 >= 26 OR col
 7
 
 statement ok
-DROP VIEW view_1_tab4_518
+DROP VIEW IF EXISTS view_1_tab4_518 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_518
+DROP VIEW IF EXISTS view_2_tab4_518 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_518
+DROP VIEW IF EXISTS view_3_tab4_518 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37913,13 +37913,13 @@ SELECT pk FROM tab0 WHERE (((col0 >= 39) OR (col1 < 88.77) AND (((col1 <= 79.45)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_519
+DROP VIEW IF EXISTS view_1_tab0_519 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_519
+DROP VIEW IF EXISTS view_2_tab0_519 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_519
+DROP VIEW IF EXISTS view_3_tab0_519 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -38008,13 +38008,13 @@ SELECT pk FROM tab1 WHERE (((col0 >= 39) OR (col1 < 88.77) AND (((col1 <= 79.45)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_519
+DROP VIEW IF EXISTS view_1_tab1_519 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_519
+DROP VIEW IF EXISTS view_2_tab1_519 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_519
+DROP VIEW IF EXISTS view_3_tab1_519 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -38103,13 +38103,13 @@ SELECT pk FROM tab2 WHERE (((col0 >= 39) OR (col1 < 88.77) AND (((col1 <= 79.45)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_519
+DROP VIEW IF EXISTS view_1_tab2_519 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_519
+DROP VIEW IF EXISTS view_2_tab2_519 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_519
+DROP VIEW IF EXISTS view_3_tab2_519 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -38198,13 +38198,13 @@ SELECT pk FROM tab3 WHERE (((col0 >= 39) OR (col1 < 88.77) AND (((col1 <= 79.45)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_519
+DROP VIEW IF EXISTS view_1_tab3_519 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_519
+DROP VIEW IF EXISTS view_2_tab3_519 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_519
+DROP VIEW IF EXISTS view_3_tab3_519 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -38293,13 +38293,13 @@ SELECT pk FROM tab4 WHERE (((col0 >= 39) OR (col1 < 88.77) AND (((col1 <= 79.45)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_519
+DROP VIEW IF EXISTS view_1_tab4_519 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_519
+DROP VIEW IF EXISTS view_2_tab4_519 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_519
+DROP VIEW IF EXISTS view_3_tab4_519 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -38385,13 +38385,13 @@ SELECT pk FROM tab0 WHERE (col3 < 63 AND col3 = 71 OR (col0 <= 3))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_520
+DROP VIEW IF EXISTS view_1_tab0_520 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_520
+DROP VIEW IF EXISTS view_2_tab0_520 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_520
+DROP VIEW IF EXISTS view_3_tab0_520 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -38477,13 +38477,13 @@ SELECT pk FROM tab1 WHERE (col3 < 63 AND col3 = 71 OR (col0 <= 3))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_520
+DROP VIEW IF EXISTS view_1_tab1_520 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_520
+DROP VIEW IF EXISTS view_2_tab1_520 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_520
+DROP VIEW IF EXISTS view_3_tab1_520 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -38569,13 +38569,13 @@ SELECT pk FROM tab2 WHERE (col3 < 63 AND col3 = 71 OR (col0 <= 3))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_520
+DROP VIEW IF EXISTS view_1_tab2_520 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_520
+DROP VIEW IF EXISTS view_2_tab2_520 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_520
+DROP VIEW IF EXISTS view_3_tab2_520 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -38661,13 +38661,13 @@ SELECT pk FROM tab3 WHERE (col3 < 63 AND col3 = 71 OR (col0 <= 3))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_520
+DROP VIEW IF EXISTS view_1_tab3_520 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_520
+DROP VIEW IF EXISTS view_2_tab3_520 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_520
+DROP VIEW IF EXISTS view_3_tab3_520 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -38753,11 +38753,11 @@ SELECT pk FROM tab4 WHERE (col3 < 63 AND col3 = 71 OR (col0 <= 3))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_520
+DROP VIEW IF EXISTS view_1_tab4_520 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_520
+DROP VIEW IF EXISTS view_2_tab4_520 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_520
+DROP VIEW IF EXISTS view_3_tab4_520 CASCADE
 

--- a/test/index/view/10/slt_good_5.test
+++ b/test/index/view/10/slt_good_5.test
@@ -230,13 +230,13 @@ SELECT pk FROM tab0 WHERE ((col0 <= 62))
 9
 
 statement ok
-DROP VIEW view_1_tab0_660
+DROP VIEW IF EXISTS view_1_tab0_660 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_660
+DROP VIEW IF EXISTS view_2_tab0_660 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_660
+DROP VIEW IF EXISTS view_3_tab0_660 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -354,13 +354,13 @@ SELECT pk FROM tab1 WHERE ((col0 <= 62))
 9
 
 statement ok
-DROP VIEW view_1_tab1_660
+DROP VIEW IF EXISTS view_1_tab1_660 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_660
+DROP VIEW IF EXISTS view_2_tab1_660 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_660
+DROP VIEW IF EXISTS view_3_tab1_660 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -478,13 +478,13 @@ SELECT pk FROM tab2 WHERE ((col0 <= 62))
 9
 
 statement ok
-DROP VIEW view_1_tab2_660
+DROP VIEW IF EXISTS view_1_tab2_660 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_660
+DROP VIEW IF EXISTS view_2_tab2_660 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_660
+DROP VIEW IF EXISTS view_3_tab2_660 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -602,13 +602,13 @@ SELECT pk FROM tab3 WHERE ((col0 <= 62))
 9
 
 statement ok
-DROP VIEW view_1_tab3_660
+DROP VIEW IF EXISTS view_1_tab3_660 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_660
+DROP VIEW IF EXISTS view_2_tab3_660 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_660
+DROP VIEW IF EXISTS view_3_tab3_660 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -726,13 +726,13 @@ SELECT pk FROM tab4 WHERE ((col0 <= 62))
 9
 
 statement ok
-DROP VIEW view_1_tab4_660
+DROP VIEW IF EXISTS view_1_tab4_660 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_660
+DROP VIEW IF EXISTS view_2_tab4_660 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_660
+DROP VIEW IF EXISTS view_3_tab4_660 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -839,13 +839,13 @@ SELECT pk FROM tab0 WHERE col0 < 47 AND col0 >= 59 AND col3 > 28 AND col0 < 26 A
 3
 
 statement ok
-DROP VIEW view_1_tab0_661
+DROP VIEW IF EXISTS view_1_tab0_661 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_661
+DROP VIEW IF EXISTS view_2_tab0_661 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_661
+DROP VIEW IF EXISTS view_3_tab0_661 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -952,13 +952,13 @@ SELECT pk FROM tab1 WHERE col0 < 47 AND col0 >= 59 AND col3 > 28 AND col0 < 26 A
 3
 
 statement ok
-DROP VIEW view_1_tab1_661
+DROP VIEW IF EXISTS view_1_tab1_661 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_661
+DROP VIEW IF EXISTS view_2_tab1_661 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_661
+DROP VIEW IF EXISTS view_3_tab1_661 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1065,13 +1065,13 @@ SELECT pk FROM tab2 WHERE col0 < 47 AND col0 >= 59 AND col3 > 28 AND col0 < 26 A
 3
 
 statement ok
-DROP VIEW view_1_tab2_661
+DROP VIEW IF EXISTS view_1_tab2_661 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_661
+DROP VIEW IF EXISTS view_2_tab2_661 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_661
+DROP VIEW IF EXISTS view_3_tab2_661 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1178,13 +1178,13 @@ SELECT pk FROM tab3 WHERE col0 < 47 AND col0 >= 59 AND col3 > 28 AND col0 < 26 A
 3
 
 statement ok
-DROP VIEW view_1_tab3_661
+DROP VIEW IF EXISTS view_1_tab3_661 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_661
+DROP VIEW IF EXISTS view_2_tab3_661 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_661
+DROP VIEW IF EXISTS view_3_tab3_661 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1291,13 +1291,13 @@ SELECT pk FROM tab4 WHERE col0 < 47 AND col0 >= 59 AND col3 > 28 AND col0 < 26 A
 3
 
 statement ok
-DROP VIEW view_1_tab4_661
+DROP VIEW IF EXISTS view_1_tab4_661 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_661
+DROP VIEW IF EXISTS view_2_tab4_661 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_661
+DROP VIEW IF EXISTS view_3_tab4_661 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1397,13 +1397,13 @@ SELECT pk FROM tab0 WHERE (col0 >= 74)
 3
 
 statement ok
-DROP VIEW view_1_tab0_662
+DROP VIEW IF EXISTS view_1_tab0_662 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_662
+DROP VIEW IF EXISTS view_2_tab0_662 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_662
+DROP VIEW IF EXISTS view_3_tab0_662 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1503,13 +1503,13 @@ SELECT pk FROM tab1 WHERE (col0 >= 74)
 3
 
 statement ok
-DROP VIEW view_1_tab1_662
+DROP VIEW IF EXISTS view_1_tab1_662 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_662
+DROP VIEW IF EXISTS view_2_tab1_662 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_662
+DROP VIEW IF EXISTS view_3_tab1_662 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1609,13 +1609,13 @@ SELECT pk FROM tab2 WHERE (col0 >= 74)
 3
 
 statement ok
-DROP VIEW view_1_tab2_662
+DROP VIEW IF EXISTS view_1_tab2_662 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_662
+DROP VIEW IF EXISTS view_2_tab2_662 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_662
+DROP VIEW IF EXISTS view_3_tab2_662 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1715,13 +1715,13 @@ SELECT pk FROM tab3 WHERE (col0 >= 74)
 3
 
 statement ok
-DROP VIEW view_1_tab3_662
+DROP VIEW IF EXISTS view_1_tab3_662 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_662
+DROP VIEW IF EXISTS view_2_tab3_662 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_662
+DROP VIEW IF EXISTS view_3_tab3_662 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1821,13 +1821,13 @@ SELECT pk FROM tab4 WHERE (col0 >= 74)
 3
 
 statement ok
-DROP VIEW view_1_tab4_662
+DROP VIEW IF EXISTS view_1_tab4_662 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_662
+DROP VIEW IF EXISTS view_2_tab4_662 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_662
+DROP VIEW IF EXISTS view_3_tab4_662 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1913,13 +1913,13 @@ SELECT pk FROM tab0 WHERE (((((col3 = 22)))) AND col3 BETWEEN 60 AND 24)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_664
+DROP VIEW IF EXISTS view_1_tab0_664 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_664
+DROP VIEW IF EXISTS view_2_tab0_664 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_664
+DROP VIEW IF EXISTS view_3_tab0_664 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2005,13 +2005,13 @@ SELECT pk FROM tab1 WHERE (((((col3 = 22)))) AND col3 BETWEEN 60 AND 24)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_664
+DROP VIEW IF EXISTS view_1_tab1_664 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_664
+DROP VIEW IF EXISTS view_2_tab1_664 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_664
+DROP VIEW IF EXISTS view_3_tab1_664 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2097,13 +2097,13 @@ SELECT pk FROM tab2 WHERE (((((col3 = 22)))) AND col3 BETWEEN 60 AND 24)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_664
+DROP VIEW IF EXISTS view_1_tab2_664 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_664
+DROP VIEW IF EXISTS view_2_tab2_664 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_664
+DROP VIEW IF EXISTS view_3_tab2_664 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2189,13 +2189,13 @@ SELECT pk FROM tab3 WHERE (((((col3 = 22)))) AND col3 BETWEEN 60 AND 24)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_664
+DROP VIEW IF EXISTS view_1_tab3_664 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_664
+DROP VIEW IF EXISTS view_2_tab3_664 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_664
+DROP VIEW IF EXISTS view_3_tab3_664 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2281,13 +2281,13 @@ SELECT pk FROM tab4 WHERE (((((col3 = 22)))) AND col3 BETWEEN 60 AND 24)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_664
+DROP VIEW IF EXISTS view_1_tab4_664 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_664
+DROP VIEW IF EXISTS view_2_tab4_664 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_664
+DROP VIEW IF EXISTS view_3_tab4_664 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2401,13 +2401,13 @@ SELECT pk FROM tab0 WHERE col3 >= 54
 9
 
 statement ok
-DROP VIEW view_1_tab0_665
+DROP VIEW IF EXISTS view_1_tab0_665 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_665
+DROP VIEW IF EXISTS view_2_tab0_665 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_665
+DROP VIEW IF EXISTS view_3_tab0_665 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2521,13 +2521,13 @@ SELECT pk FROM tab1 WHERE col3 >= 54
 9
 
 statement ok
-DROP VIEW view_1_tab1_665
+DROP VIEW IF EXISTS view_1_tab1_665 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_665
+DROP VIEW IF EXISTS view_2_tab1_665 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_665
+DROP VIEW IF EXISTS view_3_tab1_665 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2641,13 +2641,13 @@ SELECT pk FROM tab2 WHERE col3 >= 54
 9
 
 statement ok
-DROP VIEW view_1_tab2_665
+DROP VIEW IF EXISTS view_1_tab2_665 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_665
+DROP VIEW IF EXISTS view_2_tab2_665 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_665
+DROP VIEW IF EXISTS view_3_tab2_665 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2761,13 +2761,13 @@ SELECT pk FROM tab3 WHERE col3 >= 54
 9
 
 statement ok
-DROP VIEW view_1_tab3_665
+DROP VIEW IF EXISTS view_1_tab3_665 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_665
+DROP VIEW IF EXISTS view_2_tab3_665 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_665
+DROP VIEW IF EXISTS view_3_tab3_665 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2881,13 +2881,13 @@ SELECT pk FROM tab4 WHERE col3 >= 54
 9
 
 statement ok
-DROP VIEW view_1_tab4_665
+DROP VIEW IF EXISTS view_1_tab4_665 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_665
+DROP VIEW IF EXISTS view_2_tab4_665 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_665
+DROP VIEW IF EXISTS view_3_tab4_665 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2980,13 +2980,13 @@ SELECT pk FROM tab0 WHERE col3 > 6
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab0_666
+DROP VIEW IF EXISTS view_1_tab0_666 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_666
+DROP VIEW IF EXISTS view_2_tab0_666 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_666
+DROP VIEW IF EXISTS view_3_tab0_666 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3079,13 +3079,13 @@ SELECT pk FROM tab1 WHERE col3 > 6
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab1_666
+DROP VIEW IF EXISTS view_1_tab1_666 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_666
+DROP VIEW IF EXISTS view_2_tab1_666 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_666
+DROP VIEW IF EXISTS view_3_tab1_666 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3178,13 +3178,13 @@ SELECT pk FROM tab2 WHERE col3 > 6
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab2_666
+DROP VIEW IF EXISTS view_1_tab2_666 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_666
+DROP VIEW IF EXISTS view_2_tab2_666 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_666
+DROP VIEW IF EXISTS view_3_tab2_666 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3277,13 +3277,13 @@ SELECT pk FROM tab3 WHERE col3 > 6
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab3_666
+DROP VIEW IF EXISTS view_1_tab3_666 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_666
+DROP VIEW IF EXISTS view_2_tab3_666 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_666
+DROP VIEW IF EXISTS view_3_tab3_666 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3376,13 +3376,13 @@ SELECT pk FROM tab4 WHERE col3 > 6
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab4_666
+DROP VIEW IF EXISTS view_1_tab4_666 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_666
+DROP VIEW IF EXISTS view_2_tab4_666 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_666
+DROP VIEW IF EXISTS view_3_tab4_666 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3489,13 +3489,13 @@ SELECT pk FROM tab0 WHERE col4 > 68.32 AND col3 >= 23
 5
 
 statement ok
-DROP VIEW view_1_tab0_667
+DROP VIEW IF EXISTS view_1_tab0_667 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_667
+DROP VIEW IF EXISTS view_2_tab0_667 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_667
+DROP VIEW IF EXISTS view_3_tab0_667 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3602,13 +3602,13 @@ SELECT pk FROM tab1 WHERE col4 > 68.32 AND col3 >= 23
 5
 
 statement ok
-DROP VIEW view_1_tab1_667
+DROP VIEW IF EXISTS view_1_tab1_667 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_667
+DROP VIEW IF EXISTS view_2_tab1_667 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_667
+DROP VIEW IF EXISTS view_3_tab1_667 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3715,13 +3715,13 @@ SELECT pk FROM tab2 WHERE col4 > 68.32 AND col3 >= 23
 5
 
 statement ok
-DROP VIEW view_1_tab2_667
+DROP VIEW IF EXISTS view_1_tab2_667 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_667
+DROP VIEW IF EXISTS view_2_tab2_667 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_667
+DROP VIEW IF EXISTS view_3_tab2_667 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3828,13 +3828,13 @@ SELECT pk FROM tab3 WHERE col4 > 68.32 AND col3 >= 23
 5
 
 statement ok
-DROP VIEW view_1_tab3_667
+DROP VIEW IF EXISTS view_1_tab3_667 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_667
+DROP VIEW IF EXISTS view_2_tab3_667 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_667
+DROP VIEW IF EXISTS view_3_tab3_667 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3941,13 +3941,13 @@ SELECT pk FROM tab4 WHERE col4 > 68.32 AND col3 >= 23
 5
 
 statement ok
-DROP VIEW view_1_tab4_667
+DROP VIEW IF EXISTS view_1_tab4_667 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_667
+DROP VIEW IF EXISTS view_2_tab4_667 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_667
+DROP VIEW IF EXISTS view_3_tab4_667 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4033,13 +4033,13 @@ SELECT pk FROM tab0 WHERE col0 <= 63 AND (col0 >= 60 OR (col0 IS NULL AND (col1 
 ----
 
 statement ok
-DROP VIEW view_1_tab0_668
+DROP VIEW IF EXISTS view_1_tab0_668 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_668
+DROP VIEW IF EXISTS view_2_tab0_668 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_668
+DROP VIEW IF EXISTS view_3_tab0_668 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4125,13 +4125,13 @@ SELECT pk FROM tab1 WHERE col0 <= 63 AND (col0 >= 60 OR (col0 IS NULL AND (col1 
 ----
 
 statement ok
-DROP VIEW view_1_tab1_668
+DROP VIEW IF EXISTS view_1_tab1_668 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_668
+DROP VIEW IF EXISTS view_2_tab1_668 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_668
+DROP VIEW IF EXISTS view_3_tab1_668 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4217,13 +4217,13 @@ SELECT pk FROM tab2 WHERE col0 <= 63 AND (col0 >= 60 OR (col0 IS NULL AND (col1 
 ----
 
 statement ok
-DROP VIEW view_1_tab2_668
+DROP VIEW IF EXISTS view_1_tab2_668 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_668
+DROP VIEW IF EXISTS view_2_tab2_668 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_668
+DROP VIEW IF EXISTS view_3_tab2_668 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4309,13 +4309,13 @@ SELECT pk FROM tab3 WHERE col0 <= 63 AND (col0 >= 60 OR (col0 IS NULL AND (col1 
 ----
 
 statement ok
-DROP VIEW view_1_tab3_668
+DROP VIEW IF EXISTS view_1_tab3_668 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_668
+DROP VIEW IF EXISTS view_2_tab3_668 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_668
+DROP VIEW IF EXISTS view_3_tab3_668 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4401,13 +4401,13 @@ SELECT pk FROM tab4 WHERE col0 <= 63 AND (col0 >= 60 OR (col0 IS NULL AND (col1 
 ----
 
 statement ok
-DROP VIEW view_1_tab4_668
+DROP VIEW IF EXISTS view_1_tab4_668 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_668
+DROP VIEW IF EXISTS view_2_tab4_668 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_668
+DROP VIEW IF EXISTS view_3_tab4_668 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4496,13 +4496,13 @@ SELECT pk FROM tab0 WHERE col4 <= 60.0 OR ((col3 IS NULL AND ((col3 >= 14)) AND 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_669
+DROP VIEW IF EXISTS view_1_tab0_669 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_669
+DROP VIEW IF EXISTS view_2_tab0_669 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_669
+DROP VIEW IF EXISTS view_3_tab0_669 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4591,13 +4591,13 @@ SELECT pk FROM tab1 WHERE col4 <= 60.0 OR ((col3 IS NULL AND ((col3 >= 14)) AND 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_669
+DROP VIEW IF EXISTS view_1_tab1_669 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_669
+DROP VIEW IF EXISTS view_2_tab1_669 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_669
+DROP VIEW IF EXISTS view_3_tab1_669 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4686,13 +4686,13 @@ SELECT pk FROM tab2 WHERE col4 <= 60.0 OR ((col3 IS NULL AND ((col3 >= 14)) AND 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_669
+DROP VIEW IF EXISTS view_1_tab2_669 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_669
+DROP VIEW IF EXISTS view_2_tab2_669 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_669
+DROP VIEW IF EXISTS view_3_tab2_669 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4781,13 +4781,13 @@ SELECT pk FROM tab3 WHERE col4 <= 60.0 OR ((col3 IS NULL AND ((col3 >= 14)) AND 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_669
+DROP VIEW IF EXISTS view_1_tab3_669 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_669
+DROP VIEW IF EXISTS view_2_tab3_669 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_669
+DROP VIEW IF EXISTS view_3_tab3_669 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4876,13 +4876,13 @@ SELECT pk FROM tab4 WHERE col4 <= 60.0 OR ((col3 IS NULL AND ((col3 >= 14)) AND 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_669
+DROP VIEW IF EXISTS view_1_tab4_669 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_669
+DROP VIEW IF EXISTS view_2_tab4_669 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_669
+DROP VIEW IF EXISTS view_3_tab4_669 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4968,13 +4968,13 @@ SELECT pk FROM tab0 WHERE col0 = 4
 ----
 
 statement ok
-DROP VIEW view_1_tab0_670
+DROP VIEW IF EXISTS view_1_tab0_670 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_670
+DROP VIEW IF EXISTS view_2_tab0_670 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_670
+DROP VIEW IF EXISTS view_3_tab0_670 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5060,13 +5060,13 @@ SELECT pk FROM tab1 WHERE col0 = 4
 ----
 
 statement ok
-DROP VIEW view_1_tab1_670
+DROP VIEW IF EXISTS view_1_tab1_670 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_670
+DROP VIEW IF EXISTS view_2_tab1_670 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_670
+DROP VIEW IF EXISTS view_3_tab1_670 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5152,13 +5152,13 @@ SELECT pk FROM tab2 WHERE col0 = 4
 ----
 
 statement ok
-DROP VIEW view_1_tab2_670
+DROP VIEW IF EXISTS view_1_tab2_670 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_670
+DROP VIEW IF EXISTS view_2_tab2_670 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_670
+DROP VIEW IF EXISTS view_3_tab2_670 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5244,13 +5244,13 @@ SELECT pk FROM tab3 WHERE col0 = 4
 ----
 
 statement ok
-DROP VIEW view_1_tab3_670
+DROP VIEW IF EXISTS view_1_tab3_670 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_670
+DROP VIEW IF EXISTS view_2_tab3_670 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_670
+DROP VIEW IF EXISTS view_3_tab3_670 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5336,13 +5336,13 @@ SELECT pk FROM tab4 WHERE col0 = 4
 ----
 
 statement ok
-DROP VIEW view_1_tab4_670
+DROP VIEW IF EXISTS view_1_tab4_670 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_670
+DROP VIEW IF EXISTS view_2_tab4_670 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_670
+DROP VIEW IF EXISTS view_3_tab4_670 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5435,13 +5435,13 @@ SELECT pk FROM tab0 WHERE (col3 <= 71)
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab0_671
+DROP VIEW IF EXISTS view_1_tab0_671 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_671
+DROP VIEW IF EXISTS view_2_tab0_671 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_671
+DROP VIEW IF EXISTS view_3_tab0_671 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5534,13 +5534,13 @@ SELECT pk FROM tab1 WHERE (col3 <= 71)
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab1_671
+DROP VIEW IF EXISTS view_1_tab1_671 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_671
+DROP VIEW IF EXISTS view_2_tab1_671 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_671
+DROP VIEW IF EXISTS view_3_tab1_671 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5633,13 +5633,13 @@ SELECT pk FROM tab2 WHERE (col3 <= 71)
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab2_671
+DROP VIEW IF EXISTS view_1_tab2_671 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_671
+DROP VIEW IF EXISTS view_2_tab2_671 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_671
+DROP VIEW IF EXISTS view_3_tab2_671 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5732,13 +5732,13 @@ SELECT pk FROM tab3 WHERE (col3 <= 71)
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab3_671
+DROP VIEW IF EXISTS view_1_tab3_671 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_671
+DROP VIEW IF EXISTS view_2_tab3_671 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_671
+DROP VIEW IF EXISTS view_3_tab3_671 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5831,13 +5831,13 @@ SELECT pk FROM tab4 WHERE (col3 <= 71)
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab4_671
+DROP VIEW IF EXISTS view_1_tab4_671 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_671
+DROP VIEW IF EXISTS view_2_tab4_671 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_671
+DROP VIEW IF EXISTS view_3_tab4_671 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5926,13 +5926,13 @@ SELECT pk FROM tab0 WHERE col0 <= 22 AND col3 > 44 OR ((col0 >= 59 AND col0 < 57
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_673
+DROP VIEW IF EXISTS view_1_tab0_673 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_673
+DROP VIEW IF EXISTS view_2_tab0_673 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_673
+DROP VIEW IF EXISTS view_3_tab0_673 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6021,13 +6021,13 @@ SELECT pk FROM tab1 WHERE col0 <= 22 AND col3 > 44 OR ((col0 >= 59 AND col0 < 57
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_673
+DROP VIEW IF EXISTS view_1_tab1_673 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_673
+DROP VIEW IF EXISTS view_2_tab1_673 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_673
+DROP VIEW IF EXISTS view_3_tab1_673 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6116,13 +6116,13 @@ SELECT pk FROM tab2 WHERE col0 <= 22 AND col3 > 44 OR ((col0 >= 59 AND col0 < 57
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_673
+DROP VIEW IF EXISTS view_1_tab2_673 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_673
+DROP VIEW IF EXISTS view_2_tab2_673 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_673
+DROP VIEW IF EXISTS view_3_tab2_673 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6211,13 +6211,13 @@ SELECT pk FROM tab3 WHERE col0 <= 22 AND col3 > 44 OR ((col0 >= 59 AND col0 < 57
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_673
+DROP VIEW IF EXISTS view_1_tab3_673 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_673
+DROP VIEW IF EXISTS view_2_tab3_673 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_673
+DROP VIEW IF EXISTS view_3_tab3_673 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6306,13 +6306,13 @@ SELECT pk FROM tab4 WHERE col0 <= 22 AND col3 > 44 OR ((col0 >= 59 AND col0 < 57
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_673
+DROP VIEW IF EXISTS view_1_tab4_673 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_673
+DROP VIEW IF EXISTS view_2_tab4_673 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_673
+DROP VIEW IF EXISTS view_3_tab4_673 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6398,13 +6398,13 @@ SELECT pk FROM tab0 WHERE col0 > 47 AND (col3 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_674
+DROP VIEW IF EXISTS view_1_tab0_674 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_674
+DROP VIEW IF EXISTS view_2_tab0_674 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_674
+DROP VIEW IF EXISTS view_3_tab0_674 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6490,13 +6490,13 @@ SELECT pk FROM tab1 WHERE col0 > 47 AND (col3 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_674
+DROP VIEW IF EXISTS view_1_tab1_674 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_674
+DROP VIEW IF EXISTS view_2_tab1_674 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_674
+DROP VIEW IF EXISTS view_3_tab1_674 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6582,13 +6582,13 @@ SELECT pk FROM tab2 WHERE col0 > 47 AND (col3 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_674
+DROP VIEW IF EXISTS view_1_tab2_674 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_674
+DROP VIEW IF EXISTS view_2_tab2_674 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_674
+DROP VIEW IF EXISTS view_3_tab2_674 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6674,13 +6674,13 @@ SELECT pk FROM tab3 WHERE col0 > 47 AND (col3 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_674
+DROP VIEW IF EXISTS view_1_tab3_674 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_674
+DROP VIEW IF EXISTS view_2_tab3_674 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_674
+DROP VIEW IF EXISTS view_3_tab3_674 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6766,13 +6766,13 @@ SELECT pk FROM tab4 WHERE col0 > 47 AND (col3 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_674
+DROP VIEW IF EXISTS view_1_tab4_674 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_674
+DROP VIEW IF EXISTS view_2_tab4_674 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_674
+DROP VIEW IF EXISTS view_3_tab4_674 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6890,13 +6890,13 @@ SELECT pk FROM tab0 WHERE col0 IS NULL AND col3 <= 74 OR col0 >= 22 OR col3 > 96
 9
 
 statement ok
-DROP VIEW view_1_tab0_675
+DROP VIEW IF EXISTS view_1_tab0_675 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_675
+DROP VIEW IF EXISTS view_2_tab0_675 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_675
+DROP VIEW IF EXISTS view_3_tab0_675 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7014,13 +7014,13 @@ SELECT pk FROM tab1 WHERE col0 IS NULL AND col3 <= 74 OR col0 >= 22 OR col3 > 96
 9
 
 statement ok
-DROP VIEW view_1_tab1_675
+DROP VIEW IF EXISTS view_1_tab1_675 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_675
+DROP VIEW IF EXISTS view_2_tab1_675 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_675
+DROP VIEW IF EXISTS view_3_tab1_675 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7138,13 +7138,13 @@ SELECT pk FROM tab2 WHERE col0 IS NULL AND col3 <= 74 OR col0 >= 22 OR col3 > 96
 9
 
 statement ok
-DROP VIEW view_1_tab2_675
+DROP VIEW IF EXISTS view_1_tab2_675 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_675
+DROP VIEW IF EXISTS view_2_tab2_675 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_675
+DROP VIEW IF EXISTS view_3_tab2_675 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7262,13 +7262,13 @@ SELECT pk FROM tab3 WHERE col0 IS NULL AND col3 <= 74 OR col0 >= 22 OR col3 > 96
 9
 
 statement ok
-DROP VIEW view_1_tab3_675
+DROP VIEW IF EXISTS view_1_tab3_675 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_675
+DROP VIEW IF EXISTS view_2_tab3_675 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_675
+DROP VIEW IF EXISTS view_3_tab3_675 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7386,13 +7386,13 @@ SELECT pk FROM tab4 WHERE col0 IS NULL AND col3 <= 74 OR col0 >= 22 OR col3 > 96
 9
 
 statement ok
-DROP VIEW view_1_tab4_675
+DROP VIEW IF EXISTS view_1_tab4_675 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_675
+DROP VIEW IF EXISTS view_2_tab4_675 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_675
+DROP VIEW IF EXISTS view_3_tab4_675 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7506,13 +7506,13 @@ SELECT pk FROM tab0 WHERE col0 > 38
 4
 
 statement ok
-DROP VIEW view_1_tab0_676
+DROP VIEW IF EXISTS view_1_tab0_676 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_676
+DROP VIEW IF EXISTS view_2_tab0_676 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_676
+DROP VIEW IF EXISTS view_3_tab0_676 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7626,13 +7626,13 @@ SELECT pk FROM tab1 WHERE col0 > 38
 4
 
 statement ok
-DROP VIEW view_1_tab1_676
+DROP VIEW IF EXISTS view_1_tab1_676 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_676
+DROP VIEW IF EXISTS view_2_tab1_676 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_676
+DROP VIEW IF EXISTS view_3_tab1_676 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7746,13 +7746,13 @@ SELECT pk FROM tab2 WHERE col0 > 38
 4
 
 statement ok
-DROP VIEW view_1_tab2_676
+DROP VIEW IF EXISTS view_1_tab2_676 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_676
+DROP VIEW IF EXISTS view_2_tab2_676 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_676
+DROP VIEW IF EXISTS view_3_tab2_676 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7866,13 +7866,13 @@ SELECT pk FROM tab3 WHERE col0 > 38
 4
 
 statement ok
-DROP VIEW view_1_tab3_676
+DROP VIEW IF EXISTS view_1_tab3_676 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_676
+DROP VIEW IF EXISTS view_2_tab3_676 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_676
+DROP VIEW IF EXISTS view_3_tab3_676 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7986,13 +7986,13 @@ SELECT pk FROM tab4 WHERE col0 > 38
 4
 
 statement ok
-DROP VIEW view_1_tab4_676
+DROP VIEW IF EXISTS view_1_tab4_676 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_676
+DROP VIEW IF EXISTS view_2_tab4_676 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_676
+DROP VIEW IF EXISTS view_3_tab4_676 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8111,13 +8111,13 @@ SELECT pk FROM tab0 WHERE col1 < 76.9
 9
 
 statement ok
-DROP VIEW view_1_tab0_677
+DROP VIEW IF EXISTS view_1_tab0_677 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_677
+DROP VIEW IF EXISTS view_2_tab0_677 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_677
+DROP VIEW IF EXISTS view_3_tab0_677 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8236,13 +8236,13 @@ SELECT pk FROM tab1 WHERE col1 < 76.9
 9
 
 statement ok
-DROP VIEW view_1_tab1_677
+DROP VIEW IF EXISTS view_1_tab1_677 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_677
+DROP VIEW IF EXISTS view_2_tab1_677 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_677
+DROP VIEW IF EXISTS view_3_tab1_677 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8361,13 +8361,13 @@ SELECT pk FROM tab2 WHERE col1 < 76.9
 9
 
 statement ok
-DROP VIEW view_1_tab2_677
+DROP VIEW IF EXISTS view_1_tab2_677 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_677
+DROP VIEW IF EXISTS view_2_tab2_677 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_677
+DROP VIEW IF EXISTS view_3_tab2_677 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8486,13 +8486,13 @@ SELECT pk FROM tab3 WHERE col1 < 76.9
 9
 
 statement ok
-DROP VIEW view_1_tab3_677
+DROP VIEW IF EXISTS view_1_tab3_677 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_677
+DROP VIEW IF EXISTS view_2_tab3_677 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_677
+DROP VIEW IF EXISTS view_3_tab3_677 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8611,13 +8611,13 @@ SELECT pk FROM tab4 WHERE col1 < 76.9
 9
 
 statement ok
-DROP VIEW view_1_tab4_677
+DROP VIEW IF EXISTS view_1_tab4_677 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_677
+DROP VIEW IF EXISTS view_2_tab4_677 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_677
+DROP VIEW IF EXISTS view_3_tab4_677 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8735,13 +8735,13 @@ SELECT pk FROM tab0 WHERE ((col1 > 13.46))
 9
 
 statement ok
-DROP VIEW view_1_tab0_678
+DROP VIEW IF EXISTS view_1_tab0_678 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_678
+DROP VIEW IF EXISTS view_2_tab0_678 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_678
+DROP VIEW IF EXISTS view_3_tab0_678 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8859,13 +8859,13 @@ SELECT pk FROM tab1 WHERE ((col1 > 13.46))
 9
 
 statement ok
-DROP VIEW view_1_tab1_678
+DROP VIEW IF EXISTS view_1_tab1_678 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_678
+DROP VIEW IF EXISTS view_2_tab1_678 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_678
+DROP VIEW IF EXISTS view_3_tab1_678 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8983,13 +8983,13 @@ SELECT pk FROM tab2 WHERE ((col1 > 13.46))
 9
 
 statement ok
-DROP VIEW view_1_tab2_678
+DROP VIEW IF EXISTS view_1_tab2_678 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_678
+DROP VIEW IF EXISTS view_2_tab2_678 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_678
+DROP VIEW IF EXISTS view_3_tab2_678 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9107,13 +9107,13 @@ SELECT pk FROM tab3 WHERE ((col1 > 13.46))
 9
 
 statement ok
-DROP VIEW view_1_tab3_678
+DROP VIEW IF EXISTS view_1_tab3_678 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_678
+DROP VIEW IF EXISTS view_2_tab3_678 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_678
+DROP VIEW IF EXISTS view_3_tab3_678 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9231,13 +9231,13 @@ SELECT pk FROM tab4 WHERE ((col1 > 13.46))
 9
 
 statement ok
-DROP VIEW view_1_tab4_678
+DROP VIEW IF EXISTS view_1_tab4_678 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_678
+DROP VIEW IF EXISTS view_2_tab4_678 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_678
+DROP VIEW IF EXISTS view_3_tab4_678 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9337,13 +9337,13 @@ SELECT pk FROM tab0 WHERE col3 <= 19
 3
 
 statement ok
-DROP VIEW view_1_tab0_679
+DROP VIEW IF EXISTS view_1_tab0_679 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_679
+DROP VIEW IF EXISTS view_2_tab0_679 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_679
+DROP VIEW IF EXISTS view_3_tab0_679 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9443,13 +9443,13 @@ SELECT pk FROM tab1 WHERE col3 <= 19
 3
 
 statement ok
-DROP VIEW view_1_tab1_679
+DROP VIEW IF EXISTS view_1_tab1_679 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_679
+DROP VIEW IF EXISTS view_2_tab1_679 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_679
+DROP VIEW IF EXISTS view_3_tab1_679 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9549,13 +9549,13 @@ SELECT pk FROM tab2 WHERE col3 <= 19
 3
 
 statement ok
-DROP VIEW view_1_tab2_679
+DROP VIEW IF EXISTS view_1_tab2_679 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_679
+DROP VIEW IF EXISTS view_2_tab2_679 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_679
+DROP VIEW IF EXISTS view_3_tab2_679 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9655,13 +9655,13 @@ SELECT pk FROM tab3 WHERE col3 <= 19
 3
 
 statement ok
-DROP VIEW view_1_tab3_679
+DROP VIEW IF EXISTS view_1_tab3_679 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_679
+DROP VIEW IF EXISTS view_2_tab3_679 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_679
+DROP VIEW IF EXISTS view_3_tab3_679 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9761,13 +9761,13 @@ SELECT pk FROM tab4 WHERE col3 <= 19
 3
 
 statement ok
-DROP VIEW view_1_tab4_679
+DROP VIEW IF EXISTS view_1_tab4_679 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_679
+DROP VIEW IF EXISTS view_2_tab4_679 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_679
+DROP VIEW IF EXISTS view_3_tab4_679 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9874,13 +9874,13 @@ SELECT pk FROM tab0 WHERE col4 >= 70.65
 5
 
 statement ok
-DROP VIEW view_1_tab0_680
+DROP VIEW IF EXISTS view_1_tab0_680 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_680
+DROP VIEW IF EXISTS view_2_tab0_680 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_680
+DROP VIEW IF EXISTS view_3_tab0_680 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9987,13 +9987,13 @@ SELECT pk FROM tab1 WHERE col4 >= 70.65
 5
 
 statement ok
-DROP VIEW view_1_tab1_680
+DROP VIEW IF EXISTS view_1_tab1_680 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_680
+DROP VIEW IF EXISTS view_2_tab1_680 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_680
+DROP VIEW IF EXISTS view_3_tab1_680 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10100,13 +10100,13 @@ SELECT pk FROM tab2 WHERE col4 >= 70.65
 5
 
 statement ok
-DROP VIEW view_1_tab2_680
+DROP VIEW IF EXISTS view_1_tab2_680 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_680
+DROP VIEW IF EXISTS view_2_tab2_680 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_680
+DROP VIEW IF EXISTS view_3_tab2_680 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10213,13 +10213,13 @@ SELECT pk FROM tab3 WHERE col4 >= 70.65
 5
 
 statement ok
-DROP VIEW view_1_tab3_680
+DROP VIEW IF EXISTS view_1_tab3_680 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_680
+DROP VIEW IF EXISTS view_2_tab3_680 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_680
+DROP VIEW IF EXISTS view_3_tab3_680 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10326,13 +10326,13 @@ SELECT pk FROM tab4 WHERE col4 >= 70.65
 5
 
 statement ok
-DROP VIEW view_1_tab4_680
+DROP VIEW IF EXISTS view_1_tab4_680 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_680
+DROP VIEW IF EXISTS view_2_tab4_680 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_680
+DROP VIEW IF EXISTS view_3_tab4_680 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10418,13 +10418,13 @@ SELECT pk FROM tab0 WHERE col1 IN (87.83,30.38,58.81,1.42)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_681
+DROP VIEW IF EXISTS view_1_tab0_681 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_681
+DROP VIEW IF EXISTS view_2_tab0_681 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_681
+DROP VIEW IF EXISTS view_3_tab0_681 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10510,13 +10510,13 @@ SELECT pk FROM tab1 WHERE col1 IN (87.83,30.38,58.81,1.42)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_681
+DROP VIEW IF EXISTS view_1_tab1_681 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_681
+DROP VIEW IF EXISTS view_2_tab1_681 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_681
+DROP VIEW IF EXISTS view_3_tab1_681 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10602,13 +10602,13 @@ SELECT pk FROM tab2 WHERE col1 IN (87.83,30.38,58.81,1.42)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_681
+DROP VIEW IF EXISTS view_1_tab2_681 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_681
+DROP VIEW IF EXISTS view_2_tab2_681 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_681
+DROP VIEW IF EXISTS view_3_tab2_681 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10694,13 +10694,13 @@ SELECT pk FROM tab3 WHERE col1 IN (87.83,30.38,58.81,1.42)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_681
+DROP VIEW IF EXISTS view_1_tab3_681 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_681
+DROP VIEW IF EXISTS view_2_tab3_681 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_681
+DROP VIEW IF EXISTS view_3_tab3_681 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10786,13 +10786,13 @@ SELECT pk FROM tab4 WHERE col1 IN (87.83,30.38,58.81,1.42)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_681
+DROP VIEW IF EXISTS view_1_tab4_681 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_681
+DROP VIEW IF EXISTS view_2_tab4_681 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_681
+DROP VIEW IF EXISTS view_3_tab4_681 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10892,13 +10892,13 @@ SELECT pk FROM tab0 WHERE col0 > 66 AND col0 <= 96 OR col1 IS NULL
 3
 
 statement ok
-DROP VIEW view_1_tab0_682
+DROP VIEW IF EXISTS view_1_tab0_682 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_682
+DROP VIEW IF EXISTS view_2_tab0_682 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_682
+DROP VIEW IF EXISTS view_3_tab0_682 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10998,13 +10998,13 @@ SELECT pk FROM tab1 WHERE col0 > 66 AND col0 <= 96 OR col1 IS NULL
 3
 
 statement ok
-DROP VIEW view_1_tab1_682
+DROP VIEW IF EXISTS view_1_tab1_682 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_682
+DROP VIEW IF EXISTS view_2_tab1_682 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_682
+DROP VIEW IF EXISTS view_3_tab1_682 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11104,13 +11104,13 @@ SELECT pk FROM tab2 WHERE col0 > 66 AND col0 <= 96 OR col1 IS NULL
 3
 
 statement ok
-DROP VIEW view_1_tab2_682
+DROP VIEW IF EXISTS view_1_tab2_682 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_682
+DROP VIEW IF EXISTS view_2_tab2_682 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_682
+DROP VIEW IF EXISTS view_3_tab2_682 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11210,13 +11210,13 @@ SELECT pk FROM tab3 WHERE col0 > 66 AND col0 <= 96 OR col1 IS NULL
 3
 
 statement ok
-DROP VIEW view_1_tab3_682
+DROP VIEW IF EXISTS view_1_tab3_682 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_682
+DROP VIEW IF EXISTS view_2_tab3_682 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_682
+DROP VIEW IF EXISTS view_3_tab3_682 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11316,13 +11316,13 @@ SELECT pk FROM tab4 WHERE col0 > 66 AND col0 <= 96 OR col1 IS NULL
 3
 
 statement ok
-DROP VIEW view_1_tab4_682
+DROP VIEW IF EXISTS view_1_tab4_682 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_682
+DROP VIEW IF EXISTS view_2_tab4_682 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_682
+DROP VIEW IF EXISTS view_3_tab4_682 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11415,13 +11415,13 @@ SELECT pk FROM tab0 WHERE col3 >= 12
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab0_684
+DROP VIEW IF EXISTS view_1_tab0_684 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_684
+DROP VIEW IF EXISTS view_2_tab0_684 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_684
+DROP VIEW IF EXISTS view_3_tab0_684 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11514,13 +11514,13 @@ SELECT pk FROM tab1 WHERE col3 >= 12
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab1_684
+DROP VIEW IF EXISTS view_1_tab1_684 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_684
+DROP VIEW IF EXISTS view_2_tab1_684 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_684
+DROP VIEW IF EXISTS view_3_tab1_684 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11613,13 +11613,13 @@ SELECT pk FROM tab2 WHERE col3 >= 12
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab2_684
+DROP VIEW IF EXISTS view_1_tab2_684 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_684
+DROP VIEW IF EXISTS view_2_tab2_684 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_684
+DROP VIEW IF EXISTS view_3_tab2_684 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11712,13 +11712,13 @@ SELECT pk FROM tab3 WHERE col3 >= 12
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab3_684
+DROP VIEW IF EXISTS view_1_tab3_684 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_684
+DROP VIEW IF EXISTS view_2_tab3_684 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_684
+DROP VIEW IF EXISTS view_3_tab3_684 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11811,13 +11811,13 @@ SELECT pk FROM tab4 WHERE col3 >= 12
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab4_684
+DROP VIEW IF EXISTS view_1_tab4_684 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_684
+DROP VIEW IF EXISTS view_2_tab4_684 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_684
+DROP VIEW IF EXISTS view_3_tab4_684 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11937,13 +11937,13 @@ SELECT pk FROM tab0 WHERE col4 < 51.26
 9
 
 statement ok
-DROP VIEW view_1_tab0_685
+DROP VIEW IF EXISTS view_1_tab0_685 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_685
+DROP VIEW IF EXISTS view_2_tab0_685 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_685
+DROP VIEW IF EXISTS view_3_tab0_685 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12063,13 +12063,13 @@ SELECT pk FROM tab1 WHERE col4 < 51.26
 9
 
 statement ok
-DROP VIEW view_1_tab1_685
+DROP VIEW IF EXISTS view_1_tab1_685 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_685
+DROP VIEW IF EXISTS view_2_tab1_685 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_685
+DROP VIEW IF EXISTS view_3_tab1_685 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12189,13 +12189,13 @@ SELECT pk FROM tab2 WHERE col4 < 51.26
 9
 
 statement ok
-DROP VIEW view_1_tab2_685
+DROP VIEW IF EXISTS view_1_tab2_685 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_685
+DROP VIEW IF EXISTS view_2_tab2_685 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_685
+DROP VIEW IF EXISTS view_3_tab2_685 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12315,13 +12315,13 @@ SELECT pk FROM tab3 WHERE col4 < 51.26
 9
 
 statement ok
-DROP VIEW view_1_tab3_685
+DROP VIEW IF EXISTS view_1_tab3_685 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_685
+DROP VIEW IF EXISTS view_2_tab3_685 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_685
+DROP VIEW IF EXISTS view_3_tab3_685 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12441,13 +12441,13 @@ SELECT pk FROM tab4 WHERE col4 < 51.26
 9
 
 statement ok
-DROP VIEW view_1_tab4_685
+DROP VIEW IF EXISTS view_1_tab4_685 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_685
+DROP VIEW IF EXISTS view_2_tab4_685 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_685
+DROP VIEW IF EXISTS view_3_tab4_685 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12561,13 +12561,13 @@ SELECT pk FROM tab0 WHERE col3 > 45
 9
 
 statement ok
-DROP VIEW view_1_tab0_686
+DROP VIEW IF EXISTS view_1_tab0_686 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_686
+DROP VIEW IF EXISTS view_2_tab0_686 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_686
+DROP VIEW IF EXISTS view_3_tab0_686 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12681,13 +12681,13 @@ SELECT pk FROM tab1 WHERE col3 > 45
 9
 
 statement ok
-DROP VIEW view_1_tab1_686
+DROP VIEW IF EXISTS view_1_tab1_686 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_686
+DROP VIEW IF EXISTS view_2_tab1_686 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_686
+DROP VIEW IF EXISTS view_3_tab1_686 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12801,13 +12801,13 @@ SELECT pk FROM tab2 WHERE col3 > 45
 9
 
 statement ok
-DROP VIEW view_1_tab2_686
+DROP VIEW IF EXISTS view_1_tab2_686 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_686
+DROP VIEW IF EXISTS view_2_tab2_686 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_686
+DROP VIEW IF EXISTS view_3_tab2_686 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12921,13 +12921,13 @@ SELECT pk FROM tab3 WHERE col3 > 45
 9
 
 statement ok
-DROP VIEW view_1_tab3_686
+DROP VIEW IF EXISTS view_1_tab3_686 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_686
+DROP VIEW IF EXISTS view_2_tab3_686 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_686
+DROP VIEW IF EXISTS view_3_tab3_686 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13041,13 +13041,13 @@ SELECT pk FROM tab4 WHERE col3 > 45
 9
 
 statement ok
-DROP VIEW view_1_tab4_686
+DROP VIEW IF EXISTS view_1_tab4_686 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_686
+DROP VIEW IF EXISTS view_2_tab4_686 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_686
+DROP VIEW IF EXISTS view_3_tab4_686 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13140,13 +13140,13 @@ SELECT pk FROM tab0 WHERE col3 > 79
 8
 
 statement ok
-DROP VIEW view_1_tab0_687
+DROP VIEW IF EXISTS view_1_tab0_687 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_687
+DROP VIEW IF EXISTS view_2_tab0_687 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_687
+DROP VIEW IF EXISTS view_3_tab0_687 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13239,13 +13239,13 @@ SELECT pk FROM tab1 WHERE col3 > 79
 8
 
 statement ok
-DROP VIEW view_1_tab1_687
+DROP VIEW IF EXISTS view_1_tab1_687 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_687
+DROP VIEW IF EXISTS view_2_tab1_687 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_687
+DROP VIEW IF EXISTS view_3_tab1_687 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13338,13 +13338,13 @@ SELECT pk FROM tab2 WHERE col3 > 79
 8
 
 statement ok
-DROP VIEW view_1_tab2_687
+DROP VIEW IF EXISTS view_1_tab2_687 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_687
+DROP VIEW IF EXISTS view_2_tab2_687 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_687
+DROP VIEW IF EXISTS view_3_tab2_687 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13437,13 +13437,13 @@ SELECT pk FROM tab3 WHERE col3 > 79
 8
 
 statement ok
-DROP VIEW view_1_tab3_687
+DROP VIEW IF EXISTS view_1_tab3_687 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_687
+DROP VIEW IF EXISTS view_2_tab3_687 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_687
+DROP VIEW IF EXISTS view_3_tab3_687 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13536,13 +13536,13 @@ SELECT pk FROM tab4 WHERE col3 > 79
 8
 
 statement ok
-DROP VIEW view_1_tab4_687
+DROP VIEW IF EXISTS view_1_tab4_687 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_687
+DROP VIEW IF EXISTS view_2_tab4_687 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_687
+DROP VIEW IF EXISTS view_3_tab4_687 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13656,13 +13656,13 @@ SELECT pk FROM tab0 WHERE col4 >= 54.74
 8
 
 statement ok
-DROP VIEW view_1_tab0_688
+DROP VIEW IF EXISTS view_1_tab0_688 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_688
+DROP VIEW IF EXISTS view_2_tab0_688 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_688
+DROP VIEW IF EXISTS view_3_tab0_688 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13776,13 +13776,13 @@ SELECT pk FROM tab1 WHERE col4 >= 54.74
 8
 
 statement ok
-DROP VIEW view_1_tab1_688
+DROP VIEW IF EXISTS view_1_tab1_688 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_688
+DROP VIEW IF EXISTS view_2_tab1_688 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_688
+DROP VIEW IF EXISTS view_3_tab1_688 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13896,13 +13896,13 @@ SELECT pk FROM tab2 WHERE col4 >= 54.74
 8
 
 statement ok
-DROP VIEW view_1_tab2_688
+DROP VIEW IF EXISTS view_1_tab2_688 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_688
+DROP VIEW IF EXISTS view_2_tab2_688 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_688
+DROP VIEW IF EXISTS view_3_tab2_688 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14016,13 +14016,13 @@ SELECT pk FROM tab3 WHERE col4 >= 54.74
 8
 
 statement ok
-DROP VIEW view_1_tab3_688
+DROP VIEW IF EXISTS view_1_tab3_688 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_688
+DROP VIEW IF EXISTS view_2_tab3_688 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_688
+DROP VIEW IF EXISTS view_3_tab3_688 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14136,13 +14136,13 @@ SELECT pk FROM tab4 WHERE col4 >= 54.74
 8
 
 statement ok
-DROP VIEW view_1_tab4_688
+DROP VIEW IF EXISTS view_1_tab4_688 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_688
+DROP VIEW IF EXISTS view_2_tab4_688 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_688
+DROP VIEW IF EXISTS view_3_tab4_688 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14228,13 +14228,13 @@ SELECT pk FROM tab0 WHERE ((col1 IN (62.28,87.70,48.87)))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_689
+DROP VIEW IF EXISTS view_1_tab0_689 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_689
+DROP VIEW IF EXISTS view_2_tab0_689 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_689
+DROP VIEW IF EXISTS view_3_tab0_689 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14320,13 +14320,13 @@ SELECT pk FROM tab1 WHERE ((col1 IN (62.28,87.70,48.87)))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_689
+DROP VIEW IF EXISTS view_1_tab1_689 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_689
+DROP VIEW IF EXISTS view_2_tab1_689 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_689
+DROP VIEW IF EXISTS view_3_tab1_689 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14412,13 +14412,13 @@ SELECT pk FROM tab2 WHERE ((col1 IN (62.28,87.70,48.87)))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_689
+DROP VIEW IF EXISTS view_1_tab2_689 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_689
+DROP VIEW IF EXISTS view_2_tab2_689 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_689
+DROP VIEW IF EXISTS view_3_tab2_689 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14504,13 +14504,13 @@ SELECT pk FROM tab3 WHERE ((col1 IN (62.28,87.70,48.87)))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_689
+DROP VIEW IF EXISTS view_1_tab3_689 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_689
+DROP VIEW IF EXISTS view_2_tab3_689 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_689
+DROP VIEW IF EXISTS view_3_tab3_689 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14596,13 +14596,13 @@ SELECT pk FROM tab4 WHERE ((col1 IN (62.28,87.70,48.87)))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_689
+DROP VIEW IF EXISTS view_1_tab4_689 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_689
+DROP VIEW IF EXISTS view_2_tab4_689 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_689
+DROP VIEW IF EXISTS view_3_tab4_689 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14716,13 +14716,13 @@ SELECT pk FROM tab0 WHERE col3 >= 46
 9
 
 statement ok
-DROP VIEW view_1_tab0_690
+DROP VIEW IF EXISTS view_1_tab0_690 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_690
+DROP VIEW IF EXISTS view_2_tab0_690 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_690
+DROP VIEW IF EXISTS view_3_tab0_690 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14836,13 +14836,13 @@ SELECT pk FROM tab1 WHERE col3 >= 46
 9
 
 statement ok
-DROP VIEW view_1_tab1_690
+DROP VIEW IF EXISTS view_1_tab1_690 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_690
+DROP VIEW IF EXISTS view_2_tab1_690 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_690
+DROP VIEW IF EXISTS view_3_tab1_690 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14956,13 +14956,13 @@ SELECT pk FROM tab2 WHERE col3 >= 46
 9
 
 statement ok
-DROP VIEW view_1_tab2_690
+DROP VIEW IF EXISTS view_1_tab2_690 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_690
+DROP VIEW IF EXISTS view_2_tab2_690 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_690
+DROP VIEW IF EXISTS view_3_tab2_690 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15076,13 +15076,13 @@ SELECT pk FROM tab3 WHERE col3 >= 46
 9
 
 statement ok
-DROP VIEW view_1_tab3_690
+DROP VIEW IF EXISTS view_1_tab3_690 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_690
+DROP VIEW IF EXISTS view_2_tab3_690 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_690
+DROP VIEW IF EXISTS view_3_tab3_690 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15196,13 +15196,13 @@ SELECT pk FROM tab4 WHERE col3 >= 46
 9
 
 statement ok
-DROP VIEW view_1_tab4_690
+DROP VIEW IF EXISTS view_1_tab4_690 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_690
+DROP VIEW IF EXISTS view_2_tab4_690 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_690
+DROP VIEW IF EXISTS view_3_tab4_690 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15288,13 +15288,13 @@ SELECT pk FROM tab0 WHERE col0 >= 18 AND col3 < 3
 ----
 
 statement ok
-DROP VIEW view_1_tab0_691
+DROP VIEW IF EXISTS view_1_tab0_691 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_691
+DROP VIEW IF EXISTS view_2_tab0_691 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_691
+DROP VIEW IF EXISTS view_3_tab0_691 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15380,13 +15380,13 @@ SELECT pk FROM tab1 WHERE col0 >= 18 AND col3 < 3
 ----
 
 statement ok
-DROP VIEW view_1_tab1_691
+DROP VIEW IF EXISTS view_1_tab1_691 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_691
+DROP VIEW IF EXISTS view_2_tab1_691 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_691
+DROP VIEW IF EXISTS view_3_tab1_691 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15472,13 +15472,13 @@ SELECT pk FROM tab2 WHERE col0 >= 18 AND col3 < 3
 ----
 
 statement ok
-DROP VIEW view_1_tab2_691
+DROP VIEW IF EXISTS view_1_tab2_691 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_691
+DROP VIEW IF EXISTS view_2_tab2_691 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_691
+DROP VIEW IF EXISTS view_3_tab2_691 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15564,13 +15564,13 @@ SELECT pk FROM tab3 WHERE col0 >= 18 AND col3 < 3
 ----
 
 statement ok
-DROP VIEW view_1_tab3_691
+DROP VIEW IF EXISTS view_1_tab3_691 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_691
+DROP VIEW IF EXISTS view_2_tab3_691 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_691
+DROP VIEW IF EXISTS view_3_tab3_691 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15656,13 +15656,13 @@ SELECT pk FROM tab4 WHERE col0 >= 18 AND col3 < 3
 ----
 
 statement ok
-DROP VIEW view_1_tab4_691
+DROP VIEW IF EXISTS view_1_tab4_691 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_691
+DROP VIEW IF EXISTS view_2_tab4_691 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_691
+DROP VIEW IF EXISTS view_3_tab4_691 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15762,13 +15762,13 @@ SELECT pk FROM tab0 WHERE col1 > 5.53 AND col0 > 60
 3
 
 statement ok
-DROP VIEW view_1_tab0_692
+DROP VIEW IF EXISTS view_1_tab0_692 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_692
+DROP VIEW IF EXISTS view_2_tab0_692 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_692
+DROP VIEW IF EXISTS view_3_tab0_692 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15868,13 +15868,13 @@ SELECT pk FROM tab1 WHERE col1 > 5.53 AND col0 > 60
 3
 
 statement ok
-DROP VIEW view_1_tab1_692
+DROP VIEW IF EXISTS view_1_tab1_692 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_692
+DROP VIEW IF EXISTS view_2_tab1_692 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_692
+DROP VIEW IF EXISTS view_3_tab1_692 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15974,13 +15974,13 @@ SELECT pk FROM tab2 WHERE col1 > 5.53 AND col0 > 60
 3
 
 statement ok
-DROP VIEW view_1_tab2_692
+DROP VIEW IF EXISTS view_1_tab2_692 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_692
+DROP VIEW IF EXISTS view_2_tab2_692 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_692
+DROP VIEW IF EXISTS view_3_tab2_692 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16080,13 +16080,13 @@ SELECT pk FROM tab3 WHERE col1 > 5.53 AND col0 > 60
 3
 
 statement ok
-DROP VIEW view_1_tab3_692
+DROP VIEW IF EXISTS view_1_tab3_692 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_692
+DROP VIEW IF EXISTS view_2_tab3_692 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_692
+DROP VIEW IF EXISTS view_3_tab3_692 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16186,13 +16186,13 @@ SELECT pk FROM tab4 WHERE col1 > 5.53 AND col0 > 60
 3
 
 statement ok
-DROP VIEW view_1_tab4_692
+DROP VIEW IF EXISTS view_1_tab4_692 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_692
+DROP VIEW IF EXISTS view_2_tab4_692 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_692
+DROP VIEW IF EXISTS view_3_tab4_692 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16292,13 +16292,13 @@ SELECT pk FROM tab0 WHERE (((col3 < 17 OR col1 > 64.64 AND (col1 IS NULL) OR (co
 3
 
 statement ok
-DROP VIEW view_1_tab0_693
+DROP VIEW IF EXISTS view_1_tab0_693 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_693
+DROP VIEW IF EXISTS view_2_tab0_693 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_693
+DROP VIEW IF EXISTS view_3_tab0_693 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16398,13 +16398,13 @@ SELECT pk FROM tab1 WHERE (((col3 < 17 OR col1 > 64.64 AND (col1 IS NULL) OR (co
 3
 
 statement ok
-DROP VIEW view_1_tab1_693
+DROP VIEW IF EXISTS view_1_tab1_693 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_693
+DROP VIEW IF EXISTS view_2_tab1_693 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_693
+DROP VIEW IF EXISTS view_3_tab1_693 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16504,13 +16504,13 @@ SELECT pk FROM tab2 WHERE (((col3 < 17 OR col1 > 64.64 AND (col1 IS NULL) OR (co
 3
 
 statement ok
-DROP VIEW view_1_tab2_693
+DROP VIEW IF EXISTS view_1_tab2_693 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_693
+DROP VIEW IF EXISTS view_2_tab2_693 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_693
+DROP VIEW IF EXISTS view_3_tab2_693 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16610,13 +16610,13 @@ SELECT pk FROM tab3 WHERE (((col3 < 17 OR col1 > 64.64 AND (col1 IS NULL) OR (co
 3
 
 statement ok
-DROP VIEW view_1_tab3_693
+DROP VIEW IF EXISTS view_1_tab3_693 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_693
+DROP VIEW IF EXISTS view_2_tab3_693 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_693
+DROP VIEW IF EXISTS view_3_tab3_693 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16716,13 +16716,13 @@ SELECT pk FROM tab4 WHERE (((col3 < 17 OR col1 > 64.64 AND (col1 IS NULL) OR (co
 3
 
 statement ok
-DROP VIEW view_1_tab4_693
+DROP VIEW IF EXISTS view_1_tab4_693 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_693
+DROP VIEW IF EXISTS view_2_tab4_693 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_693
+DROP VIEW IF EXISTS view_3_tab4_693 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16815,13 +16815,13 @@ SELECT pk FROM tab0 WHERE ((col1 < 97.33)) OR col0 >= 41 OR col3 < 21
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab0_695
+DROP VIEW IF EXISTS view_1_tab0_695 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_695
+DROP VIEW IF EXISTS view_2_tab0_695 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_695
+DROP VIEW IF EXISTS view_3_tab0_695 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16914,13 +16914,13 @@ SELECT pk FROM tab1 WHERE ((col1 < 97.33)) OR col0 >= 41 OR col3 < 21
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab1_695
+DROP VIEW IF EXISTS view_1_tab1_695 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_695
+DROP VIEW IF EXISTS view_2_tab1_695 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_695
+DROP VIEW IF EXISTS view_3_tab1_695 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17013,13 +17013,13 @@ SELECT pk FROM tab2 WHERE ((col1 < 97.33)) OR col0 >= 41 OR col3 < 21
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab2_695
+DROP VIEW IF EXISTS view_1_tab2_695 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_695
+DROP VIEW IF EXISTS view_2_tab2_695 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_695
+DROP VIEW IF EXISTS view_3_tab2_695 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17112,13 +17112,13 @@ SELECT pk FROM tab3 WHERE ((col1 < 97.33)) OR col0 >= 41 OR col3 < 21
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab3_695
+DROP VIEW IF EXISTS view_1_tab3_695 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_695
+DROP VIEW IF EXISTS view_2_tab3_695 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_695
+DROP VIEW IF EXISTS view_3_tab3_695 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17211,13 +17211,13 @@ SELECT pk FROM tab4 WHERE ((col1 < 97.33)) OR col0 >= 41 OR col3 < 21
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab4_695
+DROP VIEW IF EXISTS view_1_tab4_695 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_695
+DROP VIEW IF EXISTS view_2_tab4_695 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_695
+DROP VIEW IF EXISTS view_3_tab4_695 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17335,13 +17335,13 @@ SELECT pk FROM tab0 WHERE col0 <= 68
 9
 
 statement ok
-DROP VIEW view_1_tab0_696
+DROP VIEW IF EXISTS view_1_tab0_696 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_696
+DROP VIEW IF EXISTS view_2_tab0_696 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_696
+DROP VIEW IF EXISTS view_3_tab0_696 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17459,13 +17459,13 @@ SELECT pk FROM tab1 WHERE col0 <= 68
 9
 
 statement ok
-DROP VIEW view_1_tab1_696
+DROP VIEW IF EXISTS view_1_tab1_696 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_696
+DROP VIEW IF EXISTS view_2_tab1_696 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_696
+DROP VIEW IF EXISTS view_3_tab1_696 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17583,13 +17583,13 @@ SELECT pk FROM tab2 WHERE col0 <= 68
 9
 
 statement ok
-DROP VIEW view_1_tab2_696
+DROP VIEW IF EXISTS view_1_tab2_696 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_696
+DROP VIEW IF EXISTS view_2_tab2_696 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_696
+DROP VIEW IF EXISTS view_3_tab2_696 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17707,13 +17707,13 @@ SELECT pk FROM tab3 WHERE col0 <= 68
 9
 
 statement ok
-DROP VIEW view_1_tab3_696
+DROP VIEW IF EXISTS view_1_tab3_696 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_696
+DROP VIEW IF EXISTS view_2_tab3_696 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_696
+DROP VIEW IF EXISTS view_3_tab3_696 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17831,13 +17831,13 @@ SELECT pk FROM tab4 WHERE col0 <= 68
 9
 
 statement ok
-DROP VIEW view_1_tab4_696
+DROP VIEW IF EXISTS view_1_tab4_696 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_696
+DROP VIEW IF EXISTS view_2_tab4_696 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_696
+DROP VIEW IF EXISTS view_3_tab4_696 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17923,13 +17923,13 @@ SELECT pk FROM tab0 WHERE col1 = 61.96
 ----
 
 statement ok
-DROP VIEW view_1_tab0_697
+DROP VIEW IF EXISTS view_1_tab0_697 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_697
+DROP VIEW IF EXISTS view_2_tab0_697 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_697
+DROP VIEW IF EXISTS view_3_tab0_697 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18015,13 +18015,13 @@ SELECT pk FROM tab1 WHERE col1 = 61.96
 ----
 
 statement ok
-DROP VIEW view_1_tab1_697
+DROP VIEW IF EXISTS view_1_tab1_697 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_697
+DROP VIEW IF EXISTS view_2_tab1_697 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_697
+DROP VIEW IF EXISTS view_3_tab1_697 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18107,13 +18107,13 @@ SELECT pk FROM tab2 WHERE col1 = 61.96
 ----
 
 statement ok
-DROP VIEW view_1_tab2_697
+DROP VIEW IF EXISTS view_1_tab2_697 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_697
+DROP VIEW IF EXISTS view_2_tab2_697 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_697
+DROP VIEW IF EXISTS view_3_tab2_697 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18199,13 +18199,13 @@ SELECT pk FROM tab3 WHERE col1 = 61.96
 ----
 
 statement ok
-DROP VIEW view_1_tab3_697
+DROP VIEW IF EXISTS view_1_tab3_697 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_697
+DROP VIEW IF EXISTS view_2_tab3_697 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_697
+DROP VIEW IF EXISTS view_3_tab3_697 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18291,13 +18291,13 @@ SELECT pk FROM tab4 WHERE col1 = 61.96
 ----
 
 statement ok
-DROP VIEW view_1_tab4_697
+DROP VIEW IF EXISTS view_1_tab4_697 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_697
+DROP VIEW IF EXISTS view_2_tab4_697 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_697
+DROP VIEW IF EXISTS view_3_tab4_697 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18386,13 +18386,13 @@ SELECT pk FROM tab0 WHERE ((col1 <= 14.36 OR col4 < 55.29) OR col3 <= 66 OR col3
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_698
+DROP VIEW IF EXISTS view_1_tab0_698 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_698
+DROP VIEW IF EXISTS view_2_tab0_698 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_698
+DROP VIEW IF EXISTS view_3_tab0_698 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18481,13 +18481,13 @@ SELECT pk FROM tab1 WHERE ((col1 <= 14.36 OR col4 < 55.29) OR col3 <= 66 OR col3
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_698
+DROP VIEW IF EXISTS view_1_tab1_698 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_698
+DROP VIEW IF EXISTS view_2_tab1_698 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_698
+DROP VIEW IF EXISTS view_3_tab1_698 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18576,13 +18576,13 @@ SELECT pk FROM tab2 WHERE ((col1 <= 14.36 OR col4 < 55.29) OR col3 <= 66 OR col3
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_698
+DROP VIEW IF EXISTS view_1_tab2_698 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_698
+DROP VIEW IF EXISTS view_2_tab2_698 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_698
+DROP VIEW IF EXISTS view_3_tab2_698 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18671,13 +18671,13 @@ SELECT pk FROM tab3 WHERE ((col1 <= 14.36 OR col4 < 55.29) OR col3 <= 66 OR col3
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_698
+DROP VIEW IF EXISTS view_1_tab3_698 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_698
+DROP VIEW IF EXISTS view_2_tab3_698 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_698
+DROP VIEW IF EXISTS view_3_tab3_698 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18766,13 +18766,13 @@ SELECT pk FROM tab4 WHERE ((col1 <= 14.36 OR col4 < 55.29) OR col3 <= 66 OR col3
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_698
+DROP VIEW IF EXISTS view_1_tab4_698 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_698
+DROP VIEW IF EXISTS view_2_tab4_698 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_698
+DROP VIEW IF EXISTS view_3_tab4_698 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18872,13 +18872,13 @@ SELECT pk FROM tab0 WHERE col0 > 48 AND ((col3 IN (36,51,8) OR (col4 < 14.74 OR 
 3
 
 statement ok
-DROP VIEW view_1_tab0_699
+DROP VIEW IF EXISTS view_1_tab0_699 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_699
+DROP VIEW IF EXISTS view_2_tab0_699 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_699
+DROP VIEW IF EXISTS view_3_tab0_699 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18978,13 +18978,13 @@ SELECT pk FROM tab1 WHERE col0 > 48 AND ((col3 IN (36,51,8) OR (col4 < 14.74 OR 
 3
 
 statement ok
-DROP VIEW view_1_tab1_699
+DROP VIEW IF EXISTS view_1_tab1_699 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_699
+DROP VIEW IF EXISTS view_2_tab1_699 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_699
+DROP VIEW IF EXISTS view_3_tab1_699 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19084,13 +19084,13 @@ SELECT pk FROM tab2 WHERE col0 > 48 AND ((col3 IN (36,51,8) OR (col4 < 14.74 OR 
 3
 
 statement ok
-DROP VIEW view_1_tab2_699
+DROP VIEW IF EXISTS view_1_tab2_699 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_699
+DROP VIEW IF EXISTS view_2_tab2_699 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_699
+DROP VIEW IF EXISTS view_3_tab2_699 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19190,13 +19190,13 @@ SELECT pk FROM tab3 WHERE col0 > 48 AND ((col3 IN (36,51,8) OR (col4 < 14.74 OR 
 3
 
 statement ok
-DROP VIEW view_1_tab3_699
+DROP VIEW IF EXISTS view_1_tab3_699 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_699
+DROP VIEW IF EXISTS view_2_tab3_699 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_699
+DROP VIEW IF EXISTS view_3_tab3_699 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19296,13 +19296,13 @@ SELECT pk FROM tab4 WHERE col0 > 48 AND ((col3 IN (36,51,8) OR (col4 < 14.74 OR 
 3
 
 statement ok
-DROP VIEW view_1_tab4_699
+DROP VIEW IF EXISTS view_1_tab4_699 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_699
+DROP VIEW IF EXISTS view_2_tab4_699 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_699
+DROP VIEW IF EXISTS view_3_tab4_699 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19388,13 +19388,13 @@ SELECT pk FROM tab0 WHERE (col0 >= 18 AND (col1 > 39.63 AND col0 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_700
+DROP VIEW IF EXISTS view_1_tab0_700 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_700
+DROP VIEW IF EXISTS view_2_tab0_700 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_700
+DROP VIEW IF EXISTS view_3_tab0_700 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19480,13 +19480,13 @@ SELECT pk FROM tab1 WHERE (col0 >= 18 AND (col1 > 39.63 AND col0 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_700
+DROP VIEW IF EXISTS view_1_tab1_700 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_700
+DROP VIEW IF EXISTS view_2_tab1_700 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_700
+DROP VIEW IF EXISTS view_3_tab1_700 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19572,13 +19572,13 @@ SELECT pk FROM tab2 WHERE (col0 >= 18 AND (col1 > 39.63 AND col0 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_700
+DROP VIEW IF EXISTS view_1_tab2_700 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_700
+DROP VIEW IF EXISTS view_2_tab2_700 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_700
+DROP VIEW IF EXISTS view_3_tab2_700 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19664,13 +19664,13 @@ SELECT pk FROM tab3 WHERE (col0 >= 18 AND (col1 > 39.63 AND col0 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_700
+DROP VIEW IF EXISTS view_1_tab3_700 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_700
+DROP VIEW IF EXISTS view_2_tab3_700 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_700
+DROP VIEW IF EXISTS view_3_tab3_700 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19756,13 +19756,13 @@ SELECT pk FROM tab4 WHERE (col0 >= 18 AND (col1 > 39.63 AND col0 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_700
+DROP VIEW IF EXISTS view_1_tab4_700 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_700
+DROP VIEW IF EXISTS view_2_tab4_700 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_700
+DROP VIEW IF EXISTS view_3_tab4_700 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19862,13 +19862,13 @@ SELECT pk FROM tab0 WHERE col0 >= 77
 3
 
 statement ok
-DROP VIEW view_1_tab0_701
+DROP VIEW IF EXISTS view_1_tab0_701 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_701
+DROP VIEW IF EXISTS view_2_tab0_701 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_701
+DROP VIEW IF EXISTS view_3_tab0_701 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19968,13 +19968,13 @@ SELECT pk FROM tab1 WHERE col0 >= 77
 3
 
 statement ok
-DROP VIEW view_1_tab1_701
+DROP VIEW IF EXISTS view_1_tab1_701 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_701
+DROP VIEW IF EXISTS view_2_tab1_701 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_701
+DROP VIEW IF EXISTS view_3_tab1_701 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20074,13 +20074,13 @@ SELECT pk FROM tab2 WHERE col0 >= 77
 3
 
 statement ok
-DROP VIEW view_1_tab2_701
+DROP VIEW IF EXISTS view_1_tab2_701 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_701
+DROP VIEW IF EXISTS view_2_tab2_701 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_701
+DROP VIEW IF EXISTS view_3_tab2_701 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20180,13 +20180,13 @@ SELECT pk FROM tab3 WHERE col0 >= 77
 3
 
 statement ok
-DROP VIEW view_1_tab3_701
+DROP VIEW IF EXISTS view_1_tab3_701 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_701
+DROP VIEW IF EXISTS view_2_tab3_701 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_701
+DROP VIEW IF EXISTS view_3_tab3_701 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20286,13 +20286,13 @@ SELECT pk FROM tab4 WHERE col0 >= 77
 3
 
 statement ok
-DROP VIEW view_1_tab4_701
+DROP VIEW IF EXISTS view_1_tab4_701 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_701
+DROP VIEW IF EXISTS view_2_tab4_701 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_701
+DROP VIEW IF EXISTS view_3_tab4_701 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20399,13 +20399,13 @@ SELECT pk FROM tab0 WHERE col3 BETWEEN 72 AND 27 OR col3 <= 37
 7
 
 statement ok
-DROP VIEW view_1_tab0_702
+DROP VIEW IF EXISTS view_1_tab0_702 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_702
+DROP VIEW IF EXISTS view_2_tab0_702 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_702
+DROP VIEW IF EXISTS view_3_tab0_702 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20512,13 +20512,13 @@ SELECT pk FROM tab1 WHERE col3 BETWEEN 72 AND 27 OR col3 <= 37
 7
 
 statement ok
-DROP VIEW view_1_tab1_702
+DROP VIEW IF EXISTS view_1_tab1_702 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_702
+DROP VIEW IF EXISTS view_2_tab1_702 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_702
+DROP VIEW IF EXISTS view_3_tab1_702 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20625,13 +20625,13 @@ SELECT pk FROM tab2 WHERE col3 BETWEEN 72 AND 27 OR col3 <= 37
 7
 
 statement ok
-DROP VIEW view_1_tab2_702
+DROP VIEW IF EXISTS view_1_tab2_702 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_702
+DROP VIEW IF EXISTS view_2_tab2_702 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_702
+DROP VIEW IF EXISTS view_3_tab2_702 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20738,13 +20738,13 @@ SELECT pk FROM tab3 WHERE col3 BETWEEN 72 AND 27 OR col3 <= 37
 7
 
 statement ok
-DROP VIEW view_1_tab3_702
+DROP VIEW IF EXISTS view_1_tab3_702 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_702
+DROP VIEW IF EXISTS view_2_tab3_702 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_702
+DROP VIEW IF EXISTS view_3_tab3_702 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20851,13 +20851,13 @@ SELECT pk FROM tab4 WHERE col3 BETWEEN 72 AND 27 OR col3 <= 37
 7
 
 statement ok
-DROP VIEW view_1_tab4_702
+DROP VIEW IF EXISTS view_1_tab4_702 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_702
+DROP VIEW IF EXISTS view_2_tab4_702 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_702
+DROP VIEW IF EXISTS view_3_tab4_702 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20950,13 +20950,13 @@ SELECT pk FROM tab0 WHERE col1 >= 92.4
 6
 
 statement ok
-DROP VIEW view_1_tab0_703
+DROP VIEW IF EXISTS view_1_tab0_703 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_703
+DROP VIEW IF EXISTS view_2_tab0_703 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_703
+DROP VIEW IF EXISTS view_3_tab0_703 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21049,13 +21049,13 @@ SELECT pk FROM tab1 WHERE col1 >= 92.4
 6
 
 statement ok
-DROP VIEW view_1_tab1_703
+DROP VIEW IF EXISTS view_1_tab1_703 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_703
+DROP VIEW IF EXISTS view_2_tab1_703 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_703
+DROP VIEW IF EXISTS view_3_tab1_703 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21148,13 +21148,13 @@ SELECT pk FROM tab2 WHERE col1 >= 92.4
 6
 
 statement ok
-DROP VIEW view_1_tab2_703
+DROP VIEW IF EXISTS view_1_tab2_703 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_703
+DROP VIEW IF EXISTS view_2_tab2_703 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_703
+DROP VIEW IF EXISTS view_3_tab2_703 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21247,13 +21247,13 @@ SELECT pk FROM tab3 WHERE col1 >= 92.4
 6
 
 statement ok
-DROP VIEW view_1_tab3_703
+DROP VIEW IF EXISTS view_1_tab3_703 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_703
+DROP VIEW IF EXISTS view_2_tab3_703 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_703
+DROP VIEW IF EXISTS view_3_tab3_703 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21346,13 +21346,13 @@ SELECT pk FROM tab4 WHERE col1 >= 92.4
 6
 
 statement ok
-DROP VIEW view_1_tab4_703
+DROP VIEW IF EXISTS view_1_tab4_703 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_703
+DROP VIEW IF EXISTS view_2_tab4_703 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_703
+DROP VIEW IF EXISTS view_3_tab4_703 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21441,13 +21441,13 @@ SELECT pk FROM tab0 WHERE (col3 < 48 OR (((col1 < 79.41 OR col0 IN (82,46,57,14,
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_704
+DROP VIEW IF EXISTS view_1_tab0_704 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_704
+DROP VIEW IF EXISTS view_2_tab0_704 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_704
+DROP VIEW IF EXISTS view_3_tab0_704 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21536,13 +21536,13 @@ SELECT pk FROM tab1 WHERE (col3 < 48 OR (((col1 < 79.41 OR col0 IN (82,46,57,14,
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_704
+DROP VIEW IF EXISTS view_1_tab1_704 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_704
+DROP VIEW IF EXISTS view_2_tab1_704 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_704
+DROP VIEW IF EXISTS view_3_tab1_704 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21631,13 +21631,13 @@ SELECT pk FROM tab2 WHERE (col3 < 48 OR (((col1 < 79.41 OR col0 IN (82,46,57,14,
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_704
+DROP VIEW IF EXISTS view_1_tab2_704 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_704
+DROP VIEW IF EXISTS view_2_tab2_704 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_704
+DROP VIEW IF EXISTS view_3_tab2_704 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21726,13 +21726,13 @@ SELECT pk FROM tab3 WHERE (col3 < 48 OR (((col1 < 79.41 OR col0 IN (82,46,57,14,
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_704
+DROP VIEW IF EXISTS view_1_tab3_704 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_704
+DROP VIEW IF EXISTS view_2_tab3_704 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_704
+DROP VIEW IF EXISTS view_3_tab3_704 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21821,13 +21821,13 @@ SELECT pk FROM tab4 WHERE (col3 < 48 OR (((col1 < 79.41 OR col0 IN (82,46,57,14,
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_704
+DROP VIEW IF EXISTS view_1_tab4_704 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_704
+DROP VIEW IF EXISTS view_2_tab4_704 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_704
+DROP VIEW IF EXISTS view_3_tab4_704 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21920,13 +21920,13 @@ SELECT pk FROM tab0 WHERE col3 > 74
 8
 
 statement ok
-DROP VIEW view_1_tab0_705
+DROP VIEW IF EXISTS view_1_tab0_705 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_705
+DROP VIEW IF EXISTS view_2_tab0_705 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_705
+DROP VIEW IF EXISTS view_3_tab0_705 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22019,13 +22019,13 @@ SELECT pk FROM tab1 WHERE col3 > 74
 8
 
 statement ok
-DROP VIEW view_1_tab1_705
+DROP VIEW IF EXISTS view_1_tab1_705 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_705
+DROP VIEW IF EXISTS view_2_tab1_705 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_705
+DROP VIEW IF EXISTS view_3_tab1_705 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22118,13 +22118,13 @@ SELECT pk FROM tab2 WHERE col3 > 74
 8
 
 statement ok
-DROP VIEW view_1_tab2_705
+DROP VIEW IF EXISTS view_1_tab2_705 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_705
+DROP VIEW IF EXISTS view_2_tab2_705 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_705
+DROP VIEW IF EXISTS view_3_tab2_705 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22217,13 +22217,13 @@ SELECT pk FROM tab3 WHERE col3 > 74
 8
 
 statement ok
-DROP VIEW view_1_tab3_705
+DROP VIEW IF EXISTS view_1_tab3_705 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_705
+DROP VIEW IF EXISTS view_2_tab3_705 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_705
+DROP VIEW IF EXISTS view_3_tab3_705 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22316,13 +22316,13 @@ SELECT pk FROM tab4 WHERE col3 > 74
 8
 
 statement ok
-DROP VIEW view_1_tab4_705
+DROP VIEW IF EXISTS view_1_tab4_705 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_705
+DROP VIEW IF EXISTS view_2_tab4_705 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_705
+DROP VIEW IF EXISTS view_3_tab4_705 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22411,13 +22411,13 @@ SELECT pk FROM tab0 WHERE (col3 > 38 OR (col3 <= 52))
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_706
+DROP VIEW IF EXISTS view_1_tab0_706 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_706
+DROP VIEW IF EXISTS view_2_tab0_706 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_706
+DROP VIEW IF EXISTS view_3_tab0_706 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22506,13 +22506,13 @@ SELECT pk FROM tab1 WHERE (col3 > 38 OR (col3 <= 52))
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_706
+DROP VIEW IF EXISTS view_1_tab1_706 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_706
+DROP VIEW IF EXISTS view_2_tab1_706 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_706
+DROP VIEW IF EXISTS view_3_tab1_706 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22601,13 +22601,13 @@ SELECT pk FROM tab2 WHERE (col3 > 38 OR (col3 <= 52))
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_706
+DROP VIEW IF EXISTS view_1_tab2_706 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_706
+DROP VIEW IF EXISTS view_2_tab2_706 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_706
+DROP VIEW IF EXISTS view_3_tab2_706 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22696,13 +22696,13 @@ SELECT pk FROM tab3 WHERE (col3 > 38 OR (col3 <= 52))
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_706
+DROP VIEW IF EXISTS view_1_tab3_706 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_706
+DROP VIEW IF EXISTS view_2_tab3_706 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_706
+DROP VIEW IF EXISTS view_3_tab3_706 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22791,13 +22791,13 @@ SELECT pk FROM tab4 WHERE (col3 > 38 OR (col3 <= 52))
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_706
+DROP VIEW IF EXISTS view_1_tab4_706 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_706
+DROP VIEW IF EXISTS view_2_tab4_706 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_706
+DROP VIEW IF EXISTS view_3_tab4_706 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22915,13 +22915,13 @@ SELECT pk FROM tab0 WHERE col0 <= 58
 9
 
 statement ok
-DROP VIEW view_1_tab0_707
+DROP VIEW IF EXISTS view_1_tab0_707 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_707
+DROP VIEW IF EXISTS view_2_tab0_707 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_707
+DROP VIEW IF EXISTS view_3_tab0_707 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23039,13 +23039,13 @@ SELECT pk FROM tab1 WHERE col0 <= 58
 9
 
 statement ok
-DROP VIEW view_1_tab1_707
+DROP VIEW IF EXISTS view_1_tab1_707 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_707
+DROP VIEW IF EXISTS view_2_tab1_707 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_707
+DROP VIEW IF EXISTS view_3_tab1_707 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23163,13 +23163,13 @@ SELECT pk FROM tab2 WHERE col0 <= 58
 9
 
 statement ok
-DROP VIEW view_1_tab2_707
+DROP VIEW IF EXISTS view_1_tab2_707 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_707
+DROP VIEW IF EXISTS view_2_tab2_707 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_707
+DROP VIEW IF EXISTS view_3_tab2_707 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23287,13 +23287,13 @@ SELECT pk FROM tab3 WHERE col0 <= 58
 9
 
 statement ok
-DROP VIEW view_1_tab3_707
+DROP VIEW IF EXISTS view_1_tab3_707 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_707
+DROP VIEW IF EXISTS view_2_tab3_707 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_707
+DROP VIEW IF EXISTS view_3_tab3_707 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23411,13 +23411,13 @@ SELECT pk FROM tab4 WHERE col0 <= 58
 9
 
 statement ok
-DROP VIEW view_1_tab4_707
+DROP VIEW IF EXISTS view_1_tab4_707 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_707
+DROP VIEW IF EXISTS view_2_tab4_707 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_707
+DROP VIEW IF EXISTS view_3_tab4_707 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23535,13 +23535,13 @@ SELECT pk FROM tab0 WHERE col0 <= 50 OR col0 BETWEEN 41 AND 65 OR col4 >= 84.93
 9
 
 statement ok
-DROP VIEW view_1_tab0_708
+DROP VIEW IF EXISTS view_1_tab0_708 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_708
+DROP VIEW IF EXISTS view_2_tab0_708 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_708
+DROP VIEW IF EXISTS view_3_tab0_708 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23659,13 +23659,13 @@ SELECT pk FROM tab1 WHERE col0 <= 50 OR col0 BETWEEN 41 AND 65 OR col4 >= 84.93
 9
 
 statement ok
-DROP VIEW view_1_tab1_708
+DROP VIEW IF EXISTS view_1_tab1_708 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_708
+DROP VIEW IF EXISTS view_2_tab1_708 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_708
+DROP VIEW IF EXISTS view_3_tab1_708 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23783,13 +23783,13 @@ SELECT pk FROM tab2 WHERE col0 <= 50 OR col0 BETWEEN 41 AND 65 OR col4 >= 84.93
 9
 
 statement ok
-DROP VIEW view_1_tab2_708
+DROP VIEW IF EXISTS view_1_tab2_708 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_708
+DROP VIEW IF EXISTS view_2_tab2_708 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_708
+DROP VIEW IF EXISTS view_3_tab2_708 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23907,13 +23907,13 @@ SELECT pk FROM tab3 WHERE col0 <= 50 OR col0 BETWEEN 41 AND 65 OR col4 >= 84.93
 9
 
 statement ok
-DROP VIEW view_1_tab3_708
+DROP VIEW IF EXISTS view_1_tab3_708 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_708
+DROP VIEW IF EXISTS view_2_tab3_708 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_708
+DROP VIEW IF EXISTS view_3_tab3_708 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24031,13 +24031,13 @@ SELECT pk FROM tab4 WHERE col0 <= 50 OR col0 BETWEEN 41 AND 65 OR col4 >= 84.93
 9
 
 statement ok
-DROP VIEW view_1_tab4_708
+DROP VIEW IF EXISTS view_1_tab4_708 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_708
+DROP VIEW IF EXISTS view_2_tab4_708 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_708
+DROP VIEW IF EXISTS view_3_tab4_708 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24123,13 +24123,13 @@ SELECT pk FROM tab0 WHERE col3 <= 46 AND col3 >= 73 OR (((((((col3 <= 87) OR col
 ----
 
 statement ok
-DROP VIEW view_1_tab0_709
+DROP VIEW IF EXISTS view_1_tab0_709 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_709
+DROP VIEW IF EXISTS view_2_tab0_709 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_709
+DROP VIEW IF EXISTS view_3_tab0_709 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24215,13 +24215,13 @@ SELECT pk FROM tab1 WHERE col3 <= 46 AND col3 >= 73 OR (((((((col3 <= 87) OR col
 ----
 
 statement ok
-DROP VIEW view_1_tab1_709
+DROP VIEW IF EXISTS view_1_tab1_709 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_709
+DROP VIEW IF EXISTS view_2_tab1_709 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_709
+DROP VIEW IF EXISTS view_3_tab1_709 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24307,13 +24307,13 @@ SELECT pk FROM tab2 WHERE col3 <= 46 AND col3 >= 73 OR (((((((col3 <= 87) OR col
 ----
 
 statement ok
-DROP VIEW view_1_tab2_709
+DROP VIEW IF EXISTS view_1_tab2_709 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_709
+DROP VIEW IF EXISTS view_2_tab2_709 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_709
+DROP VIEW IF EXISTS view_3_tab2_709 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24399,13 +24399,13 @@ SELECT pk FROM tab3 WHERE col3 <= 46 AND col3 >= 73 OR (((((((col3 <= 87) OR col
 ----
 
 statement ok
-DROP VIEW view_1_tab3_709
+DROP VIEW IF EXISTS view_1_tab3_709 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_709
+DROP VIEW IF EXISTS view_2_tab3_709 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_709
+DROP VIEW IF EXISTS view_3_tab3_709 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24491,13 +24491,13 @@ SELECT pk FROM tab4 WHERE col3 <= 46 AND col3 >= 73 OR (((((((col3 <= 87) OR col
 ----
 
 statement ok
-DROP VIEW view_1_tab4_709
+DROP VIEW IF EXISTS view_1_tab4_709 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_709
+DROP VIEW IF EXISTS view_2_tab4_709 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_709
+DROP VIEW IF EXISTS view_3_tab4_709 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24590,13 +24590,13 @@ SELECT pk FROM tab0 WHERE col1 > 98.48
 6
 
 statement ok
-DROP VIEW view_1_tab0_710
+DROP VIEW IF EXISTS view_1_tab0_710 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_710
+DROP VIEW IF EXISTS view_2_tab0_710 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_710
+DROP VIEW IF EXISTS view_3_tab0_710 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24689,13 +24689,13 @@ SELECT pk FROM tab1 WHERE col1 > 98.48
 6
 
 statement ok
-DROP VIEW view_1_tab1_710
+DROP VIEW IF EXISTS view_1_tab1_710 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_710
+DROP VIEW IF EXISTS view_2_tab1_710 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_710
+DROP VIEW IF EXISTS view_3_tab1_710 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24788,13 +24788,13 @@ SELECT pk FROM tab2 WHERE col1 > 98.48
 6
 
 statement ok
-DROP VIEW view_1_tab2_710
+DROP VIEW IF EXISTS view_1_tab2_710 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_710
+DROP VIEW IF EXISTS view_2_tab2_710 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_710
+DROP VIEW IF EXISTS view_3_tab2_710 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24887,13 +24887,13 @@ SELECT pk FROM tab3 WHERE col1 > 98.48
 6
 
 statement ok
-DROP VIEW view_1_tab3_710
+DROP VIEW IF EXISTS view_1_tab3_710 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_710
+DROP VIEW IF EXISTS view_2_tab3_710 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_710
+DROP VIEW IF EXISTS view_3_tab3_710 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24986,13 +24986,13 @@ SELECT pk FROM tab4 WHERE col1 > 98.48
 6
 
 statement ok
-DROP VIEW view_1_tab4_710
+DROP VIEW IF EXISTS view_1_tab4_710 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_710
+DROP VIEW IF EXISTS view_2_tab4_710 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_710
+DROP VIEW IF EXISTS view_3_tab4_710 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25106,13 +25106,13 @@ SELECT pk FROM tab0 WHERE ((col0 <= 45) AND (((col0 > 47 OR ((col0 <= 52)) AND (
 9
 
 statement ok
-DROP VIEW view_1_tab0_711
+DROP VIEW IF EXISTS view_1_tab0_711 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_711
+DROP VIEW IF EXISTS view_2_tab0_711 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_711
+DROP VIEW IF EXISTS view_3_tab0_711 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25226,13 +25226,13 @@ SELECT pk FROM tab1 WHERE ((col0 <= 45) AND (((col0 > 47 OR ((col0 <= 52)) AND (
 9
 
 statement ok
-DROP VIEW view_1_tab1_711
+DROP VIEW IF EXISTS view_1_tab1_711 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_711
+DROP VIEW IF EXISTS view_2_tab1_711 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_711
+DROP VIEW IF EXISTS view_3_tab1_711 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25346,13 +25346,13 @@ SELECT pk FROM tab2 WHERE ((col0 <= 45) AND (((col0 > 47 OR ((col0 <= 52)) AND (
 9
 
 statement ok
-DROP VIEW view_1_tab2_711
+DROP VIEW IF EXISTS view_1_tab2_711 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_711
+DROP VIEW IF EXISTS view_2_tab2_711 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_711
+DROP VIEW IF EXISTS view_3_tab2_711 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25466,13 +25466,13 @@ SELECT pk FROM tab3 WHERE ((col0 <= 45) AND (((col0 > 47 OR ((col0 <= 52)) AND (
 9
 
 statement ok
-DROP VIEW view_1_tab3_711
+DROP VIEW IF EXISTS view_1_tab3_711 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_711
+DROP VIEW IF EXISTS view_2_tab3_711 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_711
+DROP VIEW IF EXISTS view_3_tab3_711 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25586,13 +25586,13 @@ SELECT pk FROM tab4 WHERE ((col0 <= 45) AND (((col0 > 47 OR ((col0 <= 52)) AND (
 9
 
 statement ok
-DROP VIEW view_1_tab4_711
+DROP VIEW IF EXISTS view_1_tab4_711 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_711
+DROP VIEW IF EXISTS view_2_tab4_711 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_711
+DROP VIEW IF EXISTS view_3_tab4_711 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25699,13 +25699,13 @@ SELECT pk FROM tab0 WHERE (col0 > 46)
 3
 
 statement ok
-DROP VIEW view_1_tab0_712
+DROP VIEW IF EXISTS view_1_tab0_712 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_712
+DROP VIEW IF EXISTS view_2_tab0_712 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_712
+DROP VIEW IF EXISTS view_3_tab0_712 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25812,13 +25812,13 @@ SELECT pk FROM tab1 WHERE (col0 > 46)
 3
 
 statement ok
-DROP VIEW view_1_tab1_712
+DROP VIEW IF EXISTS view_1_tab1_712 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_712
+DROP VIEW IF EXISTS view_2_tab1_712 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_712
+DROP VIEW IF EXISTS view_3_tab1_712 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25925,13 +25925,13 @@ SELECT pk FROM tab2 WHERE (col0 > 46)
 3
 
 statement ok
-DROP VIEW view_1_tab2_712
+DROP VIEW IF EXISTS view_1_tab2_712 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_712
+DROP VIEW IF EXISTS view_2_tab2_712 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_712
+DROP VIEW IF EXISTS view_3_tab2_712 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26038,13 +26038,13 @@ SELECT pk FROM tab3 WHERE (col0 > 46)
 3
 
 statement ok
-DROP VIEW view_1_tab3_712
+DROP VIEW IF EXISTS view_1_tab3_712 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_712
+DROP VIEW IF EXISTS view_2_tab3_712 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_712
+DROP VIEW IF EXISTS view_3_tab3_712 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26151,13 +26151,13 @@ SELECT pk FROM tab4 WHERE (col0 > 46)
 3
 
 statement ok
-DROP VIEW view_1_tab4_712
+DROP VIEW IF EXISTS view_1_tab4_712 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_712
+DROP VIEW IF EXISTS view_2_tab4_712 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_712
+DROP VIEW IF EXISTS view_3_tab4_712 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26257,13 +26257,13 @@ SELECT pk FROM tab0 WHERE col0 > 79
 3
 
 statement ok
-DROP VIEW view_1_tab0_713
+DROP VIEW IF EXISTS view_1_tab0_713 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_713
+DROP VIEW IF EXISTS view_2_tab0_713 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_713
+DROP VIEW IF EXISTS view_3_tab0_713 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26363,13 +26363,13 @@ SELECT pk FROM tab1 WHERE col0 > 79
 3
 
 statement ok
-DROP VIEW view_1_tab1_713
+DROP VIEW IF EXISTS view_1_tab1_713 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_713
+DROP VIEW IF EXISTS view_2_tab1_713 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_713
+DROP VIEW IF EXISTS view_3_tab1_713 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26469,13 +26469,13 @@ SELECT pk FROM tab2 WHERE col0 > 79
 3
 
 statement ok
-DROP VIEW view_1_tab2_713
+DROP VIEW IF EXISTS view_1_tab2_713 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_713
+DROP VIEW IF EXISTS view_2_tab2_713 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_713
+DROP VIEW IF EXISTS view_3_tab2_713 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26575,13 +26575,13 @@ SELECT pk FROM tab3 WHERE col0 > 79
 3
 
 statement ok
-DROP VIEW view_1_tab3_713
+DROP VIEW IF EXISTS view_1_tab3_713 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_713
+DROP VIEW IF EXISTS view_2_tab3_713 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_713
+DROP VIEW IF EXISTS view_3_tab3_713 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26681,13 +26681,13 @@ SELECT pk FROM tab4 WHERE col0 > 79
 3
 
 statement ok
-DROP VIEW view_1_tab4_713
+DROP VIEW IF EXISTS view_1_tab4_713 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_713
+DROP VIEW IF EXISTS view_2_tab4_713 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_713
+DROP VIEW IF EXISTS view_3_tab4_713 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26807,13 +26807,13 @@ SELECT pk FROM tab0 WHERE col3 >= 33 AND (col0 < 40)
 9
 
 statement ok
-DROP VIEW view_1_tab0_714
+DROP VIEW IF EXISTS view_1_tab0_714 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_714
+DROP VIEW IF EXISTS view_2_tab0_714 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_714
+DROP VIEW IF EXISTS view_3_tab0_714 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26933,13 +26933,13 @@ SELECT pk FROM tab1 WHERE col3 >= 33 AND (col0 < 40)
 9
 
 statement ok
-DROP VIEW view_1_tab1_714
+DROP VIEW IF EXISTS view_1_tab1_714 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_714
+DROP VIEW IF EXISTS view_2_tab1_714 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_714
+DROP VIEW IF EXISTS view_3_tab1_714 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27059,13 +27059,13 @@ SELECT pk FROM tab2 WHERE col3 >= 33 AND (col0 < 40)
 9
 
 statement ok
-DROP VIEW view_1_tab2_714
+DROP VIEW IF EXISTS view_1_tab2_714 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_714
+DROP VIEW IF EXISTS view_2_tab2_714 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_714
+DROP VIEW IF EXISTS view_3_tab2_714 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27185,13 +27185,13 @@ SELECT pk FROM tab3 WHERE col3 >= 33 AND (col0 < 40)
 9
 
 statement ok
-DROP VIEW view_1_tab3_714
+DROP VIEW IF EXISTS view_1_tab3_714 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_714
+DROP VIEW IF EXISTS view_2_tab3_714 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_714
+DROP VIEW IF EXISTS view_3_tab3_714 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27311,13 +27311,13 @@ SELECT pk FROM tab4 WHERE col3 >= 33 AND (col0 < 40)
 9
 
 statement ok
-DROP VIEW view_1_tab4_714
+DROP VIEW IF EXISTS view_1_tab4_714 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_714
+DROP VIEW IF EXISTS view_2_tab4_714 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_714
+DROP VIEW IF EXISTS view_3_tab4_714 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27410,13 +27410,13 @@ SELECT pk FROM tab0 WHERE col0 <= 90
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab0_715
+DROP VIEW IF EXISTS view_1_tab0_715 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_715
+DROP VIEW IF EXISTS view_2_tab0_715 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_715
+DROP VIEW IF EXISTS view_3_tab0_715 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27509,13 +27509,13 @@ SELECT pk FROM tab1 WHERE col0 <= 90
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab1_715
+DROP VIEW IF EXISTS view_1_tab1_715 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_715
+DROP VIEW IF EXISTS view_2_tab1_715 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_715
+DROP VIEW IF EXISTS view_3_tab1_715 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27608,13 +27608,13 @@ SELECT pk FROM tab2 WHERE col0 <= 90
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab2_715
+DROP VIEW IF EXISTS view_1_tab2_715 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_715
+DROP VIEW IF EXISTS view_2_tab2_715 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_715
+DROP VIEW IF EXISTS view_3_tab2_715 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27707,13 +27707,13 @@ SELECT pk FROM tab3 WHERE col0 <= 90
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab3_715
+DROP VIEW IF EXISTS view_1_tab3_715 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_715
+DROP VIEW IF EXISTS view_2_tab3_715 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_715
+DROP VIEW IF EXISTS view_3_tab3_715 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27806,13 +27806,13 @@ SELECT pk FROM tab4 WHERE col0 <= 90
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab4_715
+DROP VIEW IF EXISTS view_1_tab4_715 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_715
+DROP VIEW IF EXISTS view_2_tab4_715 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_715
+DROP VIEW IF EXISTS view_3_tab4_715 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27930,13 +27930,13 @@ SELECT pk FROM tab0 WHERE (((col3 > 0) AND col4 IN (83.89,16.7,67.35,75.98) OR c
 9
 
 statement ok
-DROP VIEW view_1_tab0_716
+DROP VIEW IF EXISTS view_1_tab0_716 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_716
+DROP VIEW IF EXISTS view_2_tab0_716 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_716
+DROP VIEW IF EXISTS view_3_tab0_716 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28054,13 +28054,13 @@ SELECT pk FROM tab1 WHERE (((col3 > 0) AND col4 IN (83.89,16.7,67.35,75.98) OR c
 9
 
 statement ok
-DROP VIEW view_1_tab1_716
+DROP VIEW IF EXISTS view_1_tab1_716 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_716
+DROP VIEW IF EXISTS view_2_tab1_716 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_716
+DROP VIEW IF EXISTS view_3_tab1_716 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28178,13 +28178,13 @@ SELECT pk FROM tab2 WHERE (((col3 > 0) AND col4 IN (83.89,16.7,67.35,75.98) OR c
 9
 
 statement ok
-DROP VIEW view_1_tab2_716
+DROP VIEW IF EXISTS view_1_tab2_716 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_716
+DROP VIEW IF EXISTS view_2_tab2_716 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_716
+DROP VIEW IF EXISTS view_3_tab2_716 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28302,13 +28302,13 @@ SELECT pk FROM tab3 WHERE (((col3 > 0) AND col4 IN (83.89,16.7,67.35,75.98) OR c
 9
 
 statement ok
-DROP VIEW view_1_tab3_716
+DROP VIEW IF EXISTS view_1_tab3_716 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_716
+DROP VIEW IF EXISTS view_2_tab3_716 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_716
+DROP VIEW IF EXISTS view_3_tab3_716 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28426,13 +28426,13 @@ SELECT pk FROM tab4 WHERE (((col3 > 0) AND col4 IN (83.89,16.7,67.35,75.98) OR c
 9
 
 statement ok
-DROP VIEW view_1_tab4_716
+DROP VIEW IF EXISTS view_1_tab4_716 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_716
+DROP VIEW IF EXISTS view_2_tab4_716 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_716
+DROP VIEW IF EXISTS view_3_tab4_716 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28518,13 +28518,13 @@ SELECT pk FROM tab0 WHERE col3 = 26
 ----
 
 statement ok
-DROP VIEW view_1_tab0_717
+DROP VIEW IF EXISTS view_1_tab0_717 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_717
+DROP VIEW IF EXISTS view_2_tab0_717 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_717
+DROP VIEW IF EXISTS view_3_tab0_717 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28610,13 +28610,13 @@ SELECT pk FROM tab1 WHERE col3 = 26
 ----
 
 statement ok
-DROP VIEW view_1_tab1_717
+DROP VIEW IF EXISTS view_1_tab1_717 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_717
+DROP VIEW IF EXISTS view_2_tab1_717 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_717
+DROP VIEW IF EXISTS view_3_tab1_717 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28702,13 +28702,13 @@ SELECT pk FROM tab2 WHERE col3 = 26
 ----
 
 statement ok
-DROP VIEW view_1_tab2_717
+DROP VIEW IF EXISTS view_1_tab2_717 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_717
+DROP VIEW IF EXISTS view_2_tab2_717 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_717
+DROP VIEW IF EXISTS view_3_tab2_717 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28794,13 +28794,13 @@ SELECT pk FROM tab3 WHERE col3 = 26
 ----
 
 statement ok
-DROP VIEW view_1_tab3_717
+DROP VIEW IF EXISTS view_1_tab3_717 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_717
+DROP VIEW IF EXISTS view_2_tab3_717 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_717
+DROP VIEW IF EXISTS view_3_tab3_717 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28886,13 +28886,13 @@ SELECT pk FROM tab4 WHERE col3 = 26
 ----
 
 statement ok
-DROP VIEW view_1_tab4_717
+DROP VIEW IF EXISTS view_1_tab4_717 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_717
+DROP VIEW IF EXISTS view_2_tab4_717 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_717
+DROP VIEW IF EXISTS view_3_tab4_717 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29012,13 +29012,13 @@ SELECT pk FROM tab0 WHERE col0 < 41
 9
 
 statement ok
-DROP VIEW view_1_tab0_718
+DROP VIEW IF EXISTS view_1_tab0_718 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_718
+DROP VIEW IF EXISTS view_2_tab0_718 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_718
+DROP VIEW IF EXISTS view_3_tab0_718 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29138,13 +29138,13 @@ SELECT pk FROM tab1 WHERE col0 < 41
 9
 
 statement ok
-DROP VIEW view_1_tab1_718
+DROP VIEW IF EXISTS view_1_tab1_718 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_718
+DROP VIEW IF EXISTS view_2_tab1_718 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_718
+DROP VIEW IF EXISTS view_3_tab1_718 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29264,13 +29264,13 @@ SELECT pk FROM tab2 WHERE col0 < 41
 9
 
 statement ok
-DROP VIEW view_1_tab2_718
+DROP VIEW IF EXISTS view_1_tab2_718 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_718
+DROP VIEW IF EXISTS view_2_tab2_718 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_718
+DROP VIEW IF EXISTS view_3_tab2_718 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29390,13 +29390,13 @@ SELECT pk FROM tab3 WHERE col0 < 41
 9
 
 statement ok
-DROP VIEW view_1_tab3_718
+DROP VIEW IF EXISTS view_1_tab3_718 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_718
+DROP VIEW IF EXISTS view_2_tab3_718 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_718
+DROP VIEW IF EXISTS view_3_tab3_718 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29516,13 +29516,13 @@ SELECT pk FROM tab4 WHERE col0 < 41
 9
 
 statement ok
-DROP VIEW view_1_tab4_718
+DROP VIEW IF EXISTS view_1_tab4_718 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_718
+DROP VIEW IF EXISTS view_2_tab4_718 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_718
+DROP VIEW IF EXISTS view_3_tab4_718 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29608,13 +29608,13 @@ SELECT pk FROM tab0 WHERE col3 > 96
 ----
 
 statement ok
-DROP VIEW view_1_tab0_719
+DROP VIEW IF EXISTS view_1_tab0_719 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_719
+DROP VIEW IF EXISTS view_2_tab0_719 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_719
+DROP VIEW IF EXISTS view_3_tab0_719 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29700,13 +29700,13 @@ SELECT pk FROM tab1 WHERE col3 > 96
 ----
 
 statement ok
-DROP VIEW view_1_tab1_719
+DROP VIEW IF EXISTS view_1_tab1_719 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_719
+DROP VIEW IF EXISTS view_2_tab1_719 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_719
+DROP VIEW IF EXISTS view_3_tab1_719 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29792,13 +29792,13 @@ SELECT pk FROM tab2 WHERE col3 > 96
 ----
 
 statement ok
-DROP VIEW view_1_tab2_719
+DROP VIEW IF EXISTS view_1_tab2_719 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_719
+DROP VIEW IF EXISTS view_2_tab2_719 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_719
+DROP VIEW IF EXISTS view_3_tab2_719 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29884,13 +29884,13 @@ SELECT pk FROM tab3 WHERE col3 > 96
 ----
 
 statement ok
-DROP VIEW view_1_tab3_719
+DROP VIEW IF EXISTS view_1_tab3_719 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_719
+DROP VIEW IF EXISTS view_2_tab3_719 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_719
+DROP VIEW IF EXISTS view_3_tab3_719 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29976,13 +29976,13 @@ SELECT pk FROM tab4 WHERE col3 > 96
 ----
 
 statement ok
-DROP VIEW view_1_tab4_719
+DROP VIEW IF EXISTS view_1_tab4_719 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_719
+DROP VIEW IF EXISTS view_2_tab4_719 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_719
+DROP VIEW IF EXISTS view_3_tab4_719 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30068,13 +30068,13 @@ SELECT pk FROM tab0 WHERE col3 IS NULL OR (col3 <= 26 AND (col0 IN (54,39,78,36,
 ----
 
 statement ok
-DROP VIEW view_1_tab0_720
+DROP VIEW IF EXISTS view_1_tab0_720 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_720
+DROP VIEW IF EXISTS view_2_tab0_720 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_720
+DROP VIEW IF EXISTS view_3_tab0_720 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30160,13 +30160,13 @@ SELECT pk FROM tab1 WHERE col3 IS NULL OR (col3 <= 26 AND (col0 IN (54,39,78,36,
 ----
 
 statement ok
-DROP VIEW view_1_tab1_720
+DROP VIEW IF EXISTS view_1_tab1_720 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_720
+DROP VIEW IF EXISTS view_2_tab1_720 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_720
+DROP VIEW IF EXISTS view_3_tab1_720 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30252,13 +30252,13 @@ SELECT pk FROM tab2 WHERE col3 IS NULL OR (col3 <= 26 AND (col0 IN (54,39,78,36,
 ----
 
 statement ok
-DROP VIEW view_1_tab2_720
+DROP VIEW IF EXISTS view_1_tab2_720 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_720
+DROP VIEW IF EXISTS view_2_tab2_720 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_720
+DROP VIEW IF EXISTS view_3_tab2_720 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30344,13 +30344,13 @@ SELECT pk FROM tab3 WHERE col3 IS NULL OR (col3 <= 26 AND (col0 IN (54,39,78,36,
 ----
 
 statement ok
-DROP VIEW view_1_tab3_720
+DROP VIEW IF EXISTS view_1_tab3_720 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_720
+DROP VIEW IF EXISTS view_2_tab3_720 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_720
+DROP VIEW IF EXISTS view_3_tab3_720 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30436,13 +30436,13 @@ SELECT pk FROM tab4 WHERE col3 IS NULL OR (col3 <= 26 AND (col0 IN (54,39,78,36,
 ----
 
 statement ok
-DROP VIEW view_1_tab4_720
+DROP VIEW IF EXISTS view_1_tab4_720 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_720
+DROP VIEW IF EXISTS view_2_tab4_720 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_720
+DROP VIEW IF EXISTS view_3_tab4_720 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30528,13 +30528,13 @@ SELECT pk FROM tab0 WHERE ((col4 <= 20.52))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_721
+DROP VIEW IF EXISTS view_1_tab0_721 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_721
+DROP VIEW IF EXISTS view_2_tab0_721 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_721
+DROP VIEW IF EXISTS view_3_tab0_721 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30620,13 +30620,13 @@ SELECT pk FROM tab1 WHERE ((col4 <= 20.52))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_721
+DROP VIEW IF EXISTS view_1_tab1_721 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_721
+DROP VIEW IF EXISTS view_2_tab1_721 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_721
+DROP VIEW IF EXISTS view_3_tab1_721 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30712,13 +30712,13 @@ SELECT pk FROM tab2 WHERE ((col4 <= 20.52))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_721
+DROP VIEW IF EXISTS view_1_tab2_721 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_721
+DROP VIEW IF EXISTS view_2_tab2_721 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_721
+DROP VIEW IF EXISTS view_3_tab2_721 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30804,13 +30804,13 @@ SELECT pk FROM tab3 WHERE ((col4 <= 20.52))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_721
+DROP VIEW IF EXISTS view_1_tab3_721 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_721
+DROP VIEW IF EXISTS view_2_tab3_721 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_721
+DROP VIEW IF EXISTS view_3_tab3_721 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30896,13 +30896,13 @@ SELECT pk FROM tab4 WHERE ((col4 <= 20.52))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_721
+DROP VIEW IF EXISTS view_1_tab4_721 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_721
+DROP VIEW IF EXISTS view_2_tab4_721 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_721
+DROP VIEW IF EXISTS view_3_tab4_721 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31021,13 +31021,13 @@ SELECT pk FROM tab0 WHERE (col3 >= 70 OR ((col3 <= 46 OR col0 IN (50,97,52))))
 8
 
 statement ok
-DROP VIEW view_1_tab0_722
+DROP VIEW IF EXISTS view_1_tab0_722 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_722
+DROP VIEW IF EXISTS view_2_tab0_722 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_722
+DROP VIEW IF EXISTS view_3_tab0_722 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31146,13 +31146,13 @@ SELECT pk FROM tab1 WHERE (col3 >= 70 OR ((col3 <= 46 OR col0 IN (50,97,52))))
 8
 
 statement ok
-DROP VIEW view_1_tab1_722
+DROP VIEW IF EXISTS view_1_tab1_722 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_722
+DROP VIEW IF EXISTS view_2_tab1_722 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_722
+DROP VIEW IF EXISTS view_3_tab1_722 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31271,13 +31271,13 @@ SELECT pk FROM tab2 WHERE (col3 >= 70 OR ((col3 <= 46 OR col0 IN (50,97,52))))
 8
 
 statement ok
-DROP VIEW view_1_tab2_722
+DROP VIEW IF EXISTS view_1_tab2_722 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_722
+DROP VIEW IF EXISTS view_2_tab2_722 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_722
+DROP VIEW IF EXISTS view_3_tab2_722 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31396,13 +31396,13 @@ SELECT pk FROM tab3 WHERE (col3 >= 70 OR ((col3 <= 46 OR col0 IN (50,97,52))))
 8
 
 statement ok
-DROP VIEW view_1_tab3_722
+DROP VIEW IF EXISTS view_1_tab3_722 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_722
+DROP VIEW IF EXISTS view_2_tab3_722 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_722
+DROP VIEW IF EXISTS view_3_tab3_722 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31521,13 +31521,13 @@ SELECT pk FROM tab4 WHERE (col3 >= 70 OR ((col3 <= 46 OR col0 IN (50,97,52))))
 8
 
 statement ok
-DROP VIEW view_1_tab4_722
+DROP VIEW IF EXISTS view_1_tab4_722 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_722
+DROP VIEW IF EXISTS view_2_tab4_722 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_722
+DROP VIEW IF EXISTS view_3_tab4_722 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31620,13 +31620,13 @@ SELECT pk FROM tab0 WHERE col3 <= 69
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab0_723
+DROP VIEW IF EXISTS view_1_tab0_723 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_723
+DROP VIEW IF EXISTS view_2_tab0_723 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_723
+DROP VIEW IF EXISTS view_3_tab0_723 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31719,13 +31719,13 @@ SELECT pk FROM tab1 WHERE col3 <= 69
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab1_723
+DROP VIEW IF EXISTS view_1_tab1_723 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_723
+DROP VIEW IF EXISTS view_2_tab1_723 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_723
+DROP VIEW IF EXISTS view_3_tab1_723 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31818,13 +31818,13 @@ SELECT pk FROM tab2 WHERE col3 <= 69
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab2_723
+DROP VIEW IF EXISTS view_1_tab2_723 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_723
+DROP VIEW IF EXISTS view_2_tab2_723 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_723
+DROP VIEW IF EXISTS view_3_tab2_723 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31917,13 +31917,13 @@ SELECT pk FROM tab3 WHERE col3 <= 69
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab3_723
+DROP VIEW IF EXISTS view_1_tab3_723 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_723
+DROP VIEW IF EXISTS view_2_tab3_723 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_723
+DROP VIEW IF EXISTS view_3_tab3_723 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32016,13 +32016,13 @@ SELECT pk FROM tab4 WHERE col3 <= 69
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab4_723
+DROP VIEW IF EXISTS view_1_tab4_723 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_723
+DROP VIEW IF EXISTS view_2_tab4_723 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_723
+DROP VIEW IF EXISTS view_3_tab4_723 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32111,13 +32111,13 @@ SELECT pk FROM tab0 WHERE col3 <= 88
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_724
+DROP VIEW IF EXISTS view_1_tab0_724 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_724
+DROP VIEW IF EXISTS view_2_tab0_724 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_724
+DROP VIEW IF EXISTS view_3_tab0_724 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32206,13 +32206,13 @@ SELECT pk FROM tab1 WHERE col3 <= 88
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_724
+DROP VIEW IF EXISTS view_1_tab1_724 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_724
+DROP VIEW IF EXISTS view_2_tab1_724 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_724
+DROP VIEW IF EXISTS view_3_tab1_724 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32301,13 +32301,13 @@ SELECT pk FROM tab2 WHERE col3 <= 88
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_724
+DROP VIEW IF EXISTS view_1_tab2_724 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_724
+DROP VIEW IF EXISTS view_2_tab2_724 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_724
+DROP VIEW IF EXISTS view_3_tab2_724 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32396,13 +32396,13 @@ SELECT pk FROM tab3 WHERE col3 <= 88
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_724
+DROP VIEW IF EXISTS view_1_tab3_724 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_724
+DROP VIEW IF EXISTS view_2_tab3_724 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_724
+DROP VIEW IF EXISTS view_3_tab3_724 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32491,13 +32491,13 @@ SELECT pk FROM tab4 WHERE col3 <= 88
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_724
+DROP VIEW IF EXISTS view_1_tab4_724 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_724
+DROP VIEW IF EXISTS view_2_tab4_724 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_724
+DROP VIEW IF EXISTS view_3_tab4_724 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32583,13 +32583,13 @@ SELECT pk FROM tab0 WHERE (col1 > 36.41) AND col4 IS NULL OR col0 > 86 AND col4 
 ----
 
 statement ok
-DROP VIEW view_1_tab0_725
+DROP VIEW IF EXISTS view_1_tab0_725 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_725
+DROP VIEW IF EXISTS view_2_tab0_725 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_725
+DROP VIEW IF EXISTS view_3_tab0_725 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32675,13 +32675,13 @@ SELECT pk FROM tab1 WHERE (col1 > 36.41) AND col4 IS NULL OR col0 > 86 AND col4 
 ----
 
 statement ok
-DROP VIEW view_1_tab1_725
+DROP VIEW IF EXISTS view_1_tab1_725 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_725
+DROP VIEW IF EXISTS view_2_tab1_725 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_725
+DROP VIEW IF EXISTS view_3_tab1_725 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32767,13 +32767,13 @@ SELECT pk FROM tab2 WHERE (col1 > 36.41) AND col4 IS NULL OR col0 > 86 AND col4 
 ----
 
 statement ok
-DROP VIEW view_1_tab2_725
+DROP VIEW IF EXISTS view_1_tab2_725 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_725
+DROP VIEW IF EXISTS view_2_tab2_725 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_725
+DROP VIEW IF EXISTS view_3_tab2_725 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32859,13 +32859,13 @@ SELECT pk FROM tab3 WHERE (col1 > 36.41) AND col4 IS NULL OR col0 > 86 AND col4 
 ----
 
 statement ok
-DROP VIEW view_1_tab3_725
+DROP VIEW IF EXISTS view_1_tab3_725 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_725
+DROP VIEW IF EXISTS view_2_tab3_725 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_725
+DROP VIEW IF EXISTS view_3_tab3_725 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32951,13 +32951,13 @@ SELECT pk FROM tab4 WHERE (col1 > 36.41) AND col4 IS NULL OR col0 > 86 AND col4 
 ----
 
 statement ok
-DROP VIEW view_1_tab4_725
+DROP VIEW IF EXISTS view_1_tab4_725 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_725
+DROP VIEW IF EXISTS view_2_tab4_725 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_725
+DROP VIEW IF EXISTS view_3_tab4_725 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33043,13 +33043,13 @@ SELECT pk FROM tab0 WHERE col0 > 84 AND col4 <= 74.98 AND col1 IN (SELECT col4 F
 ----
 
 statement ok
-DROP VIEW view_1_tab0_726
+DROP VIEW IF EXISTS view_1_tab0_726 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_726
+DROP VIEW IF EXISTS view_2_tab0_726 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_726
+DROP VIEW IF EXISTS view_3_tab0_726 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33135,13 +33135,13 @@ SELECT pk FROM tab1 WHERE col0 > 84 AND col4 <= 74.98 AND col1 IN (SELECT col4 F
 ----
 
 statement ok
-DROP VIEW view_1_tab1_726
+DROP VIEW IF EXISTS view_1_tab1_726 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_726
+DROP VIEW IF EXISTS view_2_tab1_726 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_726
+DROP VIEW IF EXISTS view_3_tab1_726 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33227,13 +33227,13 @@ SELECT pk FROM tab2 WHERE col0 > 84 AND col4 <= 74.98 AND col1 IN (SELECT col4 F
 ----
 
 statement ok
-DROP VIEW view_1_tab2_726
+DROP VIEW IF EXISTS view_1_tab2_726 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_726
+DROP VIEW IF EXISTS view_2_tab2_726 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_726
+DROP VIEW IF EXISTS view_3_tab2_726 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33319,13 +33319,13 @@ SELECT pk FROM tab3 WHERE col0 > 84 AND col4 <= 74.98 AND col1 IN (SELECT col4 F
 ----
 
 statement ok
-DROP VIEW view_1_tab3_726
+DROP VIEW IF EXISTS view_1_tab3_726 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_726
+DROP VIEW IF EXISTS view_2_tab3_726 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_726
+DROP VIEW IF EXISTS view_3_tab3_726 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33411,13 +33411,13 @@ SELECT pk FROM tab4 WHERE col0 > 84 AND col4 <= 74.98 AND col1 IN (SELECT col4 F
 ----
 
 statement ok
-DROP VIEW view_1_tab4_726
+DROP VIEW IF EXISTS view_1_tab4_726 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_726
+DROP VIEW IF EXISTS view_2_tab4_726 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_726
+DROP VIEW IF EXISTS view_3_tab4_726 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33535,13 +33535,13 @@ SELECT pk FROM tab0 WHERE col3 <= 63 OR ((col3 >= 92) OR col0 = 44 OR col4 < 42.
 9
 
 statement ok
-DROP VIEW view_1_tab0_727
+DROP VIEW IF EXISTS view_1_tab0_727 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_727
+DROP VIEW IF EXISTS view_2_tab0_727 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_727
+DROP VIEW IF EXISTS view_3_tab0_727 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33659,13 +33659,13 @@ SELECT pk FROM tab1 WHERE col3 <= 63 OR ((col3 >= 92) OR col0 = 44 OR col4 < 42.
 9
 
 statement ok
-DROP VIEW view_1_tab1_727
+DROP VIEW IF EXISTS view_1_tab1_727 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_727
+DROP VIEW IF EXISTS view_2_tab1_727 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_727
+DROP VIEW IF EXISTS view_3_tab1_727 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33783,13 +33783,13 @@ SELECT pk FROM tab2 WHERE col3 <= 63 OR ((col3 >= 92) OR col0 = 44 OR col4 < 42.
 9
 
 statement ok
-DROP VIEW view_1_tab2_727
+DROP VIEW IF EXISTS view_1_tab2_727 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_727
+DROP VIEW IF EXISTS view_2_tab2_727 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_727
+DROP VIEW IF EXISTS view_3_tab2_727 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33907,13 +33907,13 @@ SELECT pk FROM tab3 WHERE col3 <= 63 OR ((col3 >= 92) OR col0 = 44 OR col4 < 42.
 9
 
 statement ok
-DROP VIEW view_1_tab3_727
+DROP VIEW IF EXISTS view_1_tab3_727 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_727
+DROP VIEW IF EXISTS view_2_tab3_727 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_727
+DROP VIEW IF EXISTS view_3_tab3_727 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34031,13 +34031,13 @@ SELECT pk FROM tab4 WHERE col3 <= 63 OR ((col3 >= 92) OR col0 = 44 OR col4 < 42.
 9
 
 statement ok
-DROP VIEW view_1_tab4_727
+DROP VIEW IF EXISTS view_1_tab4_727 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_727
+DROP VIEW IF EXISTS view_2_tab4_727 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_727
+DROP VIEW IF EXISTS view_3_tab4_727 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34123,13 +34123,13 @@ SELECT pk FROM tab0 WHERE (col1 > 51.38 AND col3 < 6)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_728
+DROP VIEW IF EXISTS view_1_tab0_728 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_728
+DROP VIEW IF EXISTS view_2_tab0_728 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_728
+DROP VIEW IF EXISTS view_3_tab0_728 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34215,13 +34215,13 @@ SELECT pk FROM tab1 WHERE (col1 > 51.38 AND col3 < 6)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_728
+DROP VIEW IF EXISTS view_1_tab1_728 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_728
+DROP VIEW IF EXISTS view_2_tab1_728 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_728
+DROP VIEW IF EXISTS view_3_tab1_728 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34307,13 +34307,13 @@ SELECT pk FROM tab2 WHERE (col1 > 51.38 AND col3 < 6)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_728
+DROP VIEW IF EXISTS view_1_tab2_728 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_728
+DROP VIEW IF EXISTS view_2_tab2_728 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_728
+DROP VIEW IF EXISTS view_3_tab2_728 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34399,13 +34399,13 @@ SELECT pk FROM tab3 WHERE (col1 > 51.38 AND col3 < 6)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_728
+DROP VIEW IF EXISTS view_1_tab3_728 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_728
+DROP VIEW IF EXISTS view_2_tab3_728 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_728
+DROP VIEW IF EXISTS view_3_tab3_728 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34491,13 +34491,13 @@ SELECT pk FROM tab4 WHERE (col1 > 51.38 AND col3 < 6)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_728
+DROP VIEW IF EXISTS view_1_tab4_728 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_728
+DROP VIEW IF EXISTS view_2_tab4_728 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_728
+DROP VIEW IF EXISTS view_3_tab4_728 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34583,13 +34583,13 @@ SELECT pk FROM tab0 WHERE col3 > 89
 ----
 
 statement ok
-DROP VIEW view_1_tab0_729
+DROP VIEW IF EXISTS view_1_tab0_729 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_729
+DROP VIEW IF EXISTS view_2_tab0_729 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_729
+DROP VIEW IF EXISTS view_3_tab0_729 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34675,13 +34675,13 @@ SELECT pk FROM tab1 WHERE col3 > 89
 ----
 
 statement ok
-DROP VIEW view_1_tab1_729
+DROP VIEW IF EXISTS view_1_tab1_729 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_729
+DROP VIEW IF EXISTS view_2_tab1_729 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_729
+DROP VIEW IF EXISTS view_3_tab1_729 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34767,13 +34767,13 @@ SELECT pk FROM tab2 WHERE col3 > 89
 ----
 
 statement ok
-DROP VIEW view_1_tab2_729
+DROP VIEW IF EXISTS view_1_tab2_729 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_729
+DROP VIEW IF EXISTS view_2_tab2_729 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_729
+DROP VIEW IF EXISTS view_3_tab2_729 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34859,13 +34859,13 @@ SELECT pk FROM tab3 WHERE col3 > 89
 ----
 
 statement ok
-DROP VIEW view_1_tab3_729
+DROP VIEW IF EXISTS view_1_tab3_729 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_729
+DROP VIEW IF EXISTS view_2_tab3_729 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_729
+DROP VIEW IF EXISTS view_3_tab3_729 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34951,13 +34951,13 @@ SELECT pk FROM tab4 WHERE col3 > 89
 ----
 
 statement ok
-DROP VIEW view_1_tab4_729
+DROP VIEW IF EXISTS view_1_tab4_729 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_729
+DROP VIEW IF EXISTS view_2_tab4_729 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_729
+DROP VIEW IF EXISTS view_3_tab4_729 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35043,13 +35043,13 @@ SELECT pk FROM tab0 WHERE ((col4 IN (72.82,67.64,1.27))) AND col3 >= 77
 ----
 
 statement ok
-DROP VIEW view_1_tab0_730
+DROP VIEW IF EXISTS view_1_tab0_730 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_730
+DROP VIEW IF EXISTS view_2_tab0_730 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_730
+DROP VIEW IF EXISTS view_3_tab0_730 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35135,13 +35135,13 @@ SELECT pk FROM tab1 WHERE ((col4 IN (72.82,67.64,1.27))) AND col3 >= 77
 ----
 
 statement ok
-DROP VIEW view_1_tab1_730
+DROP VIEW IF EXISTS view_1_tab1_730 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_730
+DROP VIEW IF EXISTS view_2_tab1_730 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_730
+DROP VIEW IF EXISTS view_3_tab1_730 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35227,13 +35227,13 @@ SELECT pk FROM tab2 WHERE ((col4 IN (72.82,67.64,1.27))) AND col3 >= 77
 ----
 
 statement ok
-DROP VIEW view_1_tab2_730
+DROP VIEW IF EXISTS view_1_tab2_730 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_730
+DROP VIEW IF EXISTS view_2_tab2_730 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_730
+DROP VIEW IF EXISTS view_3_tab2_730 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35319,13 +35319,13 @@ SELECT pk FROM tab3 WHERE ((col4 IN (72.82,67.64,1.27))) AND col3 >= 77
 ----
 
 statement ok
-DROP VIEW view_1_tab3_730
+DROP VIEW IF EXISTS view_1_tab3_730 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_730
+DROP VIEW IF EXISTS view_2_tab3_730 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_730
+DROP VIEW IF EXISTS view_3_tab3_730 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35411,13 +35411,13 @@ SELECT pk FROM tab4 WHERE ((col4 IN (72.82,67.64,1.27))) AND col3 >= 77
 ----
 
 statement ok
-DROP VIEW view_1_tab4_730
+DROP VIEW IF EXISTS view_1_tab4_730 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_730
+DROP VIEW IF EXISTS view_2_tab4_730 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_730
+DROP VIEW IF EXISTS view_3_tab4_730 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35503,13 +35503,13 @@ SELECT pk FROM tab0 WHERE ((col4 <= 56.89 AND col1 > 25.36)) AND col1 = 59.84
 ----
 
 statement ok
-DROP VIEW view_1_tab0_731
+DROP VIEW IF EXISTS view_1_tab0_731 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_731
+DROP VIEW IF EXISTS view_2_tab0_731 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_731
+DROP VIEW IF EXISTS view_3_tab0_731 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35595,13 +35595,13 @@ SELECT pk FROM tab1 WHERE ((col4 <= 56.89 AND col1 > 25.36)) AND col1 = 59.84
 ----
 
 statement ok
-DROP VIEW view_1_tab1_731
+DROP VIEW IF EXISTS view_1_tab1_731 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_731
+DROP VIEW IF EXISTS view_2_tab1_731 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_731
+DROP VIEW IF EXISTS view_3_tab1_731 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35687,13 +35687,13 @@ SELECT pk FROM tab2 WHERE ((col4 <= 56.89 AND col1 > 25.36)) AND col1 = 59.84
 ----
 
 statement ok
-DROP VIEW view_1_tab2_731
+DROP VIEW IF EXISTS view_1_tab2_731 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_731
+DROP VIEW IF EXISTS view_2_tab2_731 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_731
+DROP VIEW IF EXISTS view_3_tab2_731 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35779,13 +35779,13 @@ SELECT pk FROM tab3 WHERE ((col4 <= 56.89 AND col1 > 25.36)) AND col1 = 59.84
 ----
 
 statement ok
-DROP VIEW view_1_tab3_731
+DROP VIEW IF EXISTS view_1_tab3_731 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_731
+DROP VIEW IF EXISTS view_2_tab3_731 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_731
+DROP VIEW IF EXISTS view_3_tab3_731 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35871,13 +35871,13 @@ SELECT pk FROM tab4 WHERE ((col4 <= 56.89 AND col1 > 25.36)) AND col1 = 59.84
 ----
 
 statement ok
-DROP VIEW view_1_tab4_731
+DROP VIEW IF EXISTS view_1_tab4_731 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_731
+DROP VIEW IF EXISTS view_2_tab4_731 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_731
+DROP VIEW IF EXISTS view_3_tab4_731 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35963,13 +35963,13 @@ SELECT pk FROM tab0 WHERE col4 < 11.90
 ----
 
 statement ok
-DROP VIEW view_1_tab0_732
+DROP VIEW IF EXISTS view_1_tab0_732 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_732
+DROP VIEW IF EXISTS view_2_tab0_732 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_732
+DROP VIEW IF EXISTS view_3_tab0_732 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36055,13 +36055,13 @@ SELECT pk FROM tab1 WHERE col4 < 11.90
 ----
 
 statement ok
-DROP VIEW view_1_tab1_732
+DROP VIEW IF EXISTS view_1_tab1_732 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_732
+DROP VIEW IF EXISTS view_2_tab1_732 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_732
+DROP VIEW IF EXISTS view_3_tab1_732 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36147,13 +36147,13 @@ SELECT pk FROM tab2 WHERE col4 < 11.90
 ----
 
 statement ok
-DROP VIEW view_1_tab2_732
+DROP VIEW IF EXISTS view_1_tab2_732 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_732
+DROP VIEW IF EXISTS view_2_tab2_732 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_732
+DROP VIEW IF EXISTS view_3_tab2_732 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36239,13 +36239,13 @@ SELECT pk FROM tab3 WHERE col4 < 11.90
 ----
 
 statement ok
-DROP VIEW view_1_tab3_732
+DROP VIEW IF EXISTS view_1_tab3_732 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_732
+DROP VIEW IF EXISTS view_2_tab3_732 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_732
+DROP VIEW IF EXISTS view_3_tab3_732 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36331,13 +36331,13 @@ SELECT pk FROM tab4 WHERE col4 < 11.90
 ----
 
 statement ok
-DROP VIEW view_1_tab4_732
+DROP VIEW IF EXISTS view_1_tab4_732 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_732
+DROP VIEW IF EXISTS view_2_tab4_732 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_732
+DROP VIEW IF EXISTS view_3_tab4_732 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36423,13 +36423,13 @@ SELECT pk FROM tab0 WHERE col3 >= 99 AND (col0 >= 55 OR ((((col0 <= 16 AND (col0
 ----
 
 statement ok
-DROP VIEW view_1_tab0_733
+DROP VIEW IF EXISTS view_1_tab0_733 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_733
+DROP VIEW IF EXISTS view_2_tab0_733 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_733
+DROP VIEW IF EXISTS view_3_tab0_733 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36515,13 +36515,13 @@ SELECT pk FROM tab1 WHERE col3 >= 99 AND (col0 >= 55 OR ((((col0 <= 16 AND (col0
 ----
 
 statement ok
-DROP VIEW view_1_tab1_733
+DROP VIEW IF EXISTS view_1_tab1_733 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_733
+DROP VIEW IF EXISTS view_2_tab1_733 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_733
+DROP VIEW IF EXISTS view_3_tab1_733 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36607,13 +36607,13 @@ SELECT pk FROM tab2 WHERE col3 >= 99 AND (col0 >= 55 OR ((((col0 <= 16 AND (col0
 ----
 
 statement ok
-DROP VIEW view_1_tab2_733
+DROP VIEW IF EXISTS view_1_tab2_733 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_733
+DROP VIEW IF EXISTS view_2_tab2_733 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_733
+DROP VIEW IF EXISTS view_3_tab2_733 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36699,13 +36699,13 @@ SELECT pk FROM tab3 WHERE col3 >= 99 AND (col0 >= 55 OR ((((col0 <= 16 AND (col0
 ----
 
 statement ok
-DROP VIEW view_1_tab3_733
+DROP VIEW IF EXISTS view_1_tab3_733 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_733
+DROP VIEW IF EXISTS view_2_tab3_733 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_733
+DROP VIEW IF EXISTS view_3_tab3_733 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36791,13 +36791,13 @@ SELECT pk FROM tab4 WHERE col3 >= 99 AND (col0 >= 55 OR ((((col0 <= 16 AND (col0
 ----
 
 statement ok
-DROP VIEW view_1_tab4_733
+DROP VIEW IF EXISTS view_1_tab4_733 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_733
+DROP VIEW IF EXISTS view_2_tab4_733 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_733
+DROP VIEW IF EXISTS view_3_tab4_733 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36911,13 +36911,13 @@ SELECT pk FROM tab0 WHERE (col3 < 42) OR (col4 > 2.51) AND col1 IN (56.35,14.47,
 7
 
 statement ok
-DROP VIEW view_1_tab0_734
+DROP VIEW IF EXISTS view_1_tab0_734 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_734
+DROP VIEW IF EXISTS view_2_tab0_734 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_734
+DROP VIEW IF EXISTS view_3_tab0_734 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37031,13 +37031,13 @@ SELECT pk FROM tab1 WHERE (col3 < 42) OR (col4 > 2.51) AND col1 IN (56.35,14.47,
 7
 
 statement ok
-DROP VIEW view_1_tab1_734
+DROP VIEW IF EXISTS view_1_tab1_734 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_734
+DROP VIEW IF EXISTS view_2_tab1_734 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_734
+DROP VIEW IF EXISTS view_3_tab1_734 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37151,13 +37151,13 @@ SELECT pk FROM tab2 WHERE (col3 < 42) OR (col4 > 2.51) AND col1 IN (56.35,14.47,
 7
 
 statement ok
-DROP VIEW view_1_tab2_734
+DROP VIEW IF EXISTS view_1_tab2_734 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_734
+DROP VIEW IF EXISTS view_2_tab2_734 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_734
+DROP VIEW IF EXISTS view_3_tab2_734 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37271,13 +37271,13 @@ SELECT pk FROM tab3 WHERE (col3 < 42) OR (col4 > 2.51) AND col1 IN (56.35,14.47,
 7
 
 statement ok
-DROP VIEW view_1_tab3_734
+DROP VIEW IF EXISTS view_1_tab3_734 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_734
+DROP VIEW IF EXISTS view_2_tab3_734 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_734
+DROP VIEW IF EXISTS view_3_tab3_734 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37391,13 +37391,13 @@ SELECT pk FROM tab4 WHERE (col3 < 42) OR (col4 > 2.51) AND col1 IN (56.35,14.47,
 7
 
 statement ok
-DROP VIEW view_1_tab4_734
+DROP VIEW IF EXISTS view_1_tab4_734 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_734
+DROP VIEW IF EXISTS view_2_tab4_734 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_734
+DROP VIEW IF EXISTS view_3_tab4_734 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37483,13 +37483,13 @@ SELECT pk FROM tab0 WHERE (col4 < 30.65) AND col4 < 64.30 AND col3 > 96
 ----
 
 statement ok
-DROP VIEW view_1_tab0_736
+DROP VIEW IF EXISTS view_1_tab0_736 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_736
+DROP VIEW IF EXISTS view_2_tab0_736 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_736
+DROP VIEW IF EXISTS view_3_tab0_736 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37575,13 +37575,13 @@ SELECT pk FROM tab1 WHERE (col4 < 30.65) AND col4 < 64.30 AND col3 > 96
 ----
 
 statement ok
-DROP VIEW view_1_tab1_736
+DROP VIEW IF EXISTS view_1_tab1_736 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_736
+DROP VIEW IF EXISTS view_2_tab1_736 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_736
+DROP VIEW IF EXISTS view_3_tab1_736 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37667,13 +37667,13 @@ SELECT pk FROM tab2 WHERE (col4 < 30.65) AND col4 < 64.30 AND col3 > 96
 ----
 
 statement ok
-DROP VIEW view_1_tab2_736
+DROP VIEW IF EXISTS view_1_tab2_736 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_736
+DROP VIEW IF EXISTS view_2_tab2_736 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_736
+DROP VIEW IF EXISTS view_3_tab2_736 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37759,13 +37759,13 @@ SELECT pk FROM tab3 WHERE (col4 < 30.65) AND col4 < 64.30 AND col3 > 96
 ----
 
 statement ok
-DROP VIEW view_1_tab3_736
+DROP VIEW IF EXISTS view_1_tab3_736 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_736
+DROP VIEW IF EXISTS view_2_tab3_736 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_736
+DROP VIEW IF EXISTS view_3_tab3_736 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37851,11 +37851,11 @@ SELECT pk FROM tab4 WHERE (col4 < 30.65) AND col4 < 64.30 AND col3 > 96
 ----
 
 statement ok
-DROP VIEW view_1_tab4_736
+DROP VIEW IF EXISTS view_1_tab4_736 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_736
+DROP VIEW IF EXISTS view_2_tab4_736 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_736
+DROP VIEW IF EXISTS view_3_tab4_736 CASCADE
 

--- a/test/index/view/10/slt_good_6.test
+++ b/test/index/view/10/slt_good_6.test
@@ -209,13 +209,13 @@ SELECT pk FROM tab0 WHERE col3 >= 49
 9
 
 statement ok
-DROP VIEW view_1_tab0_946
+DROP VIEW IF EXISTS view_1_tab0_946 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_946
+DROP VIEW IF EXISTS view_2_tab0_946 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_946
+DROP VIEW IF EXISTS view_3_tab0_946 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -318,13 +318,13 @@ SELECT pk FROM tab1 WHERE col3 >= 49
 9
 
 statement ok
-DROP VIEW view_1_tab1_946
+DROP VIEW IF EXISTS view_1_tab1_946 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_946
+DROP VIEW IF EXISTS view_2_tab1_946 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_946
+DROP VIEW IF EXISTS view_3_tab1_946 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -427,13 +427,13 @@ SELECT pk FROM tab2 WHERE col3 >= 49
 9
 
 statement ok
-DROP VIEW view_1_tab2_946
+DROP VIEW IF EXISTS view_1_tab2_946 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_946
+DROP VIEW IF EXISTS view_2_tab2_946 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_946
+DROP VIEW IF EXISTS view_3_tab2_946 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -536,13 +536,13 @@ SELECT pk FROM tab3 WHERE col3 >= 49
 9
 
 statement ok
-DROP VIEW view_1_tab3_946
+DROP VIEW IF EXISTS view_1_tab3_946 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_946
+DROP VIEW IF EXISTS view_2_tab3_946 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_946
+DROP VIEW IF EXISTS view_3_tab3_946 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -645,13 +645,13 @@ SELECT pk FROM tab4 WHERE col3 >= 49
 9
 
 statement ok
-DROP VIEW view_1_tab4_946
+DROP VIEW IF EXISTS view_1_tab4_946 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_946
+DROP VIEW IF EXISTS view_2_tab4_946 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_946
+DROP VIEW IF EXISTS view_3_tab4_946 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -737,13 +737,13 @@ SELECT pk FROM tab0 WHERE col3 >= 12 AND (col0 = 62) AND (col3 IN (68,71,20,8,78
 ----
 
 statement ok
-DROP VIEW view_1_tab0_947
+DROP VIEW IF EXISTS view_1_tab0_947 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_947
+DROP VIEW IF EXISTS view_2_tab0_947 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_947
+DROP VIEW IF EXISTS view_3_tab0_947 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -829,13 +829,13 @@ SELECT pk FROM tab1 WHERE col3 >= 12 AND (col0 = 62) AND (col3 IN (68,71,20,8,78
 ----
 
 statement ok
-DROP VIEW view_1_tab1_947
+DROP VIEW IF EXISTS view_1_tab1_947 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_947
+DROP VIEW IF EXISTS view_2_tab1_947 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_947
+DROP VIEW IF EXISTS view_3_tab1_947 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -921,13 +921,13 @@ SELECT pk FROM tab2 WHERE col3 >= 12 AND (col0 = 62) AND (col3 IN (68,71,20,8,78
 ----
 
 statement ok
-DROP VIEW view_1_tab2_947
+DROP VIEW IF EXISTS view_1_tab2_947 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_947
+DROP VIEW IF EXISTS view_2_tab2_947 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_947
+DROP VIEW IF EXISTS view_3_tab2_947 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1013,13 +1013,13 @@ SELECT pk FROM tab3 WHERE col3 >= 12 AND (col0 = 62) AND (col3 IN (68,71,20,8,78
 ----
 
 statement ok
-DROP VIEW view_1_tab3_947
+DROP VIEW IF EXISTS view_1_tab3_947 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_947
+DROP VIEW IF EXISTS view_2_tab3_947 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_947
+DROP VIEW IF EXISTS view_3_tab3_947 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1105,13 +1105,13 @@ SELECT pk FROM tab4 WHERE col3 >= 12 AND (col0 = 62) AND (col3 IN (68,71,20,8,78
 ----
 
 statement ok
-DROP VIEW view_1_tab4_947
+DROP VIEW IF EXISTS view_1_tab4_947 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_947
+DROP VIEW IF EXISTS view_2_tab4_947 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_947
+DROP VIEW IF EXISTS view_3_tab4_947 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1204,13 +1204,13 @@ SELECT pk FROM tab0 WHERE (((col1 = 50.63 OR (col3 > 43) OR col3 < 30)))
 9 values hashing to 771a06029c003358acd302c0ec942a73
 
 statement ok
-DROP VIEW view_1_tab0_948
+DROP VIEW IF EXISTS view_1_tab0_948 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_948
+DROP VIEW IF EXISTS view_2_tab0_948 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_948
+DROP VIEW IF EXISTS view_3_tab0_948 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1303,13 +1303,13 @@ SELECT pk FROM tab1 WHERE (((col1 = 50.63 OR (col3 > 43) OR col3 < 30)))
 9 values hashing to 771a06029c003358acd302c0ec942a73
 
 statement ok
-DROP VIEW view_1_tab1_948
+DROP VIEW IF EXISTS view_1_tab1_948 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_948
+DROP VIEW IF EXISTS view_2_tab1_948 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_948
+DROP VIEW IF EXISTS view_3_tab1_948 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1402,13 +1402,13 @@ SELECT pk FROM tab2 WHERE (((col1 = 50.63 OR (col3 > 43) OR col3 < 30)))
 9 values hashing to 771a06029c003358acd302c0ec942a73
 
 statement ok
-DROP VIEW view_1_tab2_948
+DROP VIEW IF EXISTS view_1_tab2_948 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_948
+DROP VIEW IF EXISTS view_2_tab2_948 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_948
+DROP VIEW IF EXISTS view_3_tab2_948 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1501,13 +1501,13 @@ SELECT pk FROM tab3 WHERE (((col1 = 50.63 OR (col3 > 43) OR col3 < 30)))
 9 values hashing to 771a06029c003358acd302c0ec942a73
 
 statement ok
-DROP VIEW view_1_tab3_948
+DROP VIEW IF EXISTS view_1_tab3_948 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_948
+DROP VIEW IF EXISTS view_2_tab3_948 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_948
+DROP VIEW IF EXISTS view_3_tab3_948 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1600,13 +1600,13 @@ SELECT pk FROM tab4 WHERE (((col1 = 50.63 OR (col3 > 43) OR col3 < 30)))
 9 values hashing to 771a06029c003358acd302c0ec942a73
 
 statement ok
-DROP VIEW view_1_tab4_948
+DROP VIEW IF EXISTS view_1_tab4_948 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_948
+DROP VIEW IF EXISTS view_2_tab4_948 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_948
+DROP VIEW IF EXISTS view_3_tab4_948 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1692,13 +1692,13 @@ SELECT pk FROM tab0 WHERE ((col0 <= 16)) AND col4 < 12.6
 ----
 
 statement ok
-DROP VIEW view_1_tab0_949
+DROP VIEW IF EXISTS view_1_tab0_949 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_949
+DROP VIEW IF EXISTS view_2_tab0_949 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_949
+DROP VIEW IF EXISTS view_3_tab0_949 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1784,13 +1784,13 @@ SELECT pk FROM tab1 WHERE ((col0 <= 16)) AND col4 < 12.6
 ----
 
 statement ok
-DROP VIEW view_1_tab1_949
+DROP VIEW IF EXISTS view_1_tab1_949 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_949
+DROP VIEW IF EXISTS view_2_tab1_949 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_949
+DROP VIEW IF EXISTS view_3_tab1_949 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1876,13 +1876,13 @@ SELECT pk FROM tab2 WHERE ((col0 <= 16)) AND col4 < 12.6
 ----
 
 statement ok
-DROP VIEW view_1_tab2_949
+DROP VIEW IF EXISTS view_1_tab2_949 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_949
+DROP VIEW IF EXISTS view_2_tab2_949 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_949
+DROP VIEW IF EXISTS view_3_tab2_949 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1968,13 +1968,13 @@ SELECT pk FROM tab3 WHERE ((col0 <= 16)) AND col4 < 12.6
 ----
 
 statement ok
-DROP VIEW view_1_tab3_949
+DROP VIEW IF EXISTS view_1_tab3_949 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_949
+DROP VIEW IF EXISTS view_2_tab3_949 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_949
+DROP VIEW IF EXISTS view_3_tab3_949 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2060,13 +2060,13 @@ SELECT pk FROM tab4 WHERE ((col0 <= 16)) AND col4 < 12.6
 ----
 
 statement ok
-DROP VIEW view_1_tab4_949
+DROP VIEW IF EXISTS view_1_tab4_949 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_949
+DROP VIEW IF EXISTS view_2_tab4_949 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_949
+DROP VIEW IF EXISTS view_3_tab4_949 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2152,13 +2152,13 @@ SELECT pk FROM tab0 WHERE col3 = 65 AND col4 < 86.42 AND col0 > 57
 ----
 
 statement ok
-DROP VIEW view_1_tab0_950
+DROP VIEW IF EXISTS view_1_tab0_950 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_950
+DROP VIEW IF EXISTS view_2_tab0_950 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_950
+DROP VIEW IF EXISTS view_3_tab0_950 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2244,13 +2244,13 @@ SELECT pk FROM tab1 WHERE col3 = 65 AND col4 < 86.42 AND col0 > 57
 ----
 
 statement ok
-DROP VIEW view_1_tab1_950
+DROP VIEW IF EXISTS view_1_tab1_950 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_950
+DROP VIEW IF EXISTS view_2_tab1_950 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_950
+DROP VIEW IF EXISTS view_3_tab1_950 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2336,13 +2336,13 @@ SELECT pk FROM tab2 WHERE col3 = 65 AND col4 < 86.42 AND col0 > 57
 ----
 
 statement ok
-DROP VIEW view_1_tab2_950
+DROP VIEW IF EXISTS view_1_tab2_950 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_950
+DROP VIEW IF EXISTS view_2_tab2_950 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_950
+DROP VIEW IF EXISTS view_3_tab2_950 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2428,13 +2428,13 @@ SELECT pk FROM tab3 WHERE col3 = 65 AND col4 < 86.42 AND col0 > 57
 ----
 
 statement ok
-DROP VIEW view_1_tab3_950
+DROP VIEW IF EXISTS view_1_tab3_950 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_950
+DROP VIEW IF EXISTS view_2_tab3_950 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_950
+DROP VIEW IF EXISTS view_3_tab3_950 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2520,13 +2520,13 @@ SELECT pk FROM tab4 WHERE col3 = 65 AND col4 < 86.42 AND col0 > 57
 ----
 
 statement ok
-DROP VIEW view_1_tab4_950
+DROP VIEW IF EXISTS view_1_tab4_950 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_950
+DROP VIEW IF EXISTS view_2_tab4_950 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_950
+DROP VIEW IF EXISTS view_3_tab4_950 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2612,13 +2612,13 @@ SELECT pk FROM tab0 WHERE col1 = 21.5
 ----
 
 statement ok
-DROP VIEW view_1_tab0_951
+DROP VIEW IF EXISTS view_1_tab0_951 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_951
+DROP VIEW IF EXISTS view_2_tab0_951 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_951
+DROP VIEW IF EXISTS view_3_tab0_951 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2704,13 +2704,13 @@ SELECT pk FROM tab1 WHERE col1 = 21.5
 ----
 
 statement ok
-DROP VIEW view_1_tab1_951
+DROP VIEW IF EXISTS view_1_tab1_951 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_951
+DROP VIEW IF EXISTS view_2_tab1_951 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_951
+DROP VIEW IF EXISTS view_3_tab1_951 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2796,13 +2796,13 @@ SELECT pk FROM tab2 WHERE col1 = 21.5
 ----
 
 statement ok
-DROP VIEW view_1_tab2_951
+DROP VIEW IF EXISTS view_1_tab2_951 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_951
+DROP VIEW IF EXISTS view_2_tab2_951 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_951
+DROP VIEW IF EXISTS view_3_tab2_951 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2888,13 +2888,13 @@ SELECT pk FROM tab3 WHERE col1 = 21.5
 ----
 
 statement ok
-DROP VIEW view_1_tab3_951
+DROP VIEW IF EXISTS view_1_tab3_951 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_951
+DROP VIEW IF EXISTS view_2_tab3_951 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_951
+DROP VIEW IF EXISTS view_3_tab3_951 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2980,13 +2980,13 @@ SELECT pk FROM tab4 WHERE col1 = 21.5
 ----
 
 statement ok
-DROP VIEW view_1_tab4_951
+DROP VIEW IF EXISTS view_1_tab4_951 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_951
+DROP VIEW IF EXISTS view_2_tab4_951 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_951
+DROP VIEW IF EXISTS view_3_tab4_951 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3106,13 +3106,13 @@ SELECT pk FROM tab0 WHERE col1 < 54.4
 8
 
 statement ok
-DROP VIEW view_1_tab0_952
+DROP VIEW IF EXISTS view_1_tab0_952 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_952
+DROP VIEW IF EXISTS view_2_tab0_952 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_952
+DROP VIEW IF EXISTS view_3_tab0_952 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3232,13 +3232,13 @@ SELECT pk FROM tab1 WHERE col1 < 54.4
 8
 
 statement ok
-DROP VIEW view_1_tab1_952
+DROP VIEW IF EXISTS view_1_tab1_952 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_952
+DROP VIEW IF EXISTS view_2_tab1_952 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_952
+DROP VIEW IF EXISTS view_3_tab1_952 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3358,13 +3358,13 @@ SELECT pk FROM tab2 WHERE col1 < 54.4
 8
 
 statement ok
-DROP VIEW view_1_tab2_952
+DROP VIEW IF EXISTS view_1_tab2_952 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_952
+DROP VIEW IF EXISTS view_2_tab2_952 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_952
+DROP VIEW IF EXISTS view_3_tab2_952 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3484,13 +3484,13 @@ SELECT pk FROM tab3 WHERE col1 < 54.4
 8
 
 statement ok
-DROP VIEW view_1_tab3_952
+DROP VIEW IF EXISTS view_1_tab3_952 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_952
+DROP VIEW IF EXISTS view_2_tab3_952 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_952
+DROP VIEW IF EXISTS view_3_tab3_952 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3610,13 +3610,13 @@ SELECT pk FROM tab4 WHERE col1 < 54.4
 8
 
 statement ok
-DROP VIEW view_1_tab4_952
+DROP VIEW IF EXISTS view_1_tab4_952 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_952
+DROP VIEW IF EXISTS view_2_tab4_952 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_952
+DROP VIEW IF EXISTS view_3_tab4_952 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3736,13 +3736,13 @@ SELECT pk FROM tab0 WHERE col0 > 55
 7
 
 statement ok
-DROP VIEW view_1_tab0_953
+DROP VIEW IF EXISTS view_1_tab0_953 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_953
+DROP VIEW IF EXISTS view_2_tab0_953 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_953
+DROP VIEW IF EXISTS view_3_tab0_953 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3862,13 +3862,13 @@ SELECT pk FROM tab1 WHERE col0 > 55
 7
 
 statement ok
-DROP VIEW view_1_tab1_953
+DROP VIEW IF EXISTS view_1_tab1_953 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_953
+DROP VIEW IF EXISTS view_2_tab1_953 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_953
+DROP VIEW IF EXISTS view_3_tab1_953 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3988,13 +3988,13 @@ SELECT pk FROM tab2 WHERE col0 > 55
 7
 
 statement ok
-DROP VIEW view_1_tab2_953
+DROP VIEW IF EXISTS view_1_tab2_953 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_953
+DROP VIEW IF EXISTS view_2_tab2_953 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_953
+DROP VIEW IF EXISTS view_3_tab2_953 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4114,13 +4114,13 @@ SELECT pk FROM tab3 WHERE col0 > 55
 7
 
 statement ok
-DROP VIEW view_1_tab3_953
+DROP VIEW IF EXISTS view_1_tab3_953 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_953
+DROP VIEW IF EXISTS view_2_tab3_953 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_953
+DROP VIEW IF EXISTS view_3_tab3_953 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4240,13 +4240,13 @@ SELECT pk FROM tab4 WHERE col0 > 55
 7
 
 statement ok
-DROP VIEW view_1_tab4_953
+DROP VIEW IF EXISTS view_1_tab4_953 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_953
+DROP VIEW IF EXISTS view_2_tab4_953 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_953
+DROP VIEW IF EXISTS view_3_tab4_953 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4339,13 +4339,13 @@ SELECT pk FROM tab0 WHERE ((col3 > 17)) OR col0 < 83
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab0_954
+DROP VIEW IF EXISTS view_1_tab0_954 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_954
+DROP VIEW IF EXISTS view_2_tab0_954 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_954
+DROP VIEW IF EXISTS view_3_tab0_954 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4438,13 +4438,13 @@ SELECT pk FROM tab1 WHERE ((col3 > 17)) OR col0 < 83
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab1_954
+DROP VIEW IF EXISTS view_1_tab1_954 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_954
+DROP VIEW IF EXISTS view_2_tab1_954 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_954
+DROP VIEW IF EXISTS view_3_tab1_954 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4537,13 +4537,13 @@ SELECT pk FROM tab2 WHERE ((col3 > 17)) OR col0 < 83
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab2_954
+DROP VIEW IF EXISTS view_1_tab2_954 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_954
+DROP VIEW IF EXISTS view_2_tab2_954 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_954
+DROP VIEW IF EXISTS view_3_tab2_954 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4636,13 +4636,13 @@ SELECT pk FROM tab3 WHERE ((col3 > 17)) OR col0 < 83
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab3_954
+DROP VIEW IF EXISTS view_1_tab3_954 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_954
+DROP VIEW IF EXISTS view_2_tab3_954 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_954
+DROP VIEW IF EXISTS view_3_tab3_954 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4735,13 +4735,13 @@ SELECT pk FROM tab4 WHERE ((col3 > 17)) OR col0 < 83
 9 values hashing to 22e400a2ddbb013acf2a5852d6ab69fc
 
 statement ok
-DROP VIEW view_1_tab4_954
+DROP VIEW IF EXISTS view_1_tab4_954 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_954
+DROP VIEW IF EXISTS view_2_tab4_954 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_954
+DROP VIEW IF EXISTS view_3_tab4_954 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4827,13 +4827,13 @@ SELECT pk FROM tab0 WHERE (col1 = 6.67)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_955
+DROP VIEW IF EXISTS view_1_tab0_955 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_955
+DROP VIEW IF EXISTS view_2_tab0_955 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_955
+DROP VIEW IF EXISTS view_3_tab0_955 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4919,13 +4919,13 @@ SELECT pk FROM tab1 WHERE (col1 = 6.67)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_955
+DROP VIEW IF EXISTS view_1_tab1_955 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_955
+DROP VIEW IF EXISTS view_2_tab1_955 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_955
+DROP VIEW IF EXISTS view_3_tab1_955 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5011,13 +5011,13 @@ SELECT pk FROM tab2 WHERE (col1 = 6.67)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_955
+DROP VIEW IF EXISTS view_1_tab2_955 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_955
+DROP VIEW IF EXISTS view_2_tab2_955 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_955
+DROP VIEW IF EXISTS view_3_tab2_955 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5103,13 +5103,13 @@ SELECT pk FROM tab3 WHERE (col1 = 6.67)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_955
+DROP VIEW IF EXISTS view_1_tab3_955 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_955
+DROP VIEW IF EXISTS view_2_tab3_955 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_955
+DROP VIEW IF EXISTS view_3_tab3_955 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5195,13 +5195,13 @@ SELECT pk FROM tab4 WHERE (col1 = 6.67)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_955
+DROP VIEW IF EXISTS view_1_tab4_955 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_955
+DROP VIEW IF EXISTS view_2_tab4_955 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_955
+DROP VIEW IF EXISTS view_3_tab4_955 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5294,13 +5294,13 @@ SELECT pk FROM tab0 WHERE (col0 IN (36,50,61) OR col4 <= 91.8)
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab0_956
+DROP VIEW IF EXISTS view_1_tab0_956 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_956
+DROP VIEW IF EXISTS view_2_tab0_956 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_956
+DROP VIEW IF EXISTS view_3_tab0_956 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5393,13 +5393,13 @@ SELECT pk FROM tab1 WHERE (col0 IN (36,50,61) OR col4 <= 91.8)
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab1_956
+DROP VIEW IF EXISTS view_1_tab1_956 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_956
+DROP VIEW IF EXISTS view_2_tab1_956 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_956
+DROP VIEW IF EXISTS view_3_tab1_956 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5492,13 +5492,13 @@ SELECT pk FROM tab2 WHERE (col0 IN (36,50,61) OR col4 <= 91.8)
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab2_956
+DROP VIEW IF EXISTS view_1_tab2_956 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_956
+DROP VIEW IF EXISTS view_2_tab2_956 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_956
+DROP VIEW IF EXISTS view_3_tab2_956 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5591,13 +5591,13 @@ SELECT pk FROM tab3 WHERE (col0 IN (36,50,61) OR col4 <= 91.8)
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab3_956
+DROP VIEW IF EXISTS view_1_tab3_956 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_956
+DROP VIEW IF EXISTS view_2_tab3_956 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_956
+DROP VIEW IF EXISTS view_3_tab3_956 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5690,13 +5690,13 @@ SELECT pk FROM tab4 WHERE (col0 IN (36,50,61) OR col4 <= 91.8)
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab4_956
+DROP VIEW IF EXISTS view_1_tab4_956 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_956
+DROP VIEW IF EXISTS view_2_tab4_956 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_956
+DROP VIEW IF EXISTS view_3_tab4_956 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5782,13 +5782,13 @@ SELECT pk FROM tab0 WHERE col3 = 60
 ----
 
 statement ok
-DROP VIEW view_1_tab0_957
+DROP VIEW IF EXISTS view_1_tab0_957 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_957
+DROP VIEW IF EXISTS view_2_tab0_957 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_957
+DROP VIEW IF EXISTS view_3_tab0_957 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5874,13 +5874,13 @@ SELECT pk FROM tab1 WHERE col3 = 60
 ----
 
 statement ok
-DROP VIEW view_1_tab1_957
+DROP VIEW IF EXISTS view_1_tab1_957 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_957
+DROP VIEW IF EXISTS view_2_tab1_957 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_957
+DROP VIEW IF EXISTS view_3_tab1_957 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5966,13 +5966,13 @@ SELECT pk FROM tab2 WHERE col3 = 60
 ----
 
 statement ok
-DROP VIEW view_1_tab2_957
+DROP VIEW IF EXISTS view_1_tab2_957 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_957
+DROP VIEW IF EXISTS view_2_tab2_957 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_957
+DROP VIEW IF EXISTS view_3_tab2_957 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6058,13 +6058,13 @@ SELECT pk FROM tab3 WHERE col3 = 60
 ----
 
 statement ok
-DROP VIEW view_1_tab3_957
+DROP VIEW IF EXISTS view_1_tab3_957 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_957
+DROP VIEW IF EXISTS view_2_tab3_957 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_957
+DROP VIEW IF EXISTS view_3_tab3_957 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6150,13 +6150,13 @@ SELECT pk FROM tab4 WHERE col3 = 60
 ----
 
 statement ok
-DROP VIEW view_1_tab4_957
+DROP VIEW IF EXISTS view_1_tab4_957 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_957
+DROP VIEW IF EXISTS view_2_tab4_957 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_957
+DROP VIEW IF EXISTS view_3_tab4_957 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6245,13 +6245,13 @@ SELECT pk FROM tab0 WHERE (col0 < 95)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_958
+DROP VIEW IF EXISTS view_1_tab0_958 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_958
+DROP VIEW IF EXISTS view_2_tab0_958 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_958
+DROP VIEW IF EXISTS view_3_tab0_958 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6340,13 +6340,13 @@ SELECT pk FROM tab1 WHERE (col0 < 95)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_958
+DROP VIEW IF EXISTS view_1_tab1_958 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_958
+DROP VIEW IF EXISTS view_2_tab1_958 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_958
+DROP VIEW IF EXISTS view_3_tab1_958 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6435,13 +6435,13 @@ SELECT pk FROM tab2 WHERE (col0 < 95)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_958
+DROP VIEW IF EXISTS view_1_tab2_958 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_958
+DROP VIEW IF EXISTS view_2_tab2_958 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_958
+DROP VIEW IF EXISTS view_3_tab2_958 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6530,13 +6530,13 @@ SELECT pk FROM tab3 WHERE (col0 < 95)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_958
+DROP VIEW IF EXISTS view_1_tab3_958 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_958
+DROP VIEW IF EXISTS view_2_tab3_958 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_958
+DROP VIEW IF EXISTS view_3_tab3_958 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6625,13 +6625,13 @@ SELECT pk FROM tab4 WHERE (col0 < 95)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_958
+DROP VIEW IF EXISTS view_1_tab4_958 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_958
+DROP VIEW IF EXISTS view_2_tab4_958 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_958
+DROP VIEW IF EXISTS view_3_tab4_958 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6751,13 +6751,13 @@ SELECT pk FROM tab0 WHERE col1 > 29.25 AND col4 <= 41.16 AND (((col3 >= 43) AND 
 9
 
 statement ok
-DROP VIEW view_1_tab0_960
+DROP VIEW IF EXISTS view_1_tab0_960 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_960
+DROP VIEW IF EXISTS view_2_tab0_960 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_960
+DROP VIEW IF EXISTS view_3_tab0_960 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6877,13 +6877,13 @@ SELECT pk FROM tab1 WHERE col1 > 29.25 AND col4 <= 41.16 AND (((col3 >= 43) AND 
 9
 
 statement ok
-DROP VIEW view_1_tab1_960
+DROP VIEW IF EXISTS view_1_tab1_960 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_960
+DROP VIEW IF EXISTS view_2_tab1_960 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_960
+DROP VIEW IF EXISTS view_3_tab1_960 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7003,13 +7003,13 @@ SELECT pk FROM tab2 WHERE col1 > 29.25 AND col4 <= 41.16 AND (((col3 >= 43) AND 
 9
 
 statement ok
-DROP VIEW view_1_tab2_960
+DROP VIEW IF EXISTS view_1_tab2_960 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_960
+DROP VIEW IF EXISTS view_2_tab2_960 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_960
+DROP VIEW IF EXISTS view_3_tab2_960 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7129,13 +7129,13 @@ SELECT pk FROM tab3 WHERE col1 > 29.25 AND col4 <= 41.16 AND (((col3 >= 43) AND 
 9
 
 statement ok
-DROP VIEW view_1_tab3_960
+DROP VIEW IF EXISTS view_1_tab3_960 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_960
+DROP VIEW IF EXISTS view_2_tab3_960 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_960
+DROP VIEW IF EXISTS view_3_tab3_960 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7255,13 +7255,13 @@ SELECT pk FROM tab4 WHERE col1 > 29.25 AND col4 <= 41.16 AND (((col3 >= 43) AND 
 9
 
 statement ok
-DROP VIEW view_1_tab4_960
+DROP VIEW IF EXISTS view_1_tab4_960 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_960
+DROP VIEW IF EXISTS view_2_tab4_960 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_960
+DROP VIEW IF EXISTS view_3_tab4_960 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7380,13 +7380,13 @@ SELECT pk FROM tab0 WHERE (col0 > 33)
 7
 
 statement ok
-DROP VIEW view_1_tab0_961
+DROP VIEW IF EXISTS view_1_tab0_961 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_961
+DROP VIEW IF EXISTS view_2_tab0_961 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_961
+DROP VIEW IF EXISTS view_3_tab0_961 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7505,13 +7505,13 @@ SELECT pk FROM tab1 WHERE (col0 > 33)
 7
 
 statement ok
-DROP VIEW view_1_tab1_961
+DROP VIEW IF EXISTS view_1_tab1_961 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_961
+DROP VIEW IF EXISTS view_2_tab1_961 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_961
+DROP VIEW IF EXISTS view_3_tab1_961 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7630,13 +7630,13 @@ SELECT pk FROM tab2 WHERE (col0 > 33)
 7
 
 statement ok
-DROP VIEW view_1_tab2_961
+DROP VIEW IF EXISTS view_1_tab2_961 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_961
+DROP VIEW IF EXISTS view_2_tab2_961 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_961
+DROP VIEW IF EXISTS view_3_tab2_961 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7755,13 +7755,13 @@ SELECT pk FROM tab3 WHERE (col0 > 33)
 7
 
 statement ok
-DROP VIEW view_1_tab3_961
+DROP VIEW IF EXISTS view_1_tab3_961 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_961
+DROP VIEW IF EXISTS view_2_tab3_961 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_961
+DROP VIEW IF EXISTS view_3_tab3_961 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7880,13 +7880,13 @@ SELECT pk FROM tab4 WHERE (col0 > 33)
 7
 
 statement ok
-DROP VIEW view_1_tab4_961
+DROP VIEW IF EXISTS view_1_tab4_961 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_961
+DROP VIEW IF EXISTS view_2_tab4_961 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_961
+DROP VIEW IF EXISTS view_3_tab4_961 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7972,13 +7972,13 @@ SELECT pk FROM tab0 WHERE col4 IN (9.21,30.7,24.3,83.35,38.62)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_962
+DROP VIEW IF EXISTS view_1_tab0_962 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_962
+DROP VIEW IF EXISTS view_2_tab0_962 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_962
+DROP VIEW IF EXISTS view_3_tab0_962 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8064,13 +8064,13 @@ SELECT pk FROM tab1 WHERE col4 IN (9.21,30.7,24.3,83.35,38.62)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_962
+DROP VIEW IF EXISTS view_1_tab1_962 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_962
+DROP VIEW IF EXISTS view_2_tab1_962 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_962
+DROP VIEW IF EXISTS view_3_tab1_962 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8156,13 +8156,13 @@ SELECT pk FROM tab2 WHERE col4 IN (9.21,30.7,24.3,83.35,38.62)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_962
+DROP VIEW IF EXISTS view_1_tab2_962 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_962
+DROP VIEW IF EXISTS view_2_tab2_962 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_962
+DROP VIEW IF EXISTS view_3_tab2_962 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8248,13 +8248,13 @@ SELECT pk FROM tab3 WHERE col4 IN (9.21,30.7,24.3,83.35,38.62)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_962
+DROP VIEW IF EXISTS view_1_tab3_962 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_962
+DROP VIEW IF EXISTS view_2_tab3_962 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_962
+DROP VIEW IF EXISTS view_3_tab3_962 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8340,13 +8340,13 @@ SELECT pk FROM tab4 WHERE col4 IN (9.21,30.7,24.3,83.35,38.62)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_962
+DROP VIEW IF EXISTS view_1_tab4_962 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_962
+DROP VIEW IF EXISTS view_2_tab4_962 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_962
+DROP VIEW IF EXISTS view_3_tab4_962 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8439,13 +8439,13 @@ SELECT pk FROM tab0 WHERE (col0 < 56) AND col1 < 34.71
 8
 
 statement ok
-DROP VIEW view_1_tab0_963
+DROP VIEW IF EXISTS view_1_tab0_963 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_963
+DROP VIEW IF EXISTS view_2_tab0_963 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_963
+DROP VIEW IF EXISTS view_3_tab0_963 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8538,13 +8538,13 @@ SELECT pk FROM tab1 WHERE (col0 < 56) AND col1 < 34.71
 8
 
 statement ok
-DROP VIEW view_1_tab1_963
+DROP VIEW IF EXISTS view_1_tab1_963 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_963
+DROP VIEW IF EXISTS view_2_tab1_963 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_963
+DROP VIEW IF EXISTS view_3_tab1_963 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8637,13 +8637,13 @@ SELECT pk FROM tab2 WHERE (col0 < 56) AND col1 < 34.71
 8
 
 statement ok
-DROP VIEW view_1_tab2_963
+DROP VIEW IF EXISTS view_1_tab2_963 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_963
+DROP VIEW IF EXISTS view_2_tab2_963 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_963
+DROP VIEW IF EXISTS view_3_tab2_963 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8736,13 +8736,13 @@ SELECT pk FROM tab3 WHERE (col0 < 56) AND col1 < 34.71
 8
 
 statement ok
-DROP VIEW view_1_tab3_963
+DROP VIEW IF EXISTS view_1_tab3_963 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_963
+DROP VIEW IF EXISTS view_2_tab3_963 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_963
+DROP VIEW IF EXISTS view_3_tab3_963 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8835,13 +8835,13 @@ SELECT pk FROM tab4 WHERE (col0 < 56) AND col1 < 34.71
 8
 
 statement ok
-DROP VIEW view_1_tab4_963
+DROP VIEW IF EXISTS view_1_tab4_963 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_963
+DROP VIEW IF EXISTS view_2_tab4_963 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_963
+DROP VIEW IF EXISTS view_3_tab4_963 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8944,13 +8944,13 @@ SELECT pk FROM tab0 WHERE col0 <= 60
 9
 
 statement ok
-DROP VIEW view_1_tab0_964
+DROP VIEW IF EXISTS view_1_tab0_964 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_964
+DROP VIEW IF EXISTS view_2_tab0_964 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_964
+DROP VIEW IF EXISTS view_3_tab0_964 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9053,13 +9053,13 @@ SELECT pk FROM tab1 WHERE col0 <= 60
 9
 
 statement ok
-DROP VIEW view_1_tab1_964
+DROP VIEW IF EXISTS view_1_tab1_964 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_964
+DROP VIEW IF EXISTS view_2_tab1_964 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_964
+DROP VIEW IF EXISTS view_3_tab1_964 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9162,13 +9162,13 @@ SELECT pk FROM tab2 WHERE col0 <= 60
 9
 
 statement ok
-DROP VIEW view_1_tab2_964
+DROP VIEW IF EXISTS view_1_tab2_964 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_964
+DROP VIEW IF EXISTS view_2_tab2_964 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_964
+DROP VIEW IF EXISTS view_3_tab2_964 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9271,13 +9271,13 @@ SELECT pk FROM tab3 WHERE col0 <= 60
 9
 
 statement ok
-DROP VIEW view_1_tab3_964
+DROP VIEW IF EXISTS view_1_tab3_964 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_964
+DROP VIEW IF EXISTS view_2_tab3_964 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_964
+DROP VIEW IF EXISTS view_3_tab3_964 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9380,13 +9380,13 @@ SELECT pk FROM tab4 WHERE col0 <= 60
 9
 
 statement ok
-DROP VIEW view_1_tab4_964
+DROP VIEW IF EXISTS view_1_tab4_964 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_964
+DROP VIEW IF EXISTS view_2_tab4_964 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_964
+DROP VIEW IF EXISTS view_3_tab4_964 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9472,13 +9472,13 @@ SELECT pk FROM tab0 WHERE (col0 BETWEEN 31 AND 31)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_965
+DROP VIEW IF EXISTS view_1_tab0_965 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_965
+DROP VIEW IF EXISTS view_2_tab0_965 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_965
+DROP VIEW IF EXISTS view_3_tab0_965 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9564,13 +9564,13 @@ SELECT pk FROM tab1 WHERE (col0 BETWEEN 31 AND 31)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_965
+DROP VIEW IF EXISTS view_1_tab1_965 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_965
+DROP VIEW IF EXISTS view_2_tab1_965 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_965
+DROP VIEW IF EXISTS view_3_tab1_965 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9656,13 +9656,13 @@ SELECT pk FROM tab2 WHERE (col0 BETWEEN 31 AND 31)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_965
+DROP VIEW IF EXISTS view_1_tab2_965 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_965
+DROP VIEW IF EXISTS view_2_tab2_965 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_965
+DROP VIEW IF EXISTS view_3_tab2_965 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9748,13 +9748,13 @@ SELECT pk FROM tab3 WHERE (col0 BETWEEN 31 AND 31)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_965
+DROP VIEW IF EXISTS view_1_tab3_965 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_965
+DROP VIEW IF EXISTS view_2_tab3_965 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_965
+DROP VIEW IF EXISTS view_3_tab3_965 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9840,13 +9840,13 @@ SELECT pk FROM tab4 WHERE (col0 BETWEEN 31 AND 31)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_965
+DROP VIEW IF EXISTS view_1_tab4_965 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_965
+DROP VIEW IF EXISTS view_2_tab4_965 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_965
+DROP VIEW IF EXISTS view_3_tab4_965 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9966,13 +9966,13 @@ SELECT pk FROM tab0 WHERE col0 IS NULL OR col3 < 54
 8
 
 statement ok
-DROP VIEW view_1_tab0_966
+DROP VIEW IF EXISTS view_1_tab0_966 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_966
+DROP VIEW IF EXISTS view_2_tab0_966 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_966
+DROP VIEW IF EXISTS view_3_tab0_966 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10092,13 +10092,13 @@ SELECT pk FROM tab1 WHERE col0 IS NULL OR col3 < 54
 8
 
 statement ok
-DROP VIEW view_1_tab1_966
+DROP VIEW IF EXISTS view_1_tab1_966 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_966
+DROP VIEW IF EXISTS view_2_tab1_966 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_966
+DROP VIEW IF EXISTS view_3_tab1_966 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10218,13 +10218,13 @@ SELECT pk FROM tab2 WHERE col0 IS NULL OR col3 < 54
 8
 
 statement ok
-DROP VIEW view_1_tab2_966
+DROP VIEW IF EXISTS view_1_tab2_966 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_966
+DROP VIEW IF EXISTS view_2_tab2_966 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_966
+DROP VIEW IF EXISTS view_3_tab2_966 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10344,13 +10344,13 @@ SELECT pk FROM tab3 WHERE col0 IS NULL OR col3 < 54
 8
 
 statement ok
-DROP VIEW view_1_tab3_966
+DROP VIEW IF EXISTS view_1_tab3_966 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_966
+DROP VIEW IF EXISTS view_2_tab3_966 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_966
+DROP VIEW IF EXISTS view_3_tab3_966 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10470,13 +10470,13 @@ SELECT pk FROM tab4 WHERE col0 IS NULL OR col3 < 54
 8
 
 statement ok
-DROP VIEW view_1_tab4_966
+DROP VIEW IF EXISTS view_1_tab4_966 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_966
+DROP VIEW IF EXISTS view_2_tab4_966 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_966
+DROP VIEW IF EXISTS view_3_tab4_966 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10596,13 +10596,13 @@ SELECT pk FROM tab0 WHERE ((col3 = 47) OR col4 > 28.79 AND col3 <= 12 OR col3 > 
 9
 
 statement ok
-DROP VIEW view_1_tab0_967
+DROP VIEW IF EXISTS view_1_tab0_967 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_967
+DROP VIEW IF EXISTS view_2_tab0_967 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_967
+DROP VIEW IF EXISTS view_3_tab0_967 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10722,13 +10722,13 @@ SELECT pk FROM tab1 WHERE ((col3 = 47) OR col4 > 28.79 AND col3 <= 12 OR col3 > 
 9
 
 statement ok
-DROP VIEW view_1_tab1_967
+DROP VIEW IF EXISTS view_1_tab1_967 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_967
+DROP VIEW IF EXISTS view_2_tab1_967 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_967
+DROP VIEW IF EXISTS view_3_tab1_967 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10848,13 +10848,13 @@ SELECT pk FROM tab2 WHERE ((col3 = 47) OR col4 > 28.79 AND col3 <= 12 OR col3 > 
 9
 
 statement ok
-DROP VIEW view_1_tab2_967
+DROP VIEW IF EXISTS view_1_tab2_967 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_967
+DROP VIEW IF EXISTS view_2_tab2_967 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_967
+DROP VIEW IF EXISTS view_3_tab2_967 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10974,13 +10974,13 @@ SELECT pk FROM tab3 WHERE ((col3 = 47) OR col4 > 28.79 AND col3 <= 12 OR col3 > 
 9
 
 statement ok
-DROP VIEW view_1_tab3_967
+DROP VIEW IF EXISTS view_1_tab3_967 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_967
+DROP VIEW IF EXISTS view_2_tab3_967 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_967
+DROP VIEW IF EXISTS view_3_tab3_967 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11100,13 +11100,13 @@ SELECT pk FROM tab4 WHERE ((col3 = 47) OR col4 > 28.79 AND col3 <= 12 OR col3 > 
 9
 
 statement ok
-DROP VIEW view_1_tab4_967
+DROP VIEW IF EXISTS view_1_tab4_967 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_967
+DROP VIEW IF EXISTS view_2_tab4_967 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_967
+DROP VIEW IF EXISTS view_3_tab4_967 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11192,13 +11192,13 @@ SELECT pk FROM tab0 WHERE (col4 = 10.83)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_968
+DROP VIEW IF EXISTS view_1_tab0_968 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_968
+DROP VIEW IF EXISTS view_2_tab0_968 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_968
+DROP VIEW IF EXISTS view_3_tab0_968 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11284,13 +11284,13 @@ SELECT pk FROM tab1 WHERE (col4 = 10.83)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_968
+DROP VIEW IF EXISTS view_1_tab1_968 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_968
+DROP VIEW IF EXISTS view_2_tab1_968 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_968
+DROP VIEW IF EXISTS view_3_tab1_968 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11376,13 +11376,13 @@ SELECT pk FROM tab2 WHERE (col4 = 10.83)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_968
+DROP VIEW IF EXISTS view_1_tab2_968 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_968
+DROP VIEW IF EXISTS view_2_tab2_968 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_968
+DROP VIEW IF EXISTS view_3_tab2_968 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11468,13 +11468,13 @@ SELECT pk FROM tab3 WHERE (col4 = 10.83)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_968
+DROP VIEW IF EXISTS view_1_tab3_968 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_968
+DROP VIEW IF EXISTS view_2_tab3_968 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_968
+DROP VIEW IF EXISTS view_3_tab3_968 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11560,13 +11560,13 @@ SELECT pk FROM tab4 WHERE (col4 = 10.83)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_968
+DROP VIEW IF EXISTS view_1_tab4_968 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_968
+DROP VIEW IF EXISTS view_2_tab4_968 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_968
+DROP VIEW IF EXISTS view_3_tab4_968 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11652,13 +11652,13 @@ SELECT pk FROM tab0 WHERE ((col1 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_969
+DROP VIEW IF EXISTS view_1_tab0_969 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_969
+DROP VIEW IF EXISTS view_2_tab0_969 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_969
+DROP VIEW IF EXISTS view_3_tab0_969 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11744,13 +11744,13 @@ SELECT pk FROM tab1 WHERE ((col1 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_969
+DROP VIEW IF EXISTS view_1_tab1_969 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_969
+DROP VIEW IF EXISTS view_2_tab1_969 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_969
+DROP VIEW IF EXISTS view_3_tab1_969 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11836,13 +11836,13 @@ SELECT pk FROM tab2 WHERE ((col1 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_969
+DROP VIEW IF EXISTS view_1_tab2_969 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_969
+DROP VIEW IF EXISTS view_2_tab2_969 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_969
+DROP VIEW IF EXISTS view_3_tab2_969 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11928,13 +11928,13 @@ SELECT pk FROM tab3 WHERE ((col1 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_969
+DROP VIEW IF EXISTS view_1_tab3_969 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_969
+DROP VIEW IF EXISTS view_2_tab3_969 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_969
+DROP VIEW IF EXISTS view_3_tab3_969 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12020,13 +12020,13 @@ SELECT pk FROM tab4 WHERE ((col1 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_969
+DROP VIEW IF EXISTS view_1_tab4_969 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_969
+DROP VIEW IF EXISTS view_2_tab4_969 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_969
+DROP VIEW IF EXISTS view_3_tab4_969 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12144,13 +12144,13 @@ SELECT pk FROM tab0 WHERE (col0 < 86) AND col3 >= 23
 9
 
 statement ok
-DROP VIEW view_1_tab0_970
+DROP VIEW IF EXISTS view_1_tab0_970 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_970
+DROP VIEW IF EXISTS view_2_tab0_970 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_970
+DROP VIEW IF EXISTS view_3_tab0_970 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12268,13 +12268,13 @@ SELECT pk FROM tab1 WHERE (col0 < 86) AND col3 >= 23
 9
 
 statement ok
-DROP VIEW view_1_tab1_970
+DROP VIEW IF EXISTS view_1_tab1_970 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_970
+DROP VIEW IF EXISTS view_2_tab1_970 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_970
+DROP VIEW IF EXISTS view_3_tab1_970 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12392,13 +12392,13 @@ SELECT pk FROM tab2 WHERE (col0 < 86) AND col3 >= 23
 9
 
 statement ok
-DROP VIEW view_1_tab2_970
+DROP VIEW IF EXISTS view_1_tab2_970 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_970
+DROP VIEW IF EXISTS view_2_tab2_970 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_970
+DROP VIEW IF EXISTS view_3_tab2_970 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12516,13 +12516,13 @@ SELECT pk FROM tab3 WHERE (col0 < 86) AND col3 >= 23
 9
 
 statement ok
-DROP VIEW view_1_tab3_970
+DROP VIEW IF EXISTS view_1_tab3_970 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_970
+DROP VIEW IF EXISTS view_2_tab3_970 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_970
+DROP VIEW IF EXISTS view_3_tab3_970 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12640,13 +12640,13 @@ SELECT pk FROM tab4 WHERE (col0 < 86) AND col3 >= 23
 9
 
 statement ok
-DROP VIEW view_1_tab4_970
+DROP VIEW IF EXISTS view_1_tab4_970 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_970
+DROP VIEW IF EXISTS view_2_tab4_970 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_970
+DROP VIEW IF EXISTS view_3_tab4_970 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12766,13 +12766,13 @@ SELECT pk FROM tab0 WHERE col0 >= 37
 7
 
 statement ok
-DROP VIEW view_1_tab0_971
+DROP VIEW IF EXISTS view_1_tab0_971 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_971
+DROP VIEW IF EXISTS view_2_tab0_971 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_971
+DROP VIEW IF EXISTS view_3_tab0_971 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12892,13 +12892,13 @@ SELECT pk FROM tab1 WHERE col0 >= 37
 7
 
 statement ok
-DROP VIEW view_1_tab1_971
+DROP VIEW IF EXISTS view_1_tab1_971 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_971
+DROP VIEW IF EXISTS view_2_tab1_971 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_971
+DROP VIEW IF EXISTS view_3_tab1_971 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13018,13 +13018,13 @@ SELECT pk FROM tab2 WHERE col0 >= 37
 7
 
 statement ok
-DROP VIEW view_1_tab2_971
+DROP VIEW IF EXISTS view_1_tab2_971 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_971
+DROP VIEW IF EXISTS view_2_tab2_971 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_971
+DROP VIEW IF EXISTS view_3_tab2_971 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13144,13 +13144,13 @@ SELECT pk FROM tab3 WHERE col0 >= 37
 7
 
 statement ok
-DROP VIEW view_1_tab3_971
+DROP VIEW IF EXISTS view_1_tab3_971 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_971
+DROP VIEW IF EXISTS view_2_tab3_971 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_971
+DROP VIEW IF EXISTS view_3_tab3_971 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13270,13 +13270,13 @@ SELECT pk FROM tab4 WHERE col0 >= 37
 7
 
 statement ok
-DROP VIEW view_1_tab4_971
+DROP VIEW IF EXISTS view_1_tab4_971 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_971
+DROP VIEW IF EXISTS view_2_tab4_971 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_971
+DROP VIEW IF EXISTS view_3_tab4_971 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13365,13 +13365,13 @@ SELECT pk FROM tab0 WHERE ((((col4 < 66.39 AND (col3 BETWEEN 98 AND 12 AND col4 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_972
+DROP VIEW IF EXISTS view_1_tab0_972 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_972
+DROP VIEW IF EXISTS view_2_tab0_972 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_972
+DROP VIEW IF EXISTS view_3_tab0_972 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13460,13 +13460,13 @@ SELECT pk FROM tab1 WHERE ((((col4 < 66.39 AND (col3 BETWEEN 98 AND 12 AND col4 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_972
+DROP VIEW IF EXISTS view_1_tab1_972 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_972
+DROP VIEW IF EXISTS view_2_tab1_972 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_972
+DROP VIEW IF EXISTS view_3_tab1_972 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13555,13 +13555,13 @@ SELECT pk FROM tab2 WHERE ((((col4 < 66.39 AND (col3 BETWEEN 98 AND 12 AND col4 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_972
+DROP VIEW IF EXISTS view_1_tab2_972 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_972
+DROP VIEW IF EXISTS view_2_tab2_972 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_972
+DROP VIEW IF EXISTS view_3_tab2_972 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13650,13 +13650,13 @@ SELECT pk FROM tab3 WHERE ((((col4 < 66.39 AND (col3 BETWEEN 98 AND 12 AND col4 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_972
+DROP VIEW IF EXISTS view_1_tab3_972 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_972
+DROP VIEW IF EXISTS view_2_tab3_972 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_972
+DROP VIEW IF EXISTS view_3_tab3_972 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13745,13 +13745,13 @@ SELECT pk FROM tab4 WHERE ((((col4 < 66.39 AND (col3 BETWEEN 98 AND 12 AND col4 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_972
+DROP VIEW IF EXISTS view_1_tab4_972 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_972
+DROP VIEW IF EXISTS view_2_tab4_972 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_972
+DROP VIEW IF EXISTS view_3_tab4_972 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13844,13 +13844,13 @@ SELECT pk FROM tab0 WHERE col0 > 17
 9 values hashing to 6ba058c53c08bb0173bcc14ce59aeeff
 
 statement ok
-DROP VIEW view_1_tab0_973
+DROP VIEW IF EXISTS view_1_tab0_973 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_973
+DROP VIEW IF EXISTS view_2_tab0_973 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_973
+DROP VIEW IF EXISTS view_3_tab0_973 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13943,13 +13943,13 @@ SELECT pk FROM tab1 WHERE col0 > 17
 9 values hashing to 6ba058c53c08bb0173bcc14ce59aeeff
 
 statement ok
-DROP VIEW view_1_tab1_973
+DROP VIEW IF EXISTS view_1_tab1_973 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_973
+DROP VIEW IF EXISTS view_2_tab1_973 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_973
+DROP VIEW IF EXISTS view_3_tab1_973 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14042,13 +14042,13 @@ SELECT pk FROM tab2 WHERE col0 > 17
 9 values hashing to 6ba058c53c08bb0173bcc14ce59aeeff
 
 statement ok
-DROP VIEW view_1_tab2_973
+DROP VIEW IF EXISTS view_1_tab2_973 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_973
+DROP VIEW IF EXISTS view_2_tab2_973 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_973
+DROP VIEW IF EXISTS view_3_tab2_973 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14141,13 +14141,13 @@ SELECT pk FROM tab3 WHERE col0 > 17
 9 values hashing to 6ba058c53c08bb0173bcc14ce59aeeff
 
 statement ok
-DROP VIEW view_1_tab3_973
+DROP VIEW IF EXISTS view_1_tab3_973 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_973
+DROP VIEW IF EXISTS view_2_tab3_973 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_973
+DROP VIEW IF EXISTS view_3_tab3_973 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14240,13 +14240,13 @@ SELECT pk FROM tab4 WHERE col0 > 17
 9 values hashing to 6ba058c53c08bb0173bcc14ce59aeeff
 
 statement ok
-DROP VIEW view_1_tab4_973
+DROP VIEW IF EXISTS view_1_tab4_973 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_973
+DROP VIEW IF EXISTS view_2_tab4_973 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_973
+DROP VIEW IF EXISTS view_3_tab4_973 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14332,13 +14332,13 @@ SELECT pk FROM tab0 WHERE (col0 > 93 OR col3 = 98 OR col4 > 97.33)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_974
+DROP VIEW IF EXISTS view_1_tab0_974 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_974
+DROP VIEW IF EXISTS view_2_tab0_974 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_974
+DROP VIEW IF EXISTS view_3_tab0_974 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14424,13 +14424,13 @@ SELECT pk FROM tab1 WHERE (col0 > 93 OR col3 = 98 OR col4 > 97.33)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_974
+DROP VIEW IF EXISTS view_1_tab1_974 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_974
+DROP VIEW IF EXISTS view_2_tab1_974 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_974
+DROP VIEW IF EXISTS view_3_tab1_974 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14516,13 +14516,13 @@ SELECT pk FROM tab2 WHERE (col0 > 93 OR col3 = 98 OR col4 > 97.33)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_974
+DROP VIEW IF EXISTS view_1_tab2_974 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_974
+DROP VIEW IF EXISTS view_2_tab2_974 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_974
+DROP VIEW IF EXISTS view_3_tab2_974 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14608,13 +14608,13 @@ SELECT pk FROM tab3 WHERE (col0 > 93 OR col3 = 98 OR col4 > 97.33)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_974
+DROP VIEW IF EXISTS view_1_tab3_974 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_974
+DROP VIEW IF EXISTS view_2_tab3_974 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_974
+DROP VIEW IF EXISTS view_3_tab3_974 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14700,13 +14700,13 @@ SELECT pk FROM tab4 WHERE (col0 > 93 OR col3 = 98 OR col4 > 97.33)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_974
+DROP VIEW IF EXISTS view_1_tab4_974 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_974
+DROP VIEW IF EXISTS view_2_tab4_974 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_974
+DROP VIEW IF EXISTS view_3_tab4_974 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14813,13 +14813,13 @@ SELECT pk FROM tab0 WHERE col1 > 60.69
 9
 
 statement ok
-DROP VIEW view_1_tab0_975
+DROP VIEW IF EXISTS view_1_tab0_975 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_975
+DROP VIEW IF EXISTS view_2_tab0_975 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_975
+DROP VIEW IF EXISTS view_3_tab0_975 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14926,13 +14926,13 @@ SELECT pk FROM tab1 WHERE col1 > 60.69
 9
 
 statement ok
-DROP VIEW view_1_tab1_975
+DROP VIEW IF EXISTS view_1_tab1_975 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_975
+DROP VIEW IF EXISTS view_2_tab1_975 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_975
+DROP VIEW IF EXISTS view_3_tab1_975 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15039,13 +15039,13 @@ SELECT pk FROM tab2 WHERE col1 > 60.69
 9
 
 statement ok
-DROP VIEW view_1_tab2_975
+DROP VIEW IF EXISTS view_1_tab2_975 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_975
+DROP VIEW IF EXISTS view_2_tab2_975 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_975
+DROP VIEW IF EXISTS view_3_tab2_975 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15152,13 +15152,13 @@ SELECT pk FROM tab3 WHERE col1 > 60.69
 9
 
 statement ok
-DROP VIEW view_1_tab3_975
+DROP VIEW IF EXISTS view_1_tab3_975 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_975
+DROP VIEW IF EXISTS view_2_tab3_975 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_975
+DROP VIEW IF EXISTS view_3_tab3_975 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15265,13 +15265,13 @@ SELECT pk FROM tab4 WHERE col1 > 60.69
 9
 
 statement ok
-DROP VIEW view_1_tab4_975
+DROP VIEW IF EXISTS view_1_tab4_975 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_975
+DROP VIEW IF EXISTS view_2_tab4_975 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_975
+DROP VIEW IF EXISTS view_3_tab4_975 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15391,13 +15391,13 @@ SELECT pk FROM tab0 WHERE col3 < 54
 8
 
 statement ok
-DROP VIEW view_1_tab0_976
+DROP VIEW IF EXISTS view_1_tab0_976 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_976
+DROP VIEW IF EXISTS view_2_tab0_976 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_976
+DROP VIEW IF EXISTS view_3_tab0_976 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15517,13 +15517,13 @@ SELECT pk FROM tab1 WHERE col3 < 54
 8
 
 statement ok
-DROP VIEW view_1_tab1_976
+DROP VIEW IF EXISTS view_1_tab1_976 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_976
+DROP VIEW IF EXISTS view_2_tab1_976 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_976
+DROP VIEW IF EXISTS view_3_tab1_976 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15643,13 +15643,13 @@ SELECT pk FROM tab2 WHERE col3 < 54
 8
 
 statement ok
-DROP VIEW view_1_tab2_976
+DROP VIEW IF EXISTS view_1_tab2_976 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_976
+DROP VIEW IF EXISTS view_2_tab2_976 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_976
+DROP VIEW IF EXISTS view_3_tab2_976 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15769,13 +15769,13 @@ SELECT pk FROM tab3 WHERE col3 < 54
 8
 
 statement ok
-DROP VIEW view_1_tab3_976
+DROP VIEW IF EXISTS view_1_tab3_976 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_976
+DROP VIEW IF EXISTS view_2_tab3_976 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_976
+DROP VIEW IF EXISTS view_3_tab3_976 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15895,13 +15895,13 @@ SELECT pk FROM tab4 WHERE col3 < 54
 8
 
 statement ok
-DROP VIEW view_1_tab4_976
+DROP VIEW IF EXISTS view_1_tab4_976 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_976
+DROP VIEW IF EXISTS view_2_tab4_976 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_976
+DROP VIEW IF EXISTS view_3_tab4_976 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16019,13 +16019,13 @@ SELECT pk FROM tab0 WHERE (col0 > 25 OR col1 < 78.91 AND col3 IS NULL)
 8
 
 statement ok
-DROP VIEW view_1_tab0_977
+DROP VIEW IF EXISTS view_1_tab0_977 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_977
+DROP VIEW IF EXISTS view_2_tab0_977 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_977
+DROP VIEW IF EXISTS view_3_tab0_977 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16143,13 +16143,13 @@ SELECT pk FROM tab1 WHERE (col0 > 25 OR col1 < 78.91 AND col3 IS NULL)
 8
 
 statement ok
-DROP VIEW view_1_tab1_977
+DROP VIEW IF EXISTS view_1_tab1_977 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_977
+DROP VIEW IF EXISTS view_2_tab1_977 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_977
+DROP VIEW IF EXISTS view_3_tab1_977 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16267,13 +16267,13 @@ SELECT pk FROM tab2 WHERE (col0 > 25 OR col1 < 78.91 AND col3 IS NULL)
 8
 
 statement ok
-DROP VIEW view_1_tab2_977
+DROP VIEW IF EXISTS view_1_tab2_977 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_977
+DROP VIEW IF EXISTS view_2_tab2_977 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_977
+DROP VIEW IF EXISTS view_3_tab2_977 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16391,13 +16391,13 @@ SELECT pk FROM tab3 WHERE (col0 > 25 OR col1 < 78.91 AND col3 IS NULL)
 8
 
 statement ok
-DROP VIEW view_1_tab3_977
+DROP VIEW IF EXISTS view_1_tab3_977 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_977
+DROP VIEW IF EXISTS view_2_tab3_977 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_977
+DROP VIEW IF EXISTS view_3_tab3_977 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16515,13 +16515,13 @@ SELECT pk FROM tab4 WHERE (col0 > 25 OR col1 < 78.91 AND col3 IS NULL)
 8
 
 statement ok
-DROP VIEW view_1_tab4_977
+DROP VIEW IF EXISTS view_1_tab4_977 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_977
+DROP VIEW IF EXISTS view_2_tab4_977 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_977
+DROP VIEW IF EXISTS view_3_tab4_977 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16639,13 +16639,13 @@ SELECT pk FROM tab0 WHERE col1 BETWEEN 28.63 AND 29.96 OR col0 >= 21
 8
 
 statement ok
-DROP VIEW view_1_tab0_978
+DROP VIEW IF EXISTS view_1_tab0_978 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_978
+DROP VIEW IF EXISTS view_2_tab0_978 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_978
+DROP VIEW IF EXISTS view_3_tab0_978 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16763,13 +16763,13 @@ SELECT pk FROM tab1 WHERE col1 BETWEEN 28.63 AND 29.96 OR col0 >= 21
 8
 
 statement ok
-DROP VIEW view_1_tab1_978
+DROP VIEW IF EXISTS view_1_tab1_978 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_978
+DROP VIEW IF EXISTS view_2_tab1_978 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_978
+DROP VIEW IF EXISTS view_3_tab1_978 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16887,13 +16887,13 @@ SELECT pk FROM tab2 WHERE col1 BETWEEN 28.63 AND 29.96 OR col0 >= 21
 8
 
 statement ok
-DROP VIEW view_1_tab2_978
+DROP VIEW IF EXISTS view_1_tab2_978 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_978
+DROP VIEW IF EXISTS view_2_tab2_978 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_978
+DROP VIEW IF EXISTS view_3_tab2_978 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17011,13 +17011,13 @@ SELECT pk FROM tab3 WHERE col1 BETWEEN 28.63 AND 29.96 OR col0 >= 21
 8
 
 statement ok
-DROP VIEW view_1_tab3_978
+DROP VIEW IF EXISTS view_1_tab3_978 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_978
+DROP VIEW IF EXISTS view_2_tab3_978 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_978
+DROP VIEW IF EXISTS view_3_tab3_978 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17135,13 +17135,13 @@ SELECT pk FROM tab4 WHERE col1 BETWEEN 28.63 AND 29.96 OR col0 >= 21
 8
 
 statement ok
-DROP VIEW view_1_tab4_978
+DROP VIEW IF EXISTS view_1_tab4_978 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_978
+DROP VIEW IF EXISTS view_2_tab4_978 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_978
+DROP VIEW IF EXISTS view_3_tab4_978 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17260,13 +17260,13 @@ SELECT pk FROM tab0 WHERE (col3 > 40 AND col3 > 20 OR col0 >= 28) AND (col4 >= 3
 9
 
 statement ok
-DROP VIEW view_1_tab0_979
+DROP VIEW IF EXISTS view_1_tab0_979 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_979
+DROP VIEW IF EXISTS view_2_tab0_979 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_979
+DROP VIEW IF EXISTS view_3_tab0_979 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17385,13 +17385,13 @@ SELECT pk FROM tab1 WHERE (col3 > 40 AND col3 > 20 OR col0 >= 28) AND (col4 >= 3
 9
 
 statement ok
-DROP VIEW view_1_tab1_979
+DROP VIEW IF EXISTS view_1_tab1_979 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_979
+DROP VIEW IF EXISTS view_2_tab1_979 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_979
+DROP VIEW IF EXISTS view_3_tab1_979 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17510,13 +17510,13 @@ SELECT pk FROM tab2 WHERE (col3 > 40 AND col3 > 20 OR col0 >= 28) AND (col4 >= 3
 9
 
 statement ok
-DROP VIEW view_1_tab2_979
+DROP VIEW IF EXISTS view_1_tab2_979 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_979
+DROP VIEW IF EXISTS view_2_tab2_979 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_979
+DROP VIEW IF EXISTS view_3_tab2_979 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17635,13 +17635,13 @@ SELECT pk FROM tab3 WHERE (col3 > 40 AND col3 > 20 OR col0 >= 28) AND (col4 >= 3
 9
 
 statement ok
-DROP VIEW view_1_tab3_979
+DROP VIEW IF EXISTS view_1_tab3_979 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_979
+DROP VIEW IF EXISTS view_2_tab3_979 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_979
+DROP VIEW IF EXISTS view_3_tab3_979 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17760,13 +17760,13 @@ SELECT pk FROM tab4 WHERE (col3 > 40 AND col3 > 20 OR col0 >= 28) AND (col4 >= 3
 9
 
 statement ok
-DROP VIEW view_1_tab4_979
+DROP VIEW IF EXISTS view_1_tab4_979 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_979
+DROP VIEW IF EXISTS view_2_tab4_979 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_979
+DROP VIEW IF EXISTS view_3_tab4_979 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17869,13 +17869,13 @@ SELECT pk FROM tab0 WHERE col4 < 69.53 OR col3 IS NULL
 6
 
 statement ok
-DROP VIEW view_1_tab0_980
+DROP VIEW IF EXISTS view_1_tab0_980 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_980
+DROP VIEW IF EXISTS view_2_tab0_980 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_980
+DROP VIEW IF EXISTS view_3_tab0_980 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17978,13 +17978,13 @@ SELECT pk FROM tab1 WHERE col4 < 69.53 OR col3 IS NULL
 6
 
 statement ok
-DROP VIEW view_1_tab1_980
+DROP VIEW IF EXISTS view_1_tab1_980 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_980
+DROP VIEW IF EXISTS view_2_tab1_980 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_980
+DROP VIEW IF EXISTS view_3_tab1_980 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18087,13 +18087,13 @@ SELECT pk FROM tab2 WHERE col4 < 69.53 OR col3 IS NULL
 6
 
 statement ok
-DROP VIEW view_1_tab2_980
+DROP VIEW IF EXISTS view_1_tab2_980 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_980
+DROP VIEW IF EXISTS view_2_tab2_980 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_980
+DROP VIEW IF EXISTS view_3_tab2_980 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18196,13 +18196,13 @@ SELECT pk FROM tab3 WHERE col4 < 69.53 OR col3 IS NULL
 6
 
 statement ok
-DROP VIEW view_1_tab3_980
+DROP VIEW IF EXISTS view_1_tab3_980 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_980
+DROP VIEW IF EXISTS view_2_tab3_980 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_980
+DROP VIEW IF EXISTS view_3_tab3_980 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18305,13 +18305,13 @@ SELECT pk FROM tab4 WHERE col4 < 69.53 OR col3 IS NULL
 6
 
 statement ok
-DROP VIEW view_1_tab4_980
+DROP VIEW IF EXISTS view_1_tab4_980 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_980
+DROP VIEW IF EXISTS view_2_tab4_980 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_980
+DROP VIEW IF EXISTS view_3_tab4_980 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18414,13 +18414,13 @@ SELECT pk FROM tab0 WHERE col1 <= 24.39
 8
 
 statement ok
-DROP VIEW view_1_tab0_981
+DROP VIEW IF EXISTS view_1_tab0_981 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_981
+DROP VIEW IF EXISTS view_2_tab0_981 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_981
+DROP VIEW IF EXISTS view_3_tab0_981 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18523,13 +18523,13 @@ SELECT pk FROM tab1 WHERE col1 <= 24.39
 8
 
 statement ok
-DROP VIEW view_1_tab1_981
+DROP VIEW IF EXISTS view_1_tab1_981 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_981
+DROP VIEW IF EXISTS view_2_tab1_981 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_981
+DROP VIEW IF EXISTS view_3_tab1_981 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18632,13 +18632,13 @@ SELECT pk FROM tab2 WHERE col1 <= 24.39
 8
 
 statement ok
-DROP VIEW view_1_tab2_981
+DROP VIEW IF EXISTS view_1_tab2_981 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_981
+DROP VIEW IF EXISTS view_2_tab2_981 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_981
+DROP VIEW IF EXISTS view_3_tab2_981 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18741,13 +18741,13 @@ SELECT pk FROM tab3 WHERE col1 <= 24.39
 8
 
 statement ok
-DROP VIEW view_1_tab3_981
+DROP VIEW IF EXISTS view_1_tab3_981 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_981
+DROP VIEW IF EXISTS view_2_tab3_981 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_981
+DROP VIEW IF EXISTS view_3_tab3_981 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18850,13 +18850,13 @@ SELECT pk FROM tab4 WHERE col1 <= 24.39
 8
 
 statement ok
-DROP VIEW view_1_tab4_981
+DROP VIEW IF EXISTS view_1_tab4_981 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_981
+DROP VIEW IF EXISTS view_2_tab4_981 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_981
+DROP VIEW IF EXISTS view_3_tab4_981 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18959,13 +18959,13 @@ SELECT pk FROM tab0 WHERE col3 >= 50
 9
 
 statement ok
-DROP VIEW view_1_tab0_982
+DROP VIEW IF EXISTS view_1_tab0_982 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_982
+DROP VIEW IF EXISTS view_2_tab0_982 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_982
+DROP VIEW IF EXISTS view_3_tab0_982 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19068,13 +19068,13 @@ SELECT pk FROM tab1 WHERE col3 >= 50
 9
 
 statement ok
-DROP VIEW view_1_tab1_982
+DROP VIEW IF EXISTS view_1_tab1_982 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_982
+DROP VIEW IF EXISTS view_2_tab1_982 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_982
+DROP VIEW IF EXISTS view_3_tab1_982 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19177,13 +19177,13 @@ SELECT pk FROM tab2 WHERE col3 >= 50
 9
 
 statement ok
-DROP VIEW view_1_tab2_982
+DROP VIEW IF EXISTS view_1_tab2_982 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_982
+DROP VIEW IF EXISTS view_2_tab2_982 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_982
+DROP VIEW IF EXISTS view_3_tab2_982 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19286,13 +19286,13 @@ SELECT pk FROM tab3 WHERE col3 >= 50
 9
 
 statement ok
-DROP VIEW view_1_tab3_982
+DROP VIEW IF EXISTS view_1_tab3_982 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_982
+DROP VIEW IF EXISTS view_2_tab3_982 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_982
+DROP VIEW IF EXISTS view_3_tab3_982 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19395,13 +19395,13 @@ SELECT pk FROM tab4 WHERE col3 >= 50
 9
 
 statement ok
-DROP VIEW view_1_tab4_982
+DROP VIEW IF EXISTS view_1_tab4_982 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_982
+DROP VIEW IF EXISTS view_2_tab4_982 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_982
+DROP VIEW IF EXISTS view_3_tab4_982 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19508,13 +19508,13 @@ SELECT pk FROM tab0 WHERE (((((((col3 <= 34)))))))
 4
 
 statement ok
-DROP VIEW view_1_tab0_983
+DROP VIEW IF EXISTS view_1_tab0_983 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_983
+DROP VIEW IF EXISTS view_2_tab0_983 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_983
+DROP VIEW IF EXISTS view_3_tab0_983 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19621,13 +19621,13 @@ SELECT pk FROM tab1 WHERE (((((((col3 <= 34)))))))
 4
 
 statement ok
-DROP VIEW view_1_tab1_983
+DROP VIEW IF EXISTS view_1_tab1_983 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_983
+DROP VIEW IF EXISTS view_2_tab1_983 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_983
+DROP VIEW IF EXISTS view_3_tab1_983 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19734,13 +19734,13 @@ SELECT pk FROM tab2 WHERE (((((((col3 <= 34)))))))
 4
 
 statement ok
-DROP VIEW view_1_tab2_983
+DROP VIEW IF EXISTS view_1_tab2_983 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_983
+DROP VIEW IF EXISTS view_2_tab2_983 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_983
+DROP VIEW IF EXISTS view_3_tab2_983 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19847,13 +19847,13 @@ SELECT pk FROM tab3 WHERE (((((((col3 <= 34)))))))
 4
 
 statement ok
-DROP VIEW view_1_tab3_983
+DROP VIEW IF EXISTS view_1_tab3_983 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_983
+DROP VIEW IF EXISTS view_2_tab3_983 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_983
+DROP VIEW IF EXISTS view_3_tab3_983 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19960,13 +19960,13 @@ SELECT pk FROM tab4 WHERE (((((((col3 <= 34)))))))
 4
 
 statement ok
-DROP VIEW view_1_tab4_983
+DROP VIEW IF EXISTS view_1_tab4_983 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_983
+DROP VIEW IF EXISTS view_2_tab4_983 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_983
+DROP VIEW IF EXISTS view_3_tab4_983 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20066,13 +20066,13 @@ SELECT pk FROM tab0 WHERE (col0 > 42) AND ((col1 IS NULL)) OR ((((col3 > 72)))) 
 9
 
 statement ok
-DROP VIEW view_1_tab0_984
+DROP VIEW IF EXISTS view_1_tab0_984 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_984
+DROP VIEW IF EXISTS view_2_tab0_984 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_984
+DROP VIEW IF EXISTS view_3_tab0_984 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20172,13 +20172,13 @@ SELECT pk FROM tab1 WHERE (col0 > 42) AND ((col1 IS NULL)) OR ((((col3 > 72)))) 
 9
 
 statement ok
-DROP VIEW view_1_tab1_984
+DROP VIEW IF EXISTS view_1_tab1_984 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_984
+DROP VIEW IF EXISTS view_2_tab1_984 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_984
+DROP VIEW IF EXISTS view_3_tab1_984 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20278,13 +20278,13 @@ SELECT pk FROM tab2 WHERE (col0 > 42) AND ((col1 IS NULL)) OR ((((col3 > 72)))) 
 9
 
 statement ok
-DROP VIEW view_1_tab2_984
+DROP VIEW IF EXISTS view_1_tab2_984 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_984
+DROP VIEW IF EXISTS view_2_tab2_984 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_984
+DROP VIEW IF EXISTS view_3_tab2_984 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20384,13 +20384,13 @@ SELECT pk FROM tab3 WHERE (col0 > 42) AND ((col1 IS NULL)) OR ((((col3 > 72)))) 
 9
 
 statement ok
-DROP VIEW view_1_tab3_984
+DROP VIEW IF EXISTS view_1_tab3_984 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_984
+DROP VIEW IF EXISTS view_2_tab3_984 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_984
+DROP VIEW IF EXISTS view_3_tab3_984 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20490,13 +20490,13 @@ SELECT pk FROM tab4 WHERE (col0 > 42) AND ((col1 IS NULL)) OR ((((col3 > 72)))) 
 9
 
 statement ok
-DROP VIEW view_1_tab4_984
+DROP VIEW IF EXISTS view_1_tab4_984 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_984
+DROP VIEW IF EXISTS view_2_tab4_984 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_984
+DROP VIEW IF EXISTS view_3_tab4_984 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20599,13 +20599,13 @@ SELECT pk FROM tab0 WHERE col0 < 69
 9
 
 statement ok
-DROP VIEW view_1_tab0_985
+DROP VIEW IF EXISTS view_1_tab0_985 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_985
+DROP VIEW IF EXISTS view_2_tab0_985 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_985
+DROP VIEW IF EXISTS view_3_tab0_985 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20708,13 +20708,13 @@ SELECT pk FROM tab1 WHERE col0 < 69
 9
 
 statement ok
-DROP VIEW view_1_tab1_985
+DROP VIEW IF EXISTS view_1_tab1_985 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_985
+DROP VIEW IF EXISTS view_2_tab1_985 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_985
+DROP VIEW IF EXISTS view_3_tab1_985 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20817,13 +20817,13 @@ SELECT pk FROM tab2 WHERE col0 < 69
 9
 
 statement ok
-DROP VIEW view_1_tab2_985
+DROP VIEW IF EXISTS view_1_tab2_985 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_985
+DROP VIEW IF EXISTS view_2_tab2_985 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_985
+DROP VIEW IF EXISTS view_3_tab2_985 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20926,13 +20926,13 @@ SELECT pk FROM tab3 WHERE col0 < 69
 9
 
 statement ok
-DROP VIEW view_1_tab3_985
+DROP VIEW IF EXISTS view_1_tab3_985 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_985
+DROP VIEW IF EXISTS view_2_tab3_985 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_985
+DROP VIEW IF EXISTS view_3_tab3_985 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21035,13 +21035,13 @@ SELECT pk FROM tab4 WHERE col0 < 69
 9
 
 statement ok
-DROP VIEW view_1_tab4_985
+DROP VIEW IF EXISTS view_1_tab4_985 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_985
+DROP VIEW IF EXISTS view_2_tab4_985 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_985
+DROP VIEW IF EXISTS view_3_tab4_985 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21155,13 +21155,13 @@ SELECT pk FROM tab0 WHERE (col1 > 54.76)
 9
 
 statement ok
-DROP VIEW view_1_tab0_986
+DROP VIEW IF EXISTS view_1_tab0_986 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_986
+DROP VIEW IF EXISTS view_2_tab0_986 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_986
+DROP VIEW IF EXISTS view_3_tab0_986 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21275,13 +21275,13 @@ SELECT pk FROM tab1 WHERE (col1 > 54.76)
 9
 
 statement ok
-DROP VIEW view_1_tab1_986
+DROP VIEW IF EXISTS view_1_tab1_986 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_986
+DROP VIEW IF EXISTS view_2_tab1_986 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_986
+DROP VIEW IF EXISTS view_3_tab1_986 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21395,13 +21395,13 @@ SELECT pk FROM tab2 WHERE (col1 > 54.76)
 9
 
 statement ok
-DROP VIEW view_1_tab2_986
+DROP VIEW IF EXISTS view_1_tab2_986 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_986
+DROP VIEW IF EXISTS view_2_tab2_986 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_986
+DROP VIEW IF EXISTS view_3_tab2_986 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21515,13 +21515,13 @@ SELECT pk FROM tab3 WHERE (col1 > 54.76)
 9
 
 statement ok
-DROP VIEW view_1_tab3_986
+DROP VIEW IF EXISTS view_1_tab3_986 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_986
+DROP VIEW IF EXISTS view_2_tab3_986 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_986
+DROP VIEW IF EXISTS view_3_tab3_986 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21635,13 +21635,13 @@ SELECT pk FROM tab4 WHERE (col1 > 54.76)
 9
 
 statement ok
-DROP VIEW view_1_tab4_986
+DROP VIEW IF EXISTS view_1_tab4_986 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_986
+DROP VIEW IF EXISTS view_2_tab4_986 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_986
+DROP VIEW IF EXISTS view_3_tab4_986 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21748,13 +21748,13 @@ SELECT pk FROM tab0 WHERE col0 >= 75
 5
 
 statement ok
-DROP VIEW view_1_tab0_987
+DROP VIEW IF EXISTS view_1_tab0_987 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_987
+DROP VIEW IF EXISTS view_2_tab0_987 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_987
+DROP VIEW IF EXISTS view_3_tab0_987 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21861,13 +21861,13 @@ SELECT pk FROM tab1 WHERE col0 >= 75
 5
 
 statement ok
-DROP VIEW view_1_tab1_987
+DROP VIEW IF EXISTS view_1_tab1_987 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_987
+DROP VIEW IF EXISTS view_2_tab1_987 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_987
+DROP VIEW IF EXISTS view_3_tab1_987 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21974,13 +21974,13 @@ SELECT pk FROM tab2 WHERE col0 >= 75
 5
 
 statement ok
-DROP VIEW view_1_tab2_987
+DROP VIEW IF EXISTS view_1_tab2_987 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_987
+DROP VIEW IF EXISTS view_2_tab2_987 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_987
+DROP VIEW IF EXISTS view_3_tab2_987 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22087,13 +22087,13 @@ SELECT pk FROM tab3 WHERE col0 >= 75
 5
 
 statement ok
-DROP VIEW view_1_tab3_987
+DROP VIEW IF EXISTS view_1_tab3_987 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_987
+DROP VIEW IF EXISTS view_2_tab3_987 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_987
+DROP VIEW IF EXISTS view_3_tab3_987 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22200,13 +22200,13 @@ SELECT pk FROM tab4 WHERE col0 >= 75
 5
 
 statement ok
-DROP VIEW view_1_tab4_987
+DROP VIEW IF EXISTS view_1_tab4_987 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_987
+DROP VIEW IF EXISTS view_2_tab4_987 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_987
+DROP VIEW IF EXISTS view_3_tab4_987 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22299,13 +22299,13 @@ SELECT pk FROM tab0 WHERE ((((col0 < 82) AND ((col4 > 45.53 OR col4 > 29.60 OR c
 0
 
 statement ok
-DROP VIEW view_1_tab0_988
+DROP VIEW IF EXISTS view_1_tab0_988 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_988
+DROP VIEW IF EXISTS view_2_tab0_988 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_988
+DROP VIEW IF EXISTS view_3_tab0_988 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22398,13 +22398,13 @@ SELECT pk FROM tab1 WHERE ((((col0 < 82) AND ((col4 > 45.53 OR col4 > 29.60 OR c
 0
 
 statement ok
-DROP VIEW view_1_tab1_988
+DROP VIEW IF EXISTS view_1_tab1_988 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_988
+DROP VIEW IF EXISTS view_2_tab1_988 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_988
+DROP VIEW IF EXISTS view_3_tab1_988 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22497,13 +22497,13 @@ SELECT pk FROM tab2 WHERE ((((col0 < 82) AND ((col4 > 45.53 OR col4 > 29.60 OR c
 0
 
 statement ok
-DROP VIEW view_1_tab2_988
+DROP VIEW IF EXISTS view_1_tab2_988 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_988
+DROP VIEW IF EXISTS view_2_tab2_988 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_988
+DROP VIEW IF EXISTS view_3_tab2_988 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22596,13 +22596,13 @@ SELECT pk FROM tab3 WHERE ((((col0 < 82) AND ((col4 > 45.53 OR col4 > 29.60 OR c
 0
 
 statement ok
-DROP VIEW view_1_tab3_988
+DROP VIEW IF EXISTS view_1_tab3_988 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_988
+DROP VIEW IF EXISTS view_2_tab3_988 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_988
+DROP VIEW IF EXISTS view_3_tab3_988 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22695,13 +22695,13 @@ SELECT pk FROM tab4 WHERE ((((col0 < 82) AND ((col4 > 45.53 OR col4 > 29.60 OR c
 0
 
 statement ok
-DROP VIEW view_1_tab4_988
+DROP VIEW IF EXISTS view_1_tab4_988 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_988
+DROP VIEW IF EXISTS view_2_tab4_988 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_988
+DROP VIEW IF EXISTS view_3_tab4_988 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22820,13 +22820,13 @@ SELECT pk FROM tab0 WHERE col3 > 33
 9
 
 statement ok
-DROP VIEW view_1_tab0_989
+DROP VIEW IF EXISTS view_1_tab0_989 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_989
+DROP VIEW IF EXISTS view_2_tab0_989 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_989
+DROP VIEW IF EXISTS view_3_tab0_989 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22945,13 +22945,13 @@ SELECT pk FROM tab1 WHERE col3 > 33
 9
 
 statement ok
-DROP VIEW view_1_tab1_989
+DROP VIEW IF EXISTS view_1_tab1_989 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_989
+DROP VIEW IF EXISTS view_2_tab1_989 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_989
+DROP VIEW IF EXISTS view_3_tab1_989 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23070,13 +23070,13 @@ SELECT pk FROM tab2 WHERE col3 > 33
 9
 
 statement ok
-DROP VIEW view_1_tab2_989
+DROP VIEW IF EXISTS view_1_tab2_989 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_989
+DROP VIEW IF EXISTS view_2_tab2_989 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_989
+DROP VIEW IF EXISTS view_3_tab2_989 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23195,13 +23195,13 @@ SELECT pk FROM tab3 WHERE col3 > 33
 9
 
 statement ok
-DROP VIEW view_1_tab3_989
+DROP VIEW IF EXISTS view_1_tab3_989 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_989
+DROP VIEW IF EXISTS view_2_tab3_989 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_989
+DROP VIEW IF EXISTS view_3_tab3_989 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23320,13 +23320,13 @@ SELECT pk FROM tab4 WHERE col3 > 33
 9
 
 statement ok
-DROP VIEW view_1_tab4_989
+DROP VIEW IF EXISTS view_1_tab4_989 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_989
+DROP VIEW IF EXISTS view_2_tab4_989 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_989
+DROP VIEW IF EXISTS view_3_tab4_989 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23419,13 +23419,13 @@ SELECT pk FROM tab0 WHERE (col3 <= 3)
 3
 
 statement ok
-DROP VIEW view_1_tab0_990
+DROP VIEW IF EXISTS view_1_tab0_990 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_990
+DROP VIEW IF EXISTS view_2_tab0_990 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_990
+DROP VIEW IF EXISTS view_3_tab0_990 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23518,13 +23518,13 @@ SELECT pk FROM tab1 WHERE (col3 <= 3)
 3
 
 statement ok
-DROP VIEW view_1_tab1_990
+DROP VIEW IF EXISTS view_1_tab1_990 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_990
+DROP VIEW IF EXISTS view_2_tab1_990 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_990
+DROP VIEW IF EXISTS view_3_tab1_990 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23617,13 +23617,13 @@ SELECT pk FROM tab2 WHERE (col3 <= 3)
 3
 
 statement ok
-DROP VIEW view_1_tab2_990
+DROP VIEW IF EXISTS view_1_tab2_990 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_990
+DROP VIEW IF EXISTS view_2_tab2_990 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_990
+DROP VIEW IF EXISTS view_3_tab2_990 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23716,13 +23716,13 @@ SELECT pk FROM tab3 WHERE (col3 <= 3)
 3
 
 statement ok
-DROP VIEW view_1_tab3_990
+DROP VIEW IF EXISTS view_1_tab3_990 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_990
+DROP VIEW IF EXISTS view_2_tab3_990 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_990
+DROP VIEW IF EXISTS view_3_tab3_990 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23815,13 +23815,13 @@ SELECT pk FROM tab4 WHERE (col3 <= 3)
 3
 
 statement ok
-DROP VIEW view_1_tab4_990
+DROP VIEW IF EXISTS view_1_tab4_990 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_990
+DROP VIEW IF EXISTS view_2_tab4_990 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_990
+DROP VIEW IF EXISTS view_3_tab4_990 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23914,13 +23914,13 @@ SELECT pk FROM tab0 WHERE (col0 < 4 OR col0 IN (2,19,4,56))
 9
 
 statement ok
-DROP VIEW view_1_tab0_991
+DROP VIEW IF EXISTS view_1_tab0_991 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_991
+DROP VIEW IF EXISTS view_2_tab0_991 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_991
+DROP VIEW IF EXISTS view_3_tab0_991 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24013,13 +24013,13 @@ SELECT pk FROM tab1 WHERE (col0 < 4 OR col0 IN (2,19,4,56))
 9
 
 statement ok
-DROP VIEW view_1_tab1_991
+DROP VIEW IF EXISTS view_1_tab1_991 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_991
+DROP VIEW IF EXISTS view_2_tab1_991 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_991
+DROP VIEW IF EXISTS view_3_tab1_991 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24112,13 +24112,13 @@ SELECT pk FROM tab2 WHERE (col0 < 4 OR col0 IN (2,19,4,56))
 9
 
 statement ok
-DROP VIEW view_1_tab2_991
+DROP VIEW IF EXISTS view_1_tab2_991 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_991
+DROP VIEW IF EXISTS view_2_tab2_991 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_991
+DROP VIEW IF EXISTS view_3_tab2_991 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24211,13 +24211,13 @@ SELECT pk FROM tab3 WHERE (col0 < 4 OR col0 IN (2,19,4,56))
 9
 
 statement ok
-DROP VIEW view_1_tab3_991
+DROP VIEW IF EXISTS view_1_tab3_991 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_991
+DROP VIEW IF EXISTS view_2_tab3_991 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_991
+DROP VIEW IF EXISTS view_3_tab3_991 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24310,13 +24310,13 @@ SELECT pk FROM tab4 WHERE (col0 < 4 OR col0 IN (2,19,4,56))
 9
 
 statement ok
-DROP VIEW view_1_tab4_991
+DROP VIEW IF EXISTS view_1_tab4_991 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_991
+DROP VIEW IF EXISTS view_2_tab4_991 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_991
+DROP VIEW IF EXISTS view_3_tab4_991 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24416,13 +24416,13 @@ SELECT pk FROM tab0 WHERE col3 <= 25
 3
 
 statement ok
-DROP VIEW view_1_tab0_993
+DROP VIEW IF EXISTS view_1_tab0_993 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_993
+DROP VIEW IF EXISTS view_2_tab0_993 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_993
+DROP VIEW IF EXISTS view_3_tab0_993 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24522,13 +24522,13 @@ SELECT pk FROM tab1 WHERE col3 <= 25
 3
 
 statement ok
-DROP VIEW view_1_tab1_993
+DROP VIEW IF EXISTS view_1_tab1_993 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_993
+DROP VIEW IF EXISTS view_2_tab1_993 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_993
+DROP VIEW IF EXISTS view_3_tab1_993 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24628,13 +24628,13 @@ SELECT pk FROM tab2 WHERE col3 <= 25
 3
 
 statement ok
-DROP VIEW view_1_tab2_993
+DROP VIEW IF EXISTS view_1_tab2_993 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_993
+DROP VIEW IF EXISTS view_2_tab2_993 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_993
+DROP VIEW IF EXISTS view_3_tab2_993 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24734,13 +24734,13 @@ SELECT pk FROM tab3 WHERE col3 <= 25
 3
 
 statement ok
-DROP VIEW view_1_tab3_993
+DROP VIEW IF EXISTS view_1_tab3_993 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_993
+DROP VIEW IF EXISTS view_2_tab3_993 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_993
+DROP VIEW IF EXISTS view_3_tab3_993 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24840,13 +24840,13 @@ SELECT pk FROM tab4 WHERE col3 <= 25
 3
 
 statement ok
-DROP VIEW view_1_tab4_993
+DROP VIEW IF EXISTS view_1_tab4_993 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_993
+DROP VIEW IF EXISTS view_2_tab4_993 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_993
+DROP VIEW IF EXISTS view_3_tab4_993 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24965,13 +24965,13 @@ SELECT pk FROM tab0 WHERE ((col4 >= 49.48 AND col3 < 75))
 9
 
 statement ok
-DROP VIEW view_1_tab0_994
+DROP VIEW IF EXISTS view_1_tab0_994 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_994
+DROP VIEW IF EXISTS view_2_tab0_994 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_994
+DROP VIEW IF EXISTS view_3_tab0_994 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25090,13 +25090,13 @@ SELECT pk FROM tab1 WHERE ((col4 >= 49.48 AND col3 < 75))
 9
 
 statement ok
-DROP VIEW view_1_tab1_994
+DROP VIEW IF EXISTS view_1_tab1_994 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_994
+DROP VIEW IF EXISTS view_2_tab1_994 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_994
+DROP VIEW IF EXISTS view_3_tab1_994 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25215,13 +25215,13 @@ SELECT pk FROM tab2 WHERE ((col4 >= 49.48 AND col3 < 75))
 9
 
 statement ok
-DROP VIEW view_1_tab2_994
+DROP VIEW IF EXISTS view_1_tab2_994 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_994
+DROP VIEW IF EXISTS view_2_tab2_994 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_994
+DROP VIEW IF EXISTS view_3_tab2_994 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25340,13 +25340,13 @@ SELECT pk FROM tab3 WHERE ((col4 >= 49.48 AND col3 < 75))
 9
 
 statement ok
-DROP VIEW view_1_tab3_994
+DROP VIEW IF EXISTS view_1_tab3_994 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_994
+DROP VIEW IF EXISTS view_2_tab3_994 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_994
+DROP VIEW IF EXISTS view_3_tab3_994 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25465,13 +25465,13 @@ SELECT pk FROM tab4 WHERE ((col4 >= 49.48 AND col3 < 75))
 9
 
 statement ok
-DROP VIEW view_1_tab4_994
+DROP VIEW IF EXISTS view_1_tab4_994 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_994
+DROP VIEW IF EXISTS view_2_tab4_994 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_994
+DROP VIEW IF EXISTS view_3_tab4_994 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25564,13 +25564,13 @@ SELECT pk FROM tab0 WHERE (col0 > 4 OR col3 >= 69 AND col4 = 33.10)
 9 values hashing to 6ba058c53c08bb0173bcc14ce59aeeff
 
 statement ok
-DROP VIEW view_1_tab0_995
+DROP VIEW IF EXISTS view_1_tab0_995 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_995
+DROP VIEW IF EXISTS view_2_tab0_995 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_995
+DROP VIEW IF EXISTS view_3_tab0_995 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25663,13 +25663,13 @@ SELECT pk FROM tab1 WHERE (col0 > 4 OR col3 >= 69 AND col4 = 33.10)
 9 values hashing to 6ba058c53c08bb0173bcc14ce59aeeff
 
 statement ok
-DROP VIEW view_1_tab1_995
+DROP VIEW IF EXISTS view_1_tab1_995 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_995
+DROP VIEW IF EXISTS view_2_tab1_995 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_995
+DROP VIEW IF EXISTS view_3_tab1_995 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25762,13 +25762,13 @@ SELECT pk FROM tab2 WHERE (col0 > 4 OR col3 >= 69 AND col4 = 33.10)
 9 values hashing to 6ba058c53c08bb0173bcc14ce59aeeff
 
 statement ok
-DROP VIEW view_1_tab2_995
+DROP VIEW IF EXISTS view_1_tab2_995 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_995
+DROP VIEW IF EXISTS view_2_tab2_995 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_995
+DROP VIEW IF EXISTS view_3_tab2_995 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25861,13 +25861,13 @@ SELECT pk FROM tab3 WHERE (col0 > 4 OR col3 >= 69 AND col4 = 33.10)
 9 values hashing to 6ba058c53c08bb0173bcc14ce59aeeff
 
 statement ok
-DROP VIEW view_1_tab3_995
+DROP VIEW IF EXISTS view_1_tab3_995 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_995
+DROP VIEW IF EXISTS view_2_tab3_995 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_995
+DROP VIEW IF EXISTS view_3_tab3_995 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25960,13 +25960,13 @@ SELECT pk FROM tab4 WHERE (col0 > 4 OR col3 >= 69 AND col4 = 33.10)
 9 values hashing to 6ba058c53c08bb0173bcc14ce59aeeff
 
 statement ok
-DROP VIEW view_1_tab4_995
+DROP VIEW IF EXISTS view_1_tab4_995 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_995
+DROP VIEW IF EXISTS view_2_tab4_995 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_995
+DROP VIEW IF EXISTS view_3_tab4_995 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26069,13 +26069,13 @@ SELECT pk FROM tab0 WHERE col1 > 33.28
 9
 
 statement ok
-DROP VIEW view_1_tab0_996
+DROP VIEW IF EXISTS view_1_tab0_996 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_996
+DROP VIEW IF EXISTS view_2_tab0_996 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_996
+DROP VIEW IF EXISTS view_3_tab0_996 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26178,13 +26178,13 @@ SELECT pk FROM tab1 WHERE col1 > 33.28
 9
 
 statement ok
-DROP VIEW view_1_tab1_996
+DROP VIEW IF EXISTS view_1_tab1_996 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_996
+DROP VIEW IF EXISTS view_2_tab1_996 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_996
+DROP VIEW IF EXISTS view_3_tab1_996 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26287,13 +26287,13 @@ SELECT pk FROM tab2 WHERE col1 > 33.28
 9
 
 statement ok
-DROP VIEW view_1_tab2_996
+DROP VIEW IF EXISTS view_1_tab2_996 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_996
+DROP VIEW IF EXISTS view_2_tab2_996 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_996
+DROP VIEW IF EXISTS view_3_tab2_996 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26396,13 +26396,13 @@ SELECT pk FROM tab3 WHERE col1 > 33.28
 9
 
 statement ok
-DROP VIEW view_1_tab3_996
+DROP VIEW IF EXISTS view_1_tab3_996 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_996
+DROP VIEW IF EXISTS view_2_tab3_996 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_996
+DROP VIEW IF EXISTS view_3_tab3_996 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26505,13 +26505,13 @@ SELECT pk FROM tab4 WHERE col1 > 33.28
 9
 
 statement ok
-DROP VIEW view_1_tab4_996
+DROP VIEW IF EXISTS view_1_tab4_996 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_996
+DROP VIEW IF EXISTS view_2_tab4_996 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_996
+DROP VIEW IF EXISTS view_3_tab4_996 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26611,13 +26611,13 @@ SELECT pk FROM tab0 WHERE col0 = 52 OR col3 >= 30 AND col1 < 12.24 AND col3 > 61
 6
 
 statement ok
-DROP VIEW view_1_tab0_997
+DROP VIEW IF EXISTS view_1_tab0_997 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_997
+DROP VIEW IF EXISTS view_2_tab0_997 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_997
+DROP VIEW IF EXISTS view_3_tab0_997 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26717,13 +26717,13 @@ SELECT pk FROM tab1 WHERE col0 = 52 OR col3 >= 30 AND col1 < 12.24 AND col3 > 61
 6
 
 statement ok
-DROP VIEW view_1_tab1_997
+DROP VIEW IF EXISTS view_1_tab1_997 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_997
+DROP VIEW IF EXISTS view_2_tab1_997 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_997
+DROP VIEW IF EXISTS view_3_tab1_997 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26823,13 +26823,13 @@ SELECT pk FROM tab2 WHERE col0 = 52 OR col3 >= 30 AND col1 < 12.24 AND col3 > 61
 6
 
 statement ok
-DROP VIEW view_1_tab2_997
+DROP VIEW IF EXISTS view_1_tab2_997 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_997
+DROP VIEW IF EXISTS view_2_tab2_997 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_997
+DROP VIEW IF EXISTS view_3_tab2_997 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26929,13 +26929,13 @@ SELECT pk FROM tab3 WHERE col0 = 52 OR col3 >= 30 AND col1 < 12.24 AND col3 > 61
 6
 
 statement ok
-DROP VIEW view_1_tab3_997
+DROP VIEW IF EXISTS view_1_tab3_997 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_997
+DROP VIEW IF EXISTS view_2_tab3_997 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_997
+DROP VIEW IF EXISTS view_3_tab3_997 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27035,13 +27035,13 @@ SELECT pk FROM tab4 WHERE col0 = 52 OR col3 >= 30 AND col1 < 12.24 AND col3 > 61
 6
 
 statement ok
-DROP VIEW view_1_tab4_997
+DROP VIEW IF EXISTS view_1_tab4_997 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_997
+DROP VIEW IF EXISTS view_2_tab4_997 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_997
+DROP VIEW IF EXISTS view_3_tab4_997 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27127,13 +27127,13 @@ SELECT pk FROM tab0 WHERE (col4 <= 32.24) AND col3 >= 16 AND col3 IN (35,45,28,3
 ----
 
 statement ok
-DROP VIEW view_1_tab0_998
+DROP VIEW IF EXISTS view_1_tab0_998 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_998
+DROP VIEW IF EXISTS view_2_tab0_998 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_998
+DROP VIEW IF EXISTS view_3_tab0_998 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27219,13 +27219,13 @@ SELECT pk FROM tab1 WHERE (col4 <= 32.24) AND col3 >= 16 AND col3 IN (35,45,28,3
 ----
 
 statement ok
-DROP VIEW view_1_tab1_998
+DROP VIEW IF EXISTS view_1_tab1_998 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_998
+DROP VIEW IF EXISTS view_2_tab1_998 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_998
+DROP VIEW IF EXISTS view_3_tab1_998 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27311,13 +27311,13 @@ SELECT pk FROM tab2 WHERE (col4 <= 32.24) AND col3 >= 16 AND col3 IN (35,45,28,3
 ----
 
 statement ok
-DROP VIEW view_1_tab2_998
+DROP VIEW IF EXISTS view_1_tab2_998 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_998
+DROP VIEW IF EXISTS view_2_tab2_998 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_998
+DROP VIEW IF EXISTS view_3_tab2_998 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27403,13 +27403,13 @@ SELECT pk FROM tab3 WHERE (col4 <= 32.24) AND col3 >= 16 AND col3 IN (35,45,28,3
 ----
 
 statement ok
-DROP VIEW view_1_tab3_998
+DROP VIEW IF EXISTS view_1_tab3_998 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_998
+DROP VIEW IF EXISTS view_2_tab3_998 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_998
+DROP VIEW IF EXISTS view_3_tab3_998 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27495,13 +27495,13 @@ SELECT pk FROM tab4 WHERE (col4 <= 32.24) AND col3 >= 16 AND col3 IN (35,45,28,3
 ----
 
 statement ok
-DROP VIEW view_1_tab4_998
+DROP VIEW IF EXISTS view_1_tab4_998 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_998
+DROP VIEW IF EXISTS view_2_tab4_998 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_998
+DROP VIEW IF EXISTS view_3_tab4_998 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27620,13 +27620,13 @@ SELECT pk FROM tab0 WHERE col3 > 55 OR ((col0 >= 0 AND ((col3 <= 33 AND (col3 > 
 9
 
 statement ok
-DROP VIEW view_1_tab0_999
+DROP VIEW IF EXISTS view_1_tab0_999 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_999
+DROP VIEW IF EXISTS view_2_tab0_999 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_999
+DROP VIEW IF EXISTS view_3_tab0_999 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27745,13 +27745,13 @@ SELECT pk FROM tab1 WHERE col3 > 55 OR ((col0 >= 0 AND ((col3 <= 33 AND (col3 > 
 9
 
 statement ok
-DROP VIEW view_1_tab1_999
+DROP VIEW IF EXISTS view_1_tab1_999 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_999
+DROP VIEW IF EXISTS view_2_tab1_999 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_999
+DROP VIEW IF EXISTS view_3_tab1_999 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27870,13 +27870,13 @@ SELECT pk FROM tab2 WHERE col3 > 55 OR ((col0 >= 0 AND ((col3 <= 33 AND (col3 > 
 9
 
 statement ok
-DROP VIEW view_1_tab2_999
+DROP VIEW IF EXISTS view_1_tab2_999 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_999
+DROP VIEW IF EXISTS view_2_tab2_999 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_999
+DROP VIEW IF EXISTS view_3_tab2_999 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27995,13 +27995,13 @@ SELECT pk FROM tab3 WHERE col3 > 55 OR ((col0 >= 0 AND ((col3 <= 33 AND (col3 > 
 9
 
 statement ok
-DROP VIEW view_1_tab3_999
+DROP VIEW IF EXISTS view_1_tab3_999 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_999
+DROP VIEW IF EXISTS view_2_tab3_999 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_999
+DROP VIEW IF EXISTS view_3_tab3_999 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28120,13 +28120,13 @@ SELECT pk FROM tab4 WHERE col3 > 55 OR ((col0 >= 0 AND ((col3 <= 33 AND (col3 > 
 9
 
 statement ok
-DROP VIEW view_1_tab4_999
+DROP VIEW IF EXISTS view_1_tab4_999 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_999
+DROP VIEW IF EXISTS view_2_tab4_999 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_999
+DROP VIEW IF EXISTS view_3_tab4_999 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28215,13 +28215,13 @@ SELECT pk FROM tab0 WHERE ((col3 > 0 OR col0 IS NULL))
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_1000
+DROP VIEW IF EXISTS view_1_tab0_1000 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1000
+DROP VIEW IF EXISTS view_2_tab0_1000 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1000
+DROP VIEW IF EXISTS view_3_tab0_1000 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28310,13 +28310,13 @@ SELECT pk FROM tab1 WHERE ((col3 > 0 OR col0 IS NULL))
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_1000
+DROP VIEW IF EXISTS view_1_tab1_1000 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1000
+DROP VIEW IF EXISTS view_2_tab1_1000 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1000
+DROP VIEW IF EXISTS view_3_tab1_1000 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28405,13 +28405,13 @@ SELECT pk FROM tab2 WHERE ((col3 > 0 OR col0 IS NULL))
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_1000
+DROP VIEW IF EXISTS view_1_tab2_1000 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1000
+DROP VIEW IF EXISTS view_2_tab2_1000 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1000
+DROP VIEW IF EXISTS view_3_tab2_1000 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28500,13 +28500,13 @@ SELECT pk FROM tab3 WHERE ((col3 > 0 OR col0 IS NULL))
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_1000
+DROP VIEW IF EXISTS view_1_tab3_1000 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1000
+DROP VIEW IF EXISTS view_2_tab3_1000 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1000
+DROP VIEW IF EXISTS view_3_tab3_1000 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28595,13 +28595,13 @@ SELECT pk FROM tab4 WHERE ((col3 > 0 OR col0 IS NULL))
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_1000
+DROP VIEW IF EXISTS view_1_tab4_1000 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1000
+DROP VIEW IF EXISTS view_2_tab4_1000 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1000
+DROP VIEW IF EXISTS view_3_tab4_1000 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28694,13 +28694,13 @@ SELECT pk FROM tab0 WHERE (col3 IS NULL OR (col4 <= 97.38 AND col4 >= 37.35 AND 
 9
 
 statement ok
-DROP VIEW view_1_tab0_1001
+DROP VIEW IF EXISTS view_1_tab0_1001 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1001
+DROP VIEW IF EXISTS view_2_tab0_1001 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1001
+DROP VIEW IF EXISTS view_3_tab0_1001 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28793,13 +28793,13 @@ SELECT pk FROM tab1 WHERE (col3 IS NULL OR (col4 <= 97.38 AND col4 >= 37.35 AND 
 9
 
 statement ok
-DROP VIEW view_1_tab1_1001
+DROP VIEW IF EXISTS view_1_tab1_1001 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1001
+DROP VIEW IF EXISTS view_2_tab1_1001 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1001
+DROP VIEW IF EXISTS view_3_tab1_1001 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28892,13 +28892,13 @@ SELECT pk FROM tab2 WHERE (col3 IS NULL OR (col4 <= 97.38 AND col4 >= 37.35 AND 
 9
 
 statement ok
-DROP VIEW view_1_tab2_1001
+DROP VIEW IF EXISTS view_1_tab2_1001 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1001
+DROP VIEW IF EXISTS view_2_tab2_1001 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1001
+DROP VIEW IF EXISTS view_3_tab2_1001 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28991,13 +28991,13 @@ SELECT pk FROM tab3 WHERE (col3 IS NULL OR (col4 <= 97.38 AND col4 >= 37.35 AND 
 9
 
 statement ok
-DROP VIEW view_1_tab3_1001
+DROP VIEW IF EXISTS view_1_tab3_1001 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1001
+DROP VIEW IF EXISTS view_2_tab3_1001 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1001
+DROP VIEW IF EXISTS view_3_tab3_1001 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29090,13 +29090,13 @@ SELECT pk FROM tab4 WHERE (col3 IS NULL OR (col4 <= 97.38 AND col4 >= 37.35 AND 
 9
 
 statement ok
-DROP VIEW view_1_tab4_1001
+DROP VIEW IF EXISTS view_1_tab4_1001 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1001
+DROP VIEW IF EXISTS view_2_tab4_1001 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1001
+DROP VIEW IF EXISTS view_3_tab4_1001 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29182,13 +29182,13 @@ SELECT pk FROM tab0 WHERE ((col0 IN (SELECT col3 FROM tab0 WHERE (col0 IS NULL O
 ----
 
 statement ok
-DROP VIEW view_1_tab0_1002
+DROP VIEW IF EXISTS view_1_tab0_1002 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1002
+DROP VIEW IF EXISTS view_2_tab0_1002 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1002
+DROP VIEW IF EXISTS view_3_tab0_1002 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29274,13 +29274,13 @@ SELECT pk FROM tab1 WHERE ((col0 IN (SELECT col3 FROM tab1 WHERE (col0 IS NULL O
 ----
 
 statement ok
-DROP VIEW view_1_tab1_1002
+DROP VIEW IF EXISTS view_1_tab1_1002 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1002
+DROP VIEW IF EXISTS view_2_tab1_1002 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1002
+DROP VIEW IF EXISTS view_3_tab1_1002 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29366,13 +29366,13 @@ SELECT pk FROM tab2 WHERE ((col0 IN (SELECT col3 FROM tab2 WHERE (col0 IS NULL O
 ----
 
 statement ok
-DROP VIEW view_1_tab2_1002
+DROP VIEW IF EXISTS view_1_tab2_1002 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1002
+DROP VIEW IF EXISTS view_2_tab2_1002 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1002
+DROP VIEW IF EXISTS view_3_tab2_1002 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29458,13 +29458,13 @@ SELECT pk FROM tab3 WHERE ((col0 IN (SELECT col3 FROM tab3 WHERE (col0 IS NULL O
 ----
 
 statement ok
-DROP VIEW view_1_tab3_1002
+DROP VIEW IF EXISTS view_1_tab3_1002 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1002
+DROP VIEW IF EXISTS view_2_tab3_1002 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1002
+DROP VIEW IF EXISTS view_3_tab3_1002 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29550,13 +29550,13 @@ SELECT pk FROM tab4 WHERE ((col0 IN (SELECT col3 FROM tab4 WHERE (col0 IS NULL O
 ----
 
 statement ok
-DROP VIEW view_1_tab4_1002
+DROP VIEW IF EXISTS view_1_tab4_1002 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1002
+DROP VIEW IF EXISTS view_2_tab4_1002 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1002
+DROP VIEW IF EXISTS view_3_tab4_1002 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29670,13 +29670,13 @@ SELECT pk FROM tab0 WHERE ((col4 = 20.77) OR col1 >= 58.59) AND col4 > 9.52 AND 
 9
 
 statement ok
-DROP VIEW view_1_tab0_1003
+DROP VIEW IF EXISTS view_1_tab0_1003 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1003
+DROP VIEW IF EXISTS view_2_tab0_1003 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1003
+DROP VIEW IF EXISTS view_3_tab0_1003 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29790,13 +29790,13 @@ SELECT pk FROM tab1 WHERE ((col4 = 20.77) OR col1 >= 58.59) AND col4 > 9.52 AND 
 9
 
 statement ok
-DROP VIEW view_1_tab1_1003
+DROP VIEW IF EXISTS view_1_tab1_1003 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1003
+DROP VIEW IF EXISTS view_2_tab1_1003 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1003
+DROP VIEW IF EXISTS view_3_tab1_1003 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29910,13 +29910,13 @@ SELECT pk FROM tab2 WHERE ((col4 = 20.77) OR col1 >= 58.59) AND col4 > 9.52 AND 
 9
 
 statement ok
-DROP VIEW view_1_tab2_1003
+DROP VIEW IF EXISTS view_1_tab2_1003 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1003
+DROP VIEW IF EXISTS view_2_tab2_1003 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1003
+DROP VIEW IF EXISTS view_3_tab2_1003 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30030,13 +30030,13 @@ SELECT pk FROM tab3 WHERE ((col4 = 20.77) OR col1 >= 58.59) AND col4 > 9.52 AND 
 9
 
 statement ok
-DROP VIEW view_1_tab3_1003
+DROP VIEW IF EXISTS view_1_tab3_1003 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1003
+DROP VIEW IF EXISTS view_2_tab3_1003 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1003
+DROP VIEW IF EXISTS view_3_tab3_1003 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30150,13 +30150,13 @@ SELECT pk FROM tab4 WHERE ((col4 = 20.77) OR col1 >= 58.59) AND col4 > 9.52 AND 
 9
 
 statement ok
-DROP VIEW view_1_tab4_1003
+DROP VIEW IF EXISTS view_1_tab4_1003 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1003
+DROP VIEW IF EXISTS view_2_tab4_1003 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1003
+DROP VIEW IF EXISTS view_3_tab4_1003 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30274,13 +30274,13 @@ SELECT pk FROM tab0 WHERE (col0 BETWEEN 13 AND 71 AND col0 BETWEEN 65 AND 39 OR 
 9
 
 statement ok
-DROP VIEW view_1_tab0_1004
+DROP VIEW IF EXISTS view_1_tab0_1004 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1004
+DROP VIEW IF EXISTS view_2_tab0_1004 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1004
+DROP VIEW IF EXISTS view_3_tab0_1004 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30398,13 +30398,13 @@ SELECT pk FROM tab1 WHERE (col0 BETWEEN 13 AND 71 AND col0 BETWEEN 65 AND 39 OR 
 9
 
 statement ok
-DROP VIEW view_1_tab1_1004
+DROP VIEW IF EXISTS view_1_tab1_1004 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1004
+DROP VIEW IF EXISTS view_2_tab1_1004 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1004
+DROP VIEW IF EXISTS view_3_tab1_1004 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30522,13 +30522,13 @@ SELECT pk FROM tab2 WHERE (col0 BETWEEN 13 AND 71 AND col0 BETWEEN 65 AND 39 OR 
 9
 
 statement ok
-DROP VIEW view_1_tab2_1004
+DROP VIEW IF EXISTS view_1_tab2_1004 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1004
+DROP VIEW IF EXISTS view_2_tab2_1004 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1004
+DROP VIEW IF EXISTS view_3_tab2_1004 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30646,13 +30646,13 @@ SELECT pk FROM tab3 WHERE (col0 BETWEEN 13 AND 71 AND col0 BETWEEN 65 AND 39 OR 
 9
 
 statement ok
-DROP VIEW view_1_tab3_1004
+DROP VIEW IF EXISTS view_1_tab3_1004 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1004
+DROP VIEW IF EXISTS view_2_tab3_1004 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1004
+DROP VIEW IF EXISTS view_3_tab3_1004 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30770,13 +30770,13 @@ SELECT pk FROM tab4 WHERE (col0 BETWEEN 13 AND 71 AND col0 BETWEEN 65 AND 39 OR 
 9
 
 statement ok
-DROP VIEW view_1_tab4_1004
+DROP VIEW IF EXISTS view_1_tab4_1004 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1004
+DROP VIEW IF EXISTS view_2_tab4_1004 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1004
+DROP VIEW IF EXISTS view_3_tab4_1004 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30869,13 +30869,13 @@ SELECT pk FROM tab0 WHERE col0 IN (98,75,73)
 2
 
 statement ok
-DROP VIEW view_1_tab0_1005
+DROP VIEW IF EXISTS view_1_tab0_1005 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1005
+DROP VIEW IF EXISTS view_2_tab0_1005 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1005
+DROP VIEW IF EXISTS view_3_tab0_1005 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30968,13 +30968,13 @@ SELECT pk FROM tab1 WHERE col0 IN (98,75,73)
 2
 
 statement ok
-DROP VIEW view_1_tab1_1005
+DROP VIEW IF EXISTS view_1_tab1_1005 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1005
+DROP VIEW IF EXISTS view_2_tab1_1005 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1005
+DROP VIEW IF EXISTS view_3_tab1_1005 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31067,13 +31067,13 @@ SELECT pk FROM tab2 WHERE col0 IN (98,75,73)
 2
 
 statement ok
-DROP VIEW view_1_tab2_1005
+DROP VIEW IF EXISTS view_1_tab2_1005 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1005
+DROP VIEW IF EXISTS view_2_tab2_1005 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1005
+DROP VIEW IF EXISTS view_3_tab2_1005 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31166,13 +31166,13 @@ SELECT pk FROM tab3 WHERE col0 IN (98,75,73)
 2
 
 statement ok
-DROP VIEW view_1_tab3_1005
+DROP VIEW IF EXISTS view_1_tab3_1005 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1005
+DROP VIEW IF EXISTS view_2_tab3_1005 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1005
+DROP VIEW IF EXISTS view_3_tab3_1005 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31265,13 +31265,13 @@ SELECT pk FROM tab4 WHERE col0 IN (98,75,73)
 2
 
 statement ok
-DROP VIEW view_1_tab4_1005
+DROP VIEW IF EXISTS view_1_tab4_1005 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1005
+DROP VIEW IF EXISTS view_2_tab4_1005 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1005
+DROP VIEW IF EXISTS view_3_tab4_1005 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31357,13 +31357,13 @@ SELECT pk FROM tab0 WHERE col4 IN (90.48,34.88,77.27,13.89,23.92,22.77) AND col0
 ----
 
 statement ok
-DROP VIEW view_1_tab0_1006
+DROP VIEW IF EXISTS view_1_tab0_1006 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1006
+DROP VIEW IF EXISTS view_2_tab0_1006 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1006
+DROP VIEW IF EXISTS view_3_tab0_1006 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31449,13 +31449,13 @@ SELECT pk FROM tab1 WHERE col4 IN (90.48,34.88,77.27,13.89,23.92,22.77) AND col0
 ----
 
 statement ok
-DROP VIEW view_1_tab1_1006
+DROP VIEW IF EXISTS view_1_tab1_1006 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1006
+DROP VIEW IF EXISTS view_2_tab1_1006 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1006
+DROP VIEW IF EXISTS view_3_tab1_1006 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31541,13 +31541,13 @@ SELECT pk FROM tab2 WHERE col4 IN (90.48,34.88,77.27,13.89,23.92,22.77) AND col0
 ----
 
 statement ok
-DROP VIEW view_1_tab2_1006
+DROP VIEW IF EXISTS view_1_tab2_1006 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1006
+DROP VIEW IF EXISTS view_2_tab2_1006 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1006
+DROP VIEW IF EXISTS view_3_tab2_1006 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31633,13 +31633,13 @@ SELECT pk FROM tab3 WHERE col4 IN (90.48,34.88,77.27,13.89,23.92,22.77) AND col0
 ----
 
 statement ok
-DROP VIEW view_1_tab3_1006
+DROP VIEW IF EXISTS view_1_tab3_1006 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1006
+DROP VIEW IF EXISTS view_2_tab3_1006 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1006
+DROP VIEW IF EXISTS view_3_tab3_1006 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31725,13 +31725,13 @@ SELECT pk FROM tab4 WHERE col4 IN (90.48,34.88,77.27,13.89,23.92,22.77) AND col0
 ----
 
 statement ok
-DROP VIEW view_1_tab4_1006
+DROP VIEW IF EXISTS view_1_tab4_1006 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1006
+DROP VIEW IF EXISTS view_2_tab4_1006 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1006
+DROP VIEW IF EXISTS view_3_tab4_1006 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31817,13 +31817,13 @@ SELECT pk FROM tab0 WHERE col0 = 43
 ----
 
 statement ok
-DROP VIEW view_1_tab0_1007
+DROP VIEW IF EXISTS view_1_tab0_1007 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1007
+DROP VIEW IF EXISTS view_2_tab0_1007 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1007
+DROP VIEW IF EXISTS view_3_tab0_1007 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31909,13 +31909,13 @@ SELECT pk FROM tab1 WHERE col0 = 43
 ----
 
 statement ok
-DROP VIEW view_1_tab1_1007
+DROP VIEW IF EXISTS view_1_tab1_1007 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1007
+DROP VIEW IF EXISTS view_2_tab1_1007 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1007
+DROP VIEW IF EXISTS view_3_tab1_1007 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32001,13 +32001,13 @@ SELECT pk FROM tab2 WHERE col0 = 43
 ----
 
 statement ok
-DROP VIEW view_1_tab2_1007
+DROP VIEW IF EXISTS view_1_tab2_1007 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1007
+DROP VIEW IF EXISTS view_2_tab2_1007 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1007
+DROP VIEW IF EXISTS view_3_tab2_1007 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32093,13 +32093,13 @@ SELECT pk FROM tab3 WHERE col0 = 43
 ----
 
 statement ok
-DROP VIEW view_1_tab3_1007
+DROP VIEW IF EXISTS view_1_tab3_1007 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1007
+DROP VIEW IF EXISTS view_2_tab3_1007 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1007
+DROP VIEW IF EXISTS view_3_tab3_1007 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32185,13 +32185,13 @@ SELECT pk FROM tab4 WHERE col0 = 43
 ----
 
 statement ok
-DROP VIEW view_1_tab4_1007
+DROP VIEW IF EXISTS view_1_tab4_1007 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1007
+DROP VIEW IF EXISTS view_2_tab4_1007 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1007
+DROP VIEW IF EXISTS view_3_tab4_1007 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32305,13 +32305,13 @@ SELECT pk FROM tab0 WHERE col0 < 51
 9
 
 statement ok
-DROP VIEW view_1_tab0_1008
+DROP VIEW IF EXISTS view_1_tab0_1008 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1008
+DROP VIEW IF EXISTS view_2_tab0_1008 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1008
+DROP VIEW IF EXISTS view_3_tab0_1008 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32425,13 +32425,13 @@ SELECT pk FROM tab1 WHERE col0 < 51
 9
 
 statement ok
-DROP VIEW view_1_tab1_1008
+DROP VIEW IF EXISTS view_1_tab1_1008 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1008
+DROP VIEW IF EXISTS view_2_tab1_1008 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1008
+DROP VIEW IF EXISTS view_3_tab1_1008 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32545,13 +32545,13 @@ SELECT pk FROM tab2 WHERE col0 < 51
 9
 
 statement ok
-DROP VIEW view_1_tab2_1008
+DROP VIEW IF EXISTS view_1_tab2_1008 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1008
+DROP VIEW IF EXISTS view_2_tab2_1008 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1008
+DROP VIEW IF EXISTS view_3_tab2_1008 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32665,13 +32665,13 @@ SELECT pk FROM tab3 WHERE col0 < 51
 9
 
 statement ok
-DROP VIEW view_1_tab3_1008
+DROP VIEW IF EXISTS view_1_tab3_1008 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1008
+DROP VIEW IF EXISTS view_2_tab3_1008 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1008
+DROP VIEW IF EXISTS view_3_tab3_1008 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32785,11 +32785,11 @@ SELECT pk FROM tab4 WHERE col0 < 51
 9
 
 statement ok
-DROP VIEW view_1_tab4_1008
+DROP VIEW IF EXISTS view_1_tab4_1008 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1008
+DROP VIEW IF EXISTS view_2_tab4_1008 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1008
+DROP VIEW IF EXISTS view_3_tab4_1008 CASCADE
 

--- a/test/index/view/10/slt_good_7.test
+++ b/test/index/view/10/slt_good_7.test
@@ -227,13 +227,13 @@ SELECT pk FROM tab0 WHERE (col3 > 2 AND col3 >= 92) AND col1 <= 41.49 OR col1 < 
 9
 
 statement ok
-DROP VIEW view_1_tab0_1009
+DROP VIEW IF EXISTS view_1_tab0_1009 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1009
+DROP VIEW IF EXISTS view_2_tab0_1009 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1009
+DROP VIEW IF EXISTS view_3_tab0_1009 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -351,13 +351,13 @@ SELECT pk FROM tab1 WHERE (col3 > 2 AND col3 >= 92) AND col1 <= 41.49 OR col1 < 
 9
 
 statement ok
-DROP VIEW view_1_tab1_1009
+DROP VIEW IF EXISTS view_1_tab1_1009 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1009
+DROP VIEW IF EXISTS view_2_tab1_1009 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1009
+DROP VIEW IF EXISTS view_3_tab1_1009 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -475,13 +475,13 @@ SELECT pk FROM tab2 WHERE (col3 > 2 AND col3 >= 92) AND col1 <= 41.49 OR col1 < 
 9
 
 statement ok
-DROP VIEW view_1_tab2_1009
+DROP VIEW IF EXISTS view_1_tab2_1009 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1009
+DROP VIEW IF EXISTS view_2_tab2_1009 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1009
+DROP VIEW IF EXISTS view_3_tab2_1009 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -599,13 +599,13 @@ SELECT pk FROM tab3 WHERE (col3 > 2 AND col3 >= 92) AND col1 <= 41.49 OR col1 < 
 9
 
 statement ok
-DROP VIEW view_1_tab3_1009
+DROP VIEW IF EXISTS view_1_tab3_1009 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1009
+DROP VIEW IF EXISTS view_2_tab3_1009 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1009
+DROP VIEW IF EXISTS view_3_tab3_1009 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -723,13 +723,13 @@ SELECT pk FROM tab4 WHERE (col3 > 2 AND col3 >= 92) AND col1 <= 41.49 OR col1 < 
 9
 
 statement ok
-DROP VIEW view_1_tab4_1009
+DROP VIEW IF EXISTS view_1_tab4_1009 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1009
+DROP VIEW IF EXISTS view_2_tab4_1009 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1009
+DROP VIEW IF EXISTS view_3_tab4_1009 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -843,13 +843,13 @@ SELECT pk FROM tab0 WHERE col0 < 50
 8
 
 statement ok
-DROP VIEW view_1_tab0_1012
+DROP VIEW IF EXISTS view_1_tab0_1012 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1012
+DROP VIEW IF EXISTS view_2_tab0_1012 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1012
+DROP VIEW IF EXISTS view_3_tab0_1012 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -963,13 +963,13 @@ SELECT pk FROM tab1 WHERE col0 < 50
 8
 
 statement ok
-DROP VIEW view_1_tab1_1012
+DROP VIEW IF EXISTS view_1_tab1_1012 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1012
+DROP VIEW IF EXISTS view_2_tab1_1012 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1012
+DROP VIEW IF EXISTS view_3_tab1_1012 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1083,13 +1083,13 @@ SELECT pk FROM tab2 WHERE col0 < 50
 8
 
 statement ok
-DROP VIEW view_1_tab2_1012
+DROP VIEW IF EXISTS view_1_tab2_1012 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1012
+DROP VIEW IF EXISTS view_2_tab2_1012 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1012
+DROP VIEW IF EXISTS view_3_tab2_1012 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1203,13 +1203,13 @@ SELECT pk FROM tab3 WHERE col0 < 50
 8
 
 statement ok
-DROP VIEW view_1_tab3_1012
+DROP VIEW IF EXISTS view_1_tab3_1012 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1012
+DROP VIEW IF EXISTS view_2_tab3_1012 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1012
+DROP VIEW IF EXISTS view_3_tab3_1012 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1323,13 +1323,13 @@ SELECT pk FROM tab4 WHERE col0 < 50
 8
 
 statement ok
-DROP VIEW view_1_tab4_1012
+DROP VIEW IF EXISTS view_1_tab4_1012 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1012
+DROP VIEW IF EXISTS view_2_tab4_1012 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1012
+DROP VIEW IF EXISTS view_3_tab4_1012 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1448,13 +1448,13 @@ SELECT pk FROM tab0 WHERE col0 < 78
 9
 
 statement ok
-DROP VIEW view_1_tab0_1013
+DROP VIEW IF EXISTS view_1_tab0_1013 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1013
+DROP VIEW IF EXISTS view_2_tab0_1013 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1013
+DROP VIEW IF EXISTS view_3_tab0_1013 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1573,13 +1573,13 @@ SELECT pk FROM tab1 WHERE col0 < 78
 9
 
 statement ok
-DROP VIEW view_1_tab1_1013
+DROP VIEW IF EXISTS view_1_tab1_1013 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1013
+DROP VIEW IF EXISTS view_2_tab1_1013 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1013
+DROP VIEW IF EXISTS view_3_tab1_1013 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1698,13 +1698,13 @@ SELECT pk FROM tab2 WHERE col0 < 78
 9
 
 statement ok
-DROP VIEW view_1_tab2_1013
+DROP VIEW IF EXISTS view_1_tab2_1013 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1013
+DROP VIEW IF EXISTS view_2_tab2_1013 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1013
+DROP VIEW IF EXISTS view_3_tab2_1013 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1823,13 +1823,13 @@ SELECT pk FROM tab3 WHERE col0 < 78
 9
 
 statement ok
-DROP VIEW view_1_tab3_1013
+DROP VIEW IF EXISTS view_1_tab3_1013 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1013
+DROP VIEW IF EXISTS view_2_tab3_1013 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1013
+DROP VIEW IF EXISTS view_3_tab3_1013 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1948,13 +1948,13 @@ SELECT pk FROM tab4 WHERE col0 < 78
 9
 
 statement ok
-DROP VIEW view_1_tab4_1013
+DROP VIEW IF EXISTS view_1_tab4_1013 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1013
+DROP VIEW IF EXISTS view_2_tab4_1013 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1013
+DROP VIEW IF EXISTS view_3_tab4_1013 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2043,13 +2043,13 @@ SELECT pk FROM tab0 WHERE (col0 <= 94 OR col3 < 83) AND ((((((col0 < 5 AND (col3
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_1014
+DROP VIEW IF EXISTS view_1_tab0_1014 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1014
+DROP VIEW IF EXISTS view_2_tab0_1014 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1014
+DROP VIEW IF EXISTS view_3_tab0_1014 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2138,13 +2138,13 @@ SELECT pk FROM tab1 WHERE (col0 <= 94 OR col3 < 83) AND ((((((col0 < 5 AND (col3
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_1014
+DROP VIEW IF EXISTS view_1_tab1_1014 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1014
+DROP VIEW IF EXISTS view_2_tab1_1014 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1014
+DROP VIEW IF EXISTS view_3_tab1_1014 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2233,13 +2233,13 @@ SELECT pk FROM tab2 WHERE (col0 <= 94 OR col3 < 83) AND ((((((col0 < 5 AND (col3
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_1014
+DROP VIEW IF EXISTS view_1_tab2_1014 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1014
+DROP VIEW IF EXISTS view_2_tab2_1014 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1014
+DROP VIEW IF EXISTS view_3_tab2_1014 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2328,13 +2328,13 @@ SELECT pk FROM tab3 WHERE (col0 <= 94 OR col3 < 83) AND ((((((col0 < 5 AND (col3
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_1014
+DROP VIEW IF EXISTS view_1_tab3_1014 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1014
+DROP VIEW IF EXISTS view_2_tab3_1014 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1014
+DROP VIEW IF EXISTS view_3_tab3_1014 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2423,13 +2423,13 @@ SELECT pk FROM tab4 WHERE (col0 <= 94 OR col3 < 83) AND ((((((col0 < 5 AND (col3
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_1014
+DROP VIEW IF EXISTS view_1_tab4_1014 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1014
+DROP VIEW IF EXISTS view_2_tab4_1014 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1014
+DROP VIEW IF EXISTS view_3_tab4_1014 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2515,13 +2515,13 @@ SELECT pk FROM tab0 WHERE col4 BETWEEN 73.73 AND 33.21
 ----
 
 statement ok
-DROP VIEW view_1_tab0_1015
+DROP VIEW IF EXISTS view_1_tab0_1015 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1015
+DROP VIEW IF EXISTS view_2_tab0_1015 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1015
+DROP VIEW IF EXISTS view_3_tab0_1015 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2607,13 +2607,13 @@ SELECT pk FROM tab1 WHERE col4 BETWEEN 73.73 AND 33.21
 ----
 
 statement ok
-DROP VIEW view_1_tab1_1015
+DROP VIEW IF EXISTS view_1_tab1_1015 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1015
+DROP VIEW IF EXISTS view_2_tab1_1015 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1015
+DROP VIEW IF EXISTS view_3_tab1_1015 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2699,13 +2699,13 @@ SELECT pk FROM tab2 WHERE col4 BETWEEN 73.73 AND 33.21
 ----
 
 statement ok
-DROP VIEW view_1_tab2_1015
+DROP VIEW IF EXISTS view_1_tab2_1015 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1015
+DROP VIEW IF EXISTS view_2_tab2_1015 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1015
+DROP VIEW IF EXISTS view_3_tab2_1015 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2791,13 +2791,13 @@ SELECT pk FROM tab3 WHERE col4 BETWEEN 73.73 AND 33.21
 ----
 
 statement ok
-DROP VIEW view_1_tab3_1015
+DROP VIEW IF EXISTS view_1_tab3_1015 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1015
+DROP VIEW IF EXISTS view_2_tab3_1015 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1015
+DROP VIEW IF EXISTS view_3_tab3_1015 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2883,13 +2883,13 @@ SELECT pk FROM tab4 WHERE col4 BETWEEN 73.73 AND 33.21
 ----
 
 statement ok
-DROP VIEW view_1_tab4_1015
+DROP VIEW IF EXISTS view_1_tab4_1015 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1015
+DROP VIEW IF EXISTS view_2_tab4_1015 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1015
+DROP VIEW IF EXISTS view_3_tab4_1015 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3003,13 +3003,13 @@ SELECT pk FROM tab0 WHERE col0 > 58
 5
 
 statement ok
-DROP VIEW view_1_tab0_1016
+DROP VIEW IF EXISTS view_1_tab0_1016 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1016
+DROP VIEW IF EXISTS view_2_tab0_1016 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1016
+DROP VIEW IF EXISTS view_3_tab0_1016 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3123,13 +3123,13 @@ SELECT pk FROM tab1 WHERE col0 > 58
 5
 
 statement ok
-DROP VIEW view_1_tab1_1016
+DROP VIEW IF EXISTS view_1_tab1_1016 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1016
+DROP VIEW IF EXISTS view_2_tab1_1016 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1016
+DROP VIEW IF EXISTS view_3_tab1_1016 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3243,13 +3243,13 @@ SELECT pk FROM tab2 WHERE col0 > 58
 5
 
 statement ok
-DROP VIEW view_1_tab2_1016
+DROP VIEW IF EXISTS view_1_tab2_1016 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1016
+DROP VIEW IF EXISTS view_2_tab2_1016 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1016
+DROP VIEW IF EXISTS view_3_tab2_1016 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3363,13 +3363,13 @@ SELECT pk FROM tab3 WHERE col0 > 58
 5
 
 statement ok
-DROP VIEW view_1_tab3_1016
+DROP VIEW IF EXISTS view_1_tab3_1016 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1016
+DROP VIEW IF EXISTS view_2_tab3_1016 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1016
+DROP VIEW IF EXISTS view_3_tab3_1016 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3483,13 +3483,13 @@ SELECT pk FROM tab4 WHERE col0 > 58
 5
 
 statement ok
-DROP VIEW view_1_tab4_1016
+DROP VIEW IF EXISTS view_1_tab4_1016 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1016
+DROP VIEW IF EXISTS view_2_tab4_1016 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1016
+DROP VIEW IF EXISTS view_3_tab4_1016 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3578,13 +3578,13 @@ SELECT pk FROM tab0 WHERE (col0 >= 2)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_1017
+DROP VIEW IF EXISTS view_1_tab0_1017 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1017
+DROP VIEW IF EXISTS view_2_tab0_1017 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1017
+DROP VIEW IF EXISTS view_3_tab0_1017 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3673,13 +3673,13 @@ SELECT pk FROM tab1 WHERE (col0 >= 2)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_1017
+DROP VIEW IF EXISTS view_1_tab1_1017 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1017
+DROP VIEW IF EXISTS view_2_tab1_1017 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1017
+DROP VIEW IF EXISTS view_3_tab1_1017 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3768,13 +3768,13 @@ SELECT pk FROM tab2 WHERE (col0 >= 2)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_1017
+DROP VIEW IF EXISTS view_1_tab2_1017 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1017
+DROP VIEW IF EXISTS view_2_tab2_1017 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1017
+DROP VIEW IF EXISTS view_3_tab2_1017 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3863,13 +3863,13 @@ SELECT pk FROM tab3 WHERE (col0 >= 2)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_1017
+DROP VIEW IF EXISTS view_1_tab3_1017 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1017
+DROP VIEW IF EXISTS view_2_tab3_1017 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1017
+DROP VIEW IF EXISTS view_3_tab3_1017 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3958,13 +3958,13 @@ SELECT pk FROM tab4 WHERE (col0 >= 2)
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_1017
+DROP VIEW IF EXISTS view_1_tab4_1017 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1017
+DROP VIEW IF EXISTS view_2_tab4_1017 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1017
+DROP VIEW IF EXISTS view_3_tab4_1017 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4084,13 +4084,13 @@ SELECT pk FROM tab0 WHERE col0 < 63
 9
 
 statement ok
-DROP VIEW view_1_tab0_1018
+DROP VIEW IF EXISTS view_1_tab0_1018 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1018
+DROP VIEW IF EXISTS view_2_tab0_1018 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1018
+DROP VIEW IF EXISTS view_3_tab0_1018 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4210,13 +4210,13 @@ SELECT pk FROM tab1 WHERE col0 < 63
 9
 
 statement ok
-DROP VIEW view_1_tab1_1018
+DROP VIEW IF EXISTS view_1_tab1_1018 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1018
+DROP VIEW IF EXISTS view_2_tab1_1018 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1018
+DROP VIEW IF EXISTS view_3_tab1_1018 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4336,13 +4336,13 @@ SELECT pk FROM tab2 WHERE col0 < 63
 9
 
 statement ok
-DROP VIEW view_1_tab2_1018
+DROP VIEW IF EXISTS view_1_tab2_1018 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1018
+DROP VIEW IF EXISTS view_2_tab2_1018 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1018
+DROP VIEW IF EXISTS view_3_tab2_1018 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4462,13 +4462,13 @@ SELECT pk FROM tab3 WHERE col0 < 63
 9
 
 statement ok
-DROP VIEW view_1_tab3_1018
+DROP VIEW IF EXISTS view_1_tab3_1018 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1018
+DROP VIEW IF EXISTS view_2_tab3_1018 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1018
+DROP VIEW IF EXISTS view_3_tab3_1018 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4588,13 +4588,13 @@ SELECT pk FROM tab4 WHERE col0 < 63
 9
 
 statement ok
-DROP VIEW view_1_tab4_1018
+DROP VIEW IF EXISTS view_1_tab4_1018 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1018
+DROP VIEW IF EXISTS view_2_tab4_1018 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1018
+DROP VIEW IF EXISTS view_3_tab4_1018 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4680,13 +4680,13 @@ SELECT pk FROM tab0 WHERE col0 IN (93,81,44,3,48,11)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_1019
+DROP VIEW IF EXISTS view_1_tab0_1019 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1019
+DROP VIEW IF EXISTS view_2_tab0_1019 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1019
+DROP VIEW IF EXISTS view_3_tab0_1019 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4772,13 +4772,13 @@ SELECT pk FROM tab1 WHERE col0 IN (93,81,44,3,48,11)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_1019
+DROP VIEW IF EXISTS view_1_tab1_1019 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1019
+DROP VIEW IF EXISTS view_2_tab1_1019 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1019
+DROP VIEW IF EXISTS view_3_tab1_1019 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4864,13 +4864,13 @@ SELECT pk FROM tab2 WHERE col0 IN (93,81,44,3,48,11)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_1019
+DROP VIEW IF EXISTS view_1_tab2_1019 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1019
+DROP VIEW IF EXISTS view_2_tab2_1019 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1019
+DROP VIEW IF EXISTS view_3_tab2_1019 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4956,13 +4956,13 @@ SELECT pk FROM tab3 WHERE col0 IN (93,81,44,3,48,11)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_1019
+DROP VIEW IF EXISTS view_1_tab3_1019 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1019
+DROP VIEW IF EXISTS view_2_tab3_1019 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1019
+DROP VIEW IF EXISTS view_3_tab3_1019 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5048,13 +5048,13 @@ SELECT pk FROM tab4 WHERE col0 IN (93,81,44,3,48,11)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_1019
+DROP VIEW IF EXISTS view_1_tab4_1019 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1019
+DROP VIEW IF EXISTS view_2_tab4_1019 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1019
+DROP VIEW IF EXISTS view_3_tab4_1019 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5140,13 +5140,13 @@ SELECT pk FROM tab0 WHERE col0 BETWEEN 84 AND 79 OR (col4 = 85.87)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_1020
+DROP VIEW IF EXISTS view_1_tab0_1020 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1020
+DROP VIEW IF EXISTS view_2_tab0_1020 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1020
+DROP VIEW IF EXISTS view_3_tab0_1020 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5232,13 +5232,13 @@ SELECT pk FROM tab1 WHERE col0 BETWEEN 84 AND 79 OR (col4 = 85.87)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_1020
+DROP VIEW IF EXISTS view_1_tab1_1020 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1020
+DROP VIEW IF EXISTS view_2_tab1_1020 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1020
+DROP VIEW IF EXISTS view_3_tab1_1020 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5324,13 +5324,13 @@ SELECT pk FROM tab2 WHERE col0 BETWEEN 84 AND 79 OR (col4 = 85.87)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_1020
+DROP VIEW IF EXISTS view_1_tab2_1020 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1020
+DROP VIEW IF EXISTS view_2_tab2_1020 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1020
+DROP VIEW IF EXISTS view_3_tab2_1020 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5416,13 +5416,13 @@ SELECT pk FROM tab3 WHERE col0 BETWEEN 84 AND 79 OR (col4 = 85.87)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_1020
+DROP VIEW IF EXISTS view_1_tab3_1020 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1020
+DROP VIEW IF EXISTS view_2_tab3_1020 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1020
+DROP VIEW IF EXISTS view_3_tab3_1020 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5508,13 +5508,13 @@ SELECT pk FROM tab4 WHERE col0 BETWEEN 84 AND 79 OR (col4 = 85.87)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_1020
+DROP VIEW IF EXISTS view_1_tab4_1020 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1020
+DROP VIEW IF EXISTS view_2_tab4_1020 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1020
+DROP VIEW IF EXISTS view_3_tab4_1020 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5634,13 +5634,13 @@ SELECT pk FROM tab0 WHERE col0 < 68
 9
 
 statement ok
-DROP VIEW view_1_tab0_1022
+DROP VIEW IF EXISTS view_1_tab0_1022 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1022
+DROP VIEW IF EXISTS view_2_tab0_1022 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1022
+DROP VIEW IF EXISTS view_3_tab0_1022 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5760,13 +5760,13 @@ SELECT pk FROM tab1 WHERE col0 < 68
 9
 
 statement ok
-DROP VIEW view_1_tab1_1022
+DROP VIEW IF EXISTS view_1_tab1_1022 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1022
+DROP VIEW IF EXISTS view_2_tab1_1022 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1022
+DROP VIEW IF EXISTS view_3_tab1_1022 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5886,13 +5886,13 @@ SELECT pk FROM tab2 WHERE col0 < 68
 9
 
 statement ok
-DROP VIEW view_1_tab2_1022
+DROP VIEW IF EXISTS view_1_tab2_1022 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1022
+DROP VIEW IF EXISTS view_2_tab2_1022 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1022
+DROP VIEW IF EXISTS view_3_tab2_1022 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6012,13 +6012,13 @@ SELECT pk FROM tab3 WHERE col0 < 68
 9
 
 statement ok
-DROP VIEW view_1_tab3_1022
+DROP VIEW IF EXISTS view_1_tab3_1022 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1022
+DROP VIEW IF EXISTS view_2_tab3_1022 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1022
+DROP VIEW IF EXISTS view_3_tab3_1022 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6138,13 +6138,13 @@ SELECT pk FROM tab4 WHERE col0 < 68
 9
 
 statement ok
-DROP VIEW view_1_tab4_1022
+DROP VIEW IF EXISTS view_1_tab4_1022 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1022
+DROP VIEW IF EXISTS view_2_tab4_1022 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1022
+DROP VIEW IF EXISTS view_3_tab4_1022 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6237,13 +6237,13 @@ SELECT pk FROM tab0 WHERE col0 > 22 OR col4 <= 27.14
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab0_1023
+DROP VIEW IF EXISTS view_1_tab0_1023 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1023
+DROP VIEW IF EXISTS view_2_tab0_1023 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1023
+DROP VIEW IF EXISTS view_3_tab0_1023 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6336,13 +6336,13 @@ SELECT pk FROM tab1 WHERE col0 > 22 OR col4 <= 27.14
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab1_1023
+DROP VIEW IF EXISTS view_1_tab1_1023 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1023
+DROP VIEW IF EXISTS view_2_tab1_1023 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1023
+DROP VIEW IF EXISTS view_3_tab1_1023 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6435,13 +6435,13 @@ SELECT pk FROM tab2 WHERE col0 > 22 OR col4 <= 27.14
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab2_1023
+DROP VIEW IF EXISTS view_1_tab2_1023 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1023
+DROP VIEW IF EXISTS view_2_tab2_1023 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1023
+DROP VIEW IF EXISTS view_3_tab2_1023 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6534,13 +6534,13 @@ SELECT pk FROM tab3 WHERE col0 > 22 OR col4 <= 27.14
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab3_1023
+DROP VIEW IF EXISTS view_1_tab3_1023 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1023
+DROP VIEW IF EXISTS view_2_tab3_1023 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1023
+DROP VIEW IF EXISTS view_3_tab3_1023 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6633,13 +6633,13 @@ SELECT pk FROM tab4 WHERE col0 > 22 OR col4 <= 27.14
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab4_1023
+DROP VIEW IF EXISTS view_1_tab4_1023 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1023
+DROP VIEW IF EXISTS view_2_tab4_1023 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1023
+DROP VIEW IF EXISTS view_3_tab4_1023 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6757,13 +6757,13 @@ SELECT pk FROM tab0 WHERE (col0 >= 12)
 9
 
 statement ok
-DROP VIEW view_1_tab0_1024
+DROP VIEW IF EXISTS view_1_tab0_1024 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1024
+DROP VIEW IF EXISTS view_2_tab0_1024 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1024
+DROP VIEW IF EXISTS view_3_tab0_1024 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6881,13 +6881,13 @@ SELECT pk FROM tab1 WHERE (col0 >= 12)
 9
 
 statement ok
-DROP VIEW view_1_tab1_1024
+DROP VIEW IF EXISTS view_1_tab1_1024 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1024
+DROP VIEW IF EXISTS view_2_tab1_1024 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1024
+DROP VIEW IF EXISTS view_3_tab1_1024 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7005,13 +7005,13 @@ SELECT pk FROM tab2 WHERE (col0 >= 12)
 9
 
 statement ok
-DROP VIEW view_1_tab2_1024
+DROP VIEW IF EXISTS view_1_tab2_1024 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1024
+DROP VIEW IF EXISTS view_2_tab2_1024 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1024
+DROP VIEW IF EXISTS view_3_tab2_1024 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7129,13 +7129,13 @@ SELECT pk FROM tab3 WHERE (col0 >= 12)
 9
 
 statement ok
-DROP VIEW view_1_tab3_1024
+DROP VIEW IF EXISTS view_1_tab3_1024 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1024
+DROP VIEW IF EXISTS view_2_tab3_1024 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1024
+DROP VIEW IF EXISTS view_3_tab3_1024 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7253,13 +7253,13 @@ SELECT pk FROM tab4 WHERE (col0 >= 12)
 9
 
 statement ok
-DROP VIEW view_1_tab4_1024
+DROP VIEW IF EXISTS view_1_tab4_1024 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1024
+DROP VIEW IF EXISTS view_2_tab4_1024 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1024
+DROP VIEW IF EXISTS view_3_tab4_1024 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7348,13 +7348,13 @@ SELECT pk FROM tab0 WHERE col3 <= 88 OR col4 <= 84.5
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_1025
+DROP VIEW IF EXISTS view_1_tab0_1025 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1025
+DROP VIEW IF EXISTS view_2_tab0_1025 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1025
+DROP VIEW IF EXISTS view_3_tab0_1025 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7443,13 +7443,13 @@ SELECT pk FROM tab1 WHERE col3 <= 88 OR col4 <= 84.5
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_1025
+DROP VIEW IF EXISTS view_1_tab1_1025 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1025
+DROP VIEW IF EXISTS view_2_tab1_1025 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1025
+DROP VIEW IF EXISTS view_3_tab1_1025 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7538,13 +7538,13 @@ SELECT pk FROM tab2 WHERE col3 <= 88 OR col4 <= 84.5
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_1025
+DROP VIEW IF EXISTS view_1_tab2_1025 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1025
+DROP VIEW IF EXISTS view_2_tab2_1025 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1025
+DROP VIEW IF EXISTS view_3_tab2_1025 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7633,13 +7633,13 @@ SELECT pk FROM tab3 WHERE col3 <= 88 OR col4 <= 84.5
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_1025
+DROP VIEW IF EXISTS view_1_tab3_1025 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1025
+DROP VIEW IF EXISTS view_2_tab3_1025 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1025
+DROP VIEW IF EXISTS view_3_tab3_1025 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7728,13 +7728,13 @@ SELECT pk FROM tab4 WHERE col3 <= 88 OR col4 <= 84.5
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_1025
+DROP VIEW IF EXISTS view_1_tab4_1025 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1025
+DROP VIEW IF EXISTS view_2_tab4_1025 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1025
+DROP VIEW IF EXISTS view_3_tab4_1025 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7854,13 +7854,13 @@ SELECT pk FROM tab0 WHERE col1 <= 44.51
 9
 
 statement ok
-DROP VIEW view_1_tab0_1026
+DROP VIEW IF EXISTS view_1_tab0_1026 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1026
+DROP VIEW IF EXISTS view_2_tab0_1026 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1026
+DROP VIEW IF EXISTS view_3_tab0_1026 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7980,13 +7980,13 @@ SELECT pk FROM tab1 WHERE col1 <= 44.51
 9
 
 statement ok
-DROP VIEW view_1_tab1_1026
+DROP VIEW IF EXISTS view_1_tab1_1026 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1026
+DROP VIEW IF EXISTS view_2_tab1_1026 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1026
+DROP VIEW IF EXISTS view_3_tab1_1026 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8106,13 +8106,13 @@ SELECT pk FROM tab2 WHERE col1 <= 44.51
 9
 
 statement ok
-DROP VIEW view_1_tab2_1026
+DROP VIEW IF EXISTS view_1_tab2_1026 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1026
+DROP VIEW IF EXISTS view_2_tab2_1026 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1026
+DROP VIEW IF EXISTS view_3_tab2_1026 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8232,13 +8232,13 @@ SELECT pk FROM tab3 WHERE col1 <= 44.51
 9
 
 statement ok
-DROP VIEW view_1_tab3_1026
+DROP VIEW IF EXISTS view_1_tab3_1026 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1026
+DROP VIEW IF EXISTS view_2_tab3_1026 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1026
+DROP VIEW IF EXISTS view_3_tab3_1026 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8358,13 +8358,13 @@ SELECT pk FROM tab4 WHERE col1 <= 44.51
 9
 
 statement ok
-DROP VIEW view_1_tab4_1026
+DROP VIEW IF EXISTS view_1_tab4_1026 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1026
+DROP VIEW IF EXISTS view_2_tab4_1026 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1026
+DROP VIEW IF EXISTS view_3_tab4_1026 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8457,13 +8457,13 @@ SELECT pk FROM tab0 WHERE (((col3 >= 84)))
 6
 
 statement ok
-DROP VIEW view_1_tab0_1027
+DROP VIEW IF EXISTS view_1_tab0_1027 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1027
+DROP VIEW IF EXISTS view_2_tab0_1027 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1027
+DROP VIEW IF EXISTS view_3_tab0_1027 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8556,13 +8556,13 @@ SELECT pk FROM tab1 WHERE (((col3 >= 84)))
 6
 
 statement ok
-DROP VIEW view_1_tab1_1027
+DROP VIEW IF EXISTS view_1_tab1_1027 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1027
+DROP VIEW IF EXISTS view_2_tab1_1027 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1027
+DROP VIEW IF EXISTS view_3_tab1_1027 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8655,13 +8655,13 @@ SELECT pk FROM tab2 WHERE (((col3 >= 84)))
 6
 
 statement ok
-DROP VIEW view_1_tab2_1027
+DROP VIEW IF EXISTS view_1_tab2_1027 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1027
+DROP VIEW IF EXISTS view_2_tab2_1027 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1027
+DROP VIEW IF EXISTS view_3_tab2_1027 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8754,13 +8754,13 @@ SELECT pk FROM tab3 WHERE (((col3 >= 84)))
 6
 
 statement ok
-DROP VIEW view_1_tab3_1027
+DROP VIEW IF EXISTS view_1_tab3_1027 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1027
+DROP VIEW IF EXISTS view_2_tab3_1027 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1027
+DROP VIEW IF EXISTS view_3_tab3_1027 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8853,13 +8853,13 @@ SELECT pk FROM tab4 WHERE (((col3 >= 84)))
 6
 
 statement ok
-DROP VIEW view_1_tab4_1027
+DROP VIEW IF EXISTS view_1_tab4_1027 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1027
+DROP VIEW IF EXISTS view_2_tab4_1027 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1027
+DROP VIEW IF EXISTS view_3_tab4_1027 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8948,13 +8948,13 @@ SELECT pk FROM tab0 WHERE (((((col4 < 70.55)) OR col3 >= 41 AND col4 = 70.71 OR 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_1028
+DROP VIEW IF EXISTS view_1_tab0_1028 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1028
+DROP VIEW IF EXISTS view_2_tab0_1028 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1028
+DROP VIEW IF EXISTS view_3_tab0_1028 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9043,13 +9043,13 @@ SELECT pk FROM tab1 WHERE (((((col4 < 70.55)) OR col3 >= 41 AND col4 = 70.71 OR 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_1028
+DROP VIEW IF EXISTS view_1_tab1_1028 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1028
+DROP VIEW IF EXISTS view_2_tab1_1028 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1028
+DROP VIEW IF EXISTS view_3_tab1_1028 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9138,13 +9138,13 @@ SELECT pk FROM tab2 WHERE (((((col4 < 70.55)) OR col3 >= 41 AND col4 = 70.71 OR 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_1028
+DROP VIEW IF EXISTS view_1_tab2_1028 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1028
+DROP VIEW IF EXISTS view_2_tab2_1028 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1028
+DROP VIEW IF EXISTS view_3_tab2_1028 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9233,13 +9233,13 @@ SELECT pk FROM tab3 WHERE (((((col4 < 70.55)) OR col3 >= 41 AND col4 = 70.71 OR 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_1028
+DROP VIEW IF EXISTS view_1_tab3_1028 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1028
+DROP VIEW IF EXISTS view_2_tab3_1028 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1028
+DROP VIEW IF EXISTS view_3_tab3_1028 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9328,13 +9328,13 @@ SELECT pk FROM tab4 WHERE (((((col4 < 70.55)) OR col3 >= 41 AND col4 = 70.71 OR 
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_1028
+DROP VIEW IF EXISTS view_1_tab4_1028 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1028
+DROP VIEW IF EXISTS view_2_tab4_1028 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1028
+DROP VIEW IF EXISTS view_3_tab4_1028 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9453,13 +9453,13 @@ SELECT pk FROM tab0 WHERE (col0 >= 27)
 9
 
 statement ok
-DROP VIEW view_1_tab0_1029
+DROP VIEW IF EXISTS view_1_tab0_1029 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1029
+DROP VIEW IF EXISTS view_2_tab0_1029 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1029
+DROP VIEW IF EXISTS view_3_tab0_1029 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9578,13 +9578,13 @@ SELECT pk FROM tab1 WHERE (col0 >= 27)
 9
 
 statement ok
-DROP VIEW view_1_tab1_1029
+DROP VIEW IF EXISTS view_1_tab1_1029 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1029
+DROP VIEW IF EXISTS view_2_tab1_1029 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1029
+DROP VIEW IF EXISTS view_3_tab1_1029 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9703,13 +9703,13 @@ SELECT pk FROM tab2 WHERE (col0 >= 27)
 9
 
 statement ok
-DROP VIEW view_1_tab2_1029
+DROP VIEW IF EXISTS view_1_tab2_1029 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1029
+DROP VIEW IF EXISTS view_2_tab2_1029 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1029
+DROP VIEW IF EXISTS view_3_tab2_1029 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9828,13 +9828,13 @@ SELECT pk FROM tab3 WHERE (col0 >= 27)
 9
 
 statement ok
-DROP VIEW view_1_tab3_1029
+DROP VIEW IF EXISTS view_1_tab3_1029 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1029
+DROP VIEW IF EXISTS view_2_tab3_1029 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1029
+DROP VIEW IF EXISTS view_3_tab3_1029 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9953,13 +9953,13 @@ SELECT pk FROM tab4 WHERE (col0 >= 27)
 9
 
 statement ok
-DROP VIEW view_1_tab4_1029
+DROP VIEW IF EXISTS view_1_tab4_1029 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1029
+DROP VIEW IF EXISTS view_2_tab4_1029 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1029
+DROP VIEW IF EXISTS view_3_tab4_1029 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10073,13 +10073,13 @@ SELECT pk FROM tab0 WHERE ((col1 IS NULL AND col1 IN (54.43,78.86,33.15,51.13) A
 9
 
 statement ok
-DROP VIEW view_1_tab0_1030
+DROP VIEW IF EXISTS view_1_tab0_1030 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1030
+DROP VIEW IF EXISTS view_2_tab0_1030 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1030
+DROP VIEW IF EXISTS view_3_tab0_1030 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10193,13 +10193,13 @@ SELECT pk FROM tab1 WHERE ((col1 IS NULL AND col1 IN (54.43,78.86,33.15,51.13) A
 9
 
 statement ok
-DROP VIEW view_1_tab1_1030
+DROP VIEW IF EXISTS view_1_tab1_1030 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1030
+DROP VIEW IF EXISTS view_2_tab1_1030 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1030
+DROP VIEW IF EXISTS view_3_tab1_1030 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10313,13 +10313,13 @@ SELECT pk FROM tab2 WHERE ((col1 IS NULL AND col1 IN (54.43,78.86,33.15,51.13) A
 9
 
 statement ok
-DROP VIEW view_1_tab2_1030
+DROP VIEW IF EXISTS view_1_tab2_1030 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1030
+DROP VIEW IF EXISTS view_2_tab2_1030 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1030
+DROP VIEW IF EXISTS view_3_tab2_1030 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10433,13 +10433,13 @@ SELECT pk FROM tab3 WHERE ((col1 IS NULL AND col1 IN (54.43,78.86,33.15,51.13) A
 9
 
 statement ok
-DROP VIEW view_1_tab3_1030
+DROP VIEW IF EXISTS view_1_tab3_1030 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1030
+DROP VIEW IF EXISTS view_2_tab3_1030 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1030
+DROP VIEW IF EXISTS view_3_tab3_1030 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10553,13 +10553,13 @@ SELECT pk FROM tab4 WHERE ((col1 IS NULL AND col1 IN (54.43,78.86,33.15,51.13) A
 9
 
 statement ok
-DROP VIEW view_1_tab4_1030
+DROP VIEW IF EXISTS view_1_tab4_1030 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1030
+DROP VIEW IF EXISTS view_2_tab4_1030 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1030
+DROP VIEW IF EXISTS view_3_tab4_1030 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10662,13 +10662,13 @@ SELECT pk FROM tab0 WHERE col0 <= 78 AND col3 BETWEEN 8 AND 98
 9
 
 statement ok
-DROP VIEW view_1_tab0_1031
+DROP VIEW IF EXISTS view_1_tab0_1031 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1031
+DROP VIEW IF EXISTS view_2_tab0_1031 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1031
+DROP VIEW IF EXISTS view_3_tab0_1031 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10771,13 +10771,13 @@ SELECT pk FROM tab1 WHERE col0 <= 78 AND col3 BETWEEN 8 AND 98
 9
 
 statement ok
-DROP VIEW view_1_tab1_1031
+DROP VIEW IF EXISTS view_1_tab1_1031 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1031
+DROP VIEW IF EXISTS view_2_tab1_1031 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1031
+DROP VIEW IF EXISTS view_3_tab1_1031 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10880,13 +10880,13 @@ SELECT pk FROM tab2 WHERE col0 <= 78 AND col3 BETWEEN 8 AND 98
 9
 
 statement ok
-DROP VIEW view_1_tab2_1031
+DROP VIEW IF EXISTS view_1_tab2_1031 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1031
+DROP VIEW IF EXISTS view_2_tab2_1031 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1031
+DROP VIEW IF EXISTS view_3_tab2_1031 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10989,13 +10989,13 @@ SELECT pk FROM tab3 WHERE col0 <= 78 AND col3 BETWEEN 8 AND 98
 9
 
 statement ok
-DROP VIEW view_1_tab3_1031
+DROP VIEW IF EXISTS view_1_tab3_1031 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1031
+DROP VIEW IF EXISTS view_2_tab3_1031 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1031
+DROP VIEW IF EXISTS view_3_tab3_1031 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11098,13 +11098,13 @@ SELECT pk FROM tab4 WHERE col0 <= 78 AND col3 BETWEEN 8 AND 98
 9
 
 statement ok
-DROP VIEW view_1_tab4_1031
+DROP VIEW IF EXISTS view_1_tab4_1031 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1031
+DROP VIEW IF EXISTS view_2_tab4_1031 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1031
+DROP VIEW IF EXISTS view_3_tab4_1031 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11204,13 +11204,13 @@ SELECT pk FROM tab0 WHERE col4 <= 10.93
 6
 
 statement ok
-DROP VIEW view_1_tab0_1032
+DROP VIEW IF EXISTS view_1_tab0_1032 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1032
+DROP VIEW IF EXISTS view_2_tab0_1032 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1032
+DROP VIEW IF EXISTS view_3_tab0_1032 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11310,13 +11310,13 @@ SELECT pk FROM tab1 WHERE col4 <= 10.93
 6
 
 statement ok
-DROP VIEW view_1_tab1_1032
+DROP VIEW IF EXISTS view_1_tab1_1032 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1032
+DROP VIEW IF EXISTS view_2_tab1_1032 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1032
+DROP VIEW IF EXISTS view_3_tab1_1032 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11416,13 +11416,13 @@ SELECT pk FROM tab2 WHERE col4 <= 10.93
 6
 
 statement ok
-DROP VIEW view_1_tab2_1032
+DROP VIEW IF EXISTS view_1_tab2_1032 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1032
+DROP VIEW IF EXISTS view_2_tab2_1032 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1032
+DROP VIEW IF EXISTS view_3_tab2_1032 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11522,13 +11522,13 @@ SELECT pk FROM tab3 WHERE col4 <= 10.93
 6
 
 statement ok
-DROP VIEW view_1_tab3_1032
+DROP VIEW IF EXISTS view_1_tab3_1032 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1032
+DROP VIEW IF EXISTS view_2_tab3_1032 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1032
+DROP VIEW IF EXISTS view_3_tab3_1032 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11628,13 +11628,13 @@ SELECT pk FROM tab4 WHERE col4 <= 10.93
 6
 
 statement ok
-DROP VIEW view_1_tab4_1032
+DROP VIEW IF EXISTS view_1_tab4_1032 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1032
+DROP VIEW IF EXISTS view_2_tab4_1032 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1032
+DROP VIEW IF EXISTS view_3_tab4_1032 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11727,13 +11727,13 @@ SELECT pk FROM tab0 WHERE col4 >= 74.47
 3
 
 statement ok
-DROP VIEW view_1_tab0_1033
+DROP VIEW IF EXISTS view_1_tab0_1033 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1033
+DROP VIEW IF EXISTS view_2_tab0_1033 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1033
+DROP VIEW IF EXISTS view_3_tab0_1033 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11826,13 +11826,13 @@ SELECT pk FROM tab1 WHERE col4 >= 74.47
 3
 
 statement ok
-DROP VIEW view_1_tab1_1033
+DROP VIEW IF EXISTS view_1_tab1_1033 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1033
+DROP VIEW IF EXISTS view_2_tab1_1033 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1033
+DROP VIEW IF EXISTS view_3_tab1_1033 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11925,13 +11925,13 @@ SELECT pk FROM tab2 WHERE col4 >= 74.47
 3
 
 statement ok
-DROP VIEW view_1_tab2_1033
+DROP VIEW IF EXISTS view_1_tab2_1033 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1033
+DROP VIEW IF EXISTS view_2_tab2_1033 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1033
+DROP VIEW IF EXISTS view_3_tab2_1033 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12024,13 +12024,13 @@ SELECT pk FROM tab3 WHERE col4 >= 74.47
 3
 
 statement ok
-DROP VIEW view_1_tab3_1033
+DROP VIEW IF EXISTS view_1_tab3_1033 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1033
+DROP VIEW IF EXISTS view_2_tab3_1033 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1033
+DROP VIEW IF EXISTS view_3_tab3_1033 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12123,13 +12123,13 @@ SELECT pk FROM tab4 WHERE col4 >= 74.47
 3
 
 statement ok
-DROP VIEW view_1_tab4_1033
+DROP VIEW IF EXISTS view_1_tab4_1033 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1033
+DROP VIEW IF EXISTS view_2_tab4_1033 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1033
+DROP VIEW IF EXISTS view_3_tab4_1033 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12236,13 +12236,13 @@ SELECT pk FROM tab0 WHERE col0 <= 14
 8
 
 statement ok
-DROP VIEW view_1_tab0_1035
+DROP VIEW IF EXISTS view_1_tab0_1035 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1035
+DROP VIEW IF EXISTS view_2_tab0_1035 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1035
+DROP VIEW IF EXISTS view_3_tab0_1035 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12349,13 +12349,13 @@ SELECT pk FROM tab1 WHERE col0 <= 14
 8
 
 statement ok
-DROP VIEW view_1_tab1_1035
+DROP VIEW IF EXISTS view_1_tab1_1035 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1035
+DROP VIEW IF EXISTS view_2_tab1_1035 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1035
+DROP VIEW IF EXISTS view_3_tab1_1035 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12462,13 +12462,13 @@ SELECT pk FROM tab2 WHERE col0 <= 14
 8
 
 statement ok
-DROP VIEW view_1_tab2_1035
+DROP VIEW IF EXISTS view_1_tab2_1035 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1035
+DROP VIEW IF EXISTS view_2_tab2_1035 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1035
+DROP VIEW IF EXISTS view_3_tab2_1035 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12575,13 +12575,13 @@ SELECT pk FROM tab3 WHERE col0 <= 14
 8
 
 statement ok
-DROP VIEW view_1_tab3_1035
+DROP VIEW IF EXISTS view_1_tab3_1035 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1035
+DROP VIEW IF EXISTS view_2_tab3_1035 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1035
+DROP VIEW IF EXISTS view_3_tab3_1035 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12688,13 +12688,13 @@ SELECT pk FROM tab4 WHERE col0 <= 14
 8
 
 statement ok
-DROP VIEW view_1_tab4_1035
+DROP VIEW IF EXISTS view_1_tab4_1035 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1035
+DROP VIEW IF EXISTS view_2_tab4_1035 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1035
+DROP VIEW IF EXISTS view_3_tab4_1035 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12812,13 +12812,13 @@ SELECT pk FROM tab0 WHERE col3 >= 19 OR col4 >= 22.98 OR (col3 >= 80)
 9
 
 statement ok
-DROP VIEW view_1_tab0_1036
+DROP VIEW IF EXISTS view_1_tab0_1036 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1036
+DROP VIEW IF EXISTS view_2_tab0_1036 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1036
+DROP VIEW IF EXISTS view_3_tab0_1036 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12936,13 +12936,13 @@ SELECT pk FROM tab1 WHERE col3 >= 19 OR col4 >= 22.98 OR (col3 >= 80)
 9
 
 statement ok
-DROP VIEW view_1_tab1_1036
+DROP VIEW IF EXISTS view_1_tab1_1036 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1036
+DROP VIEW IF EXISTS view_2_tab1_1036 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1036
+DROP VIEW IF EXISTS view_3_tab1_1036 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13060,13 +13060,13 @@ SELECT pk FROM tab2 WHERE col3 >= 19 OR col4 >= 22.98 OR (col3 >= 80)
 9
 
 statement ok
-DROP VIEW view_1_tab2_1036
+DROP VIEW IF EXISTS view_1_tab2_1036 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1036
+DROP VIEW IF EXISTS view_2_tab2_1036 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1036
+DROP VIEW IF EXISTS view_3_tab2_1036 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13184,13 +13184,13 @@ SELECT pk FROM tab3 WHERE col3 >= 19 OR col4 >= 22.98 OR (col3 >= 80)
 9
 
 statement ok
-DROP VIEW view_1_tab3_1036
+DROP VIEW IF EXISTS view_1_tab3_1036 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1036
+DROP VIEW IF EXISTS view_2_tab3_1036 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1036
+DROP VIEW IF EXISTS view_3_tab3_1036 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13308,13 +13308,13 @@ SELECT pk FROM tab4 WHERE col3 >= 19 OR col4 >= 22.98 OR (col3 >= 80)
 9
 
 statement ok
-DROP VIEW view_1_tab4_1036
+DROP VIEW IF EXISTS view_1_tab4_1036 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1036
+DROP VIEW IF EXISTS view_2_tab4_1036 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1036
+DROP VIEW IF EXISTS view_3_tab4_1036 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13407,13 +13407,13 @@ SELECT pk FROM tab0 WHERE col3 <= 78
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab0_1037
+DROP VIEW IF EXISTS view_1_tab0_1037 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1037
+DROP VIEW IF EXISTS view_2_tab0_1037 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1037
+DROP VIEW IF EXISTS view_3_tab0_1037 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13506,13 +13506,13 @@ SELECT pk FROM tab1 WHERE col3 <= 78
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab1_1037
+DROP VIEW IF EXISTS view_1_tab1_1037 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1037
+DROP VIEW IF EXISTS view_2_tab1_1037 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1037
+DROP VIEW IF EXISTS view_3_tab1_1037 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13605,13 +13605,13 @@ SELECT pk FROM tab2 WHERE col3 <= 78
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab2_1037
+DROP VIEW IF EXISTS view_1_tab2_1037 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1037
+DROP VIEW IF EXISTS view_2_tab2_1037 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1037
+DROP VIEW IF EXISTS view_3_tab2_1037 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13704,13 +13704,13 @@ SELECT pk FROM tab3 WHERE col3 <= 78
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab3_1037
+DROP VIEW IF EXISTS view_1_tab3_1037 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1037
+DROP VIEW IF EXISTS view_2_tab3_1037 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1037
+DROP VIEW IF EXISTS view_3_tab3_1037 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13803,13 +13803,13 @@ SELECT pk FROM tab4 WHERE col3 <= 78
 9 values hashing to b62312116f93d37c7a952ee38494f224
 
 statement ok
-DROP VIEW view_1_tab4_1037
+DROP VIEW IF EXISTS view_1_tab4_1037 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1037
+DROP VIEW IF EXISTS view_2_tab4_1037 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1037
+DROP VIEW IF EXISTS view_3_tab4_1037 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13902,13 +13902,13 @@ SELECT pk FROM tab0 WHERE (((col3 IS NULL) AND col3 > 51 OR col3 >= 87))
 6
 
 statement ok
-DROP VIEW view_1_tab0_1038
+DROP VIEW IF EXISTS view_1_tab0_1038 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1038
+DROP VIEW IF EXISTS view_2_tab0_1038 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1038
+DROP VIEW IF EXISTS view_3_tab0_1038 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14001,13 +14001,13 @@ SELECT pk FROM tab1 WHERE (((col3 IS NULL) AND col3 > 51 OR col3 >= 87))
 6
 
 statement ok
-DROP VIEW view_1_tab1_1038
+DROP VIEW IF EXISTS view_1_tab1_1038 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1038
+DROP VIEW IF EXISTS view_2_tab1_1038 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1038
+DROP VIEW IF EXISTS view_3_tab1_1038 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14100,13 +14100,13 @@ SELECT pk FROM tab2 WHERE (((col3 IS NULL) AND col3 > 51 OR col3 >= 87))
 6
 
 statement ok
-DROP VIEW view_1_tab2_1038
+DROP VIEW IF EXISTS view_1_tab2_1038 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1038
+DROP VIEW IF EXISTS view_2_tab2_1038 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1038
+DROP VIEW IF EXISTS view_3_tab2_1038 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14199,13 +14199,13 @@ SELECT pk FROM tab3 WHERE (((col3 IS NULL) AND col3 > 51 OR col3 >= 87))
 6
 
 statement ok
-DROP VIEW view_1_tab3_1038
+DROP VIEW IF EXISTS view_1_tab3_1038 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1038
+DROP VIEW IF EXISTS view_2_tab3_1038 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1038
+DROP VIEW IF EXISTS view_3_tab3_1038 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14298,13 +14298,13 @@ SELECT pk FROM tab4 WHERE (((col3 IS NULL) AND col3 > 51 OR col3 >= 87))
 6
 
 statement ok
-DROP VIEW view_1_tab4_1038
+DROP VIEW IF EXISTS view_1_tab4_1038 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1038
+DROP VIEW IF EXISTS view_2_tab4_1038 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1038
+DROP VIEW IF EXISTS view_3_tab4_1038 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14390,13 +14390,13 @@ SELECT pk FROM tab0 WHERE col4 = 51.56
 ----
 
 statement ok
-DROP VIEW view_1_tab0_1039
+DROP VIEW IF EXISTS view_1_tab0_1039 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1039
+DROP VIEW IF EXISTS view_2_tab0_1039 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1039
+DROP VIEW IF EXISTS view_3_tab0_1039 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14482,13 +14482,13 @@ SELECT pk FROM tab1 WHERE col4 = 51.56
 ----
 
 statement ok
-DROP VIEW view_1_tab1_1039
+DROP VIEW IF EXISTS view_1_tab1_1039 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1039
+DROP VIEW IF EXISTS view_2_tab1_1039 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1039
+DROP VIEW IF EXISTS view_3_tab1_1039 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14574,13 +14574,13 @@ SELECT pk FROM tab2 WHERE col4 = 51.56
 ----
 
 statement ok
-DROP VIEW view_1_tab2_1039
+DROP VIEW IF EXISTS view_1_tab2_1039 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1039
+DROP VIEW IF EXISTS view_2_tab2_1039 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1039
+DROP VIEW IF EXISTS view_3_tab2_1039 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14666,13 +14666,13 @@ SELECT pk FROM tab3 WHERE col4 = 51.56
 ----
 
 statement ok
-DROP VIEW view_1_tab3_1039
+DROP VIEW IF EXISTS view_1_tab3_1039 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1039
+DROP VIEW IF EXISTS view_2_tab3_1039 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1039
+DROP VIEW IF EXISTS view_3_tab3_1039 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14758,13 +14758,13 @@ SELECT pk FROM tab4 WHERE col4 = 51.56
 ----
 
 statement ok
-DROP VIEW view_1_tab4_1039
+DROP VIEW IF EXISTS view_1_tab4_1039 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1039
+DROP VIEW IF EXISTS view_2_tab4_1039 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1039
+DROP VIEW IF EXISTS view_3_tab4_1039 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14850,13 +14850,13 @@ SELECT pk FROM tab0 WHERE (col3 >= 91)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_1040
+DROP VIEW IF EXISTS view_1_tab0_1040 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1040
+DROP VIEW IF EXISTS view_2_tab0_1040 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1040
+DROP VIEW IF EXISTS view_3_tab0_1040 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14942,13 +14942,13 @@ SELECT pk FROM tab1 WHERE (col3 >= 91)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_1040
+DROP VIEW IF EXISTS view_1_tab1_1040 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1040
+DROP VIEW IF EXISTS view_2_tab1_1040 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1040
+DROP VIEW IF EXISTS view_3_tab1_1040 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15034,13 +15034,13 @@ SELECT pk FROM tab2 WHERE (col3 >= 91)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_1040
+DROP VIEW IF EXISTS view_1_tab2_1040 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1040
+DROP VIEW IF EXISTS view_2_tab2_1040 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1040
+DROP VIEW IF EXISTS view_3_tab2_1040 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15126,13 +15126,13 @@ SELECT pk FROM tab3 WHERE (col3 >= 91)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_1040
+DROP VIEW IF EXISTS view_1_tab3_1040 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1040
+DROP VIEW IF EXISTS view_2_tab3_1040 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1040
+DROP VIEW IF EXISTS view_3_tab3_1040 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15218,13 +15218,13 @@ SELECT pk FROM tab4 WHERE (col3 >= 91)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_1040
+DROP VIEW IF EXISTS view_1_tab4_1040 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1040
+DROP VIEW IF EXISTS view_2_tab4_1040 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1040
+DROP VIEW IF EXISTS view_3_tab4_1040 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15310,13 +15310,13 @@ SELECT pk FROM tab0 WHERE ((col4 <= 6.77) AND col3 > 79)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_1041
+DROP VIEW IF EXISTS view_1_tab0_1041 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1041
+DROP VIEW IF EXISTS view_2_tab0_1041 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1041
+DROP VIEW IF EXISTS view_3_tab0_1041 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15402,13 +15402,13 @@ SELECT pk FROM tab1 WHERE ((col4 <= 6.77) AND col3 > 79)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_1041
+DROP VIEW IF EXISTS view_1_tab1_1041 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1041
+DROP VIEW IF EXISTS view_2_tab1_1041 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1041
+DROP VIEW IF EXISTS view_3_tab1_1041 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15494,13 +15494,13 @@ SELECT pk FROM tab2 WHERE ((col4 <= 6.77) AND col3 > 79)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_1041
+DROP VIEW IF EXISTS view_1_tab2_1041 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1041
+DROP VIEW IF EXISTS view_2_tab2_1041 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1041
+DROP VIEW IF EXISTS view_3_tab2_1041 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15586,13 +15586,13 @@ SELECT pk FROM tab3 WHERE ((col4 <= 6.77) AND col3 > 79)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_1041
+DROP VIEW IF EXISTS view_1_tab3_1041 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1041
+DROP VIEW IF EXISTS view_2_tab3_1041 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1041
+DROP VIEW IF EXISTS view_3_tab3_1041 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15678,13 +15678,13 @@ SELECT pk FROM tab4 WHERE ((col4 <= 6.77) AND col3 > 79)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_1041
+DROP VIEW IF EXISTS view_1_tab4_1041 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1041
+DROP VIEW IF EXISTS view_2_tab4_1041 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1041
+DROP VIEW IF EXISTS view_3_tab4_1041 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15777,13 +15777,13 @@ SELECT pk FROM tab0 WHERE ((col0 > 16 OR ((col0 < 9 OR col3 IN (SELECT col0 FROM
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab0_1042
+DROP VIEW IF EXISTS view_1_tab0_1042 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1042
+DROP VIEW IF EXISTS view_2_tab0_1042 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1042
+DROP VIEW IF EXISTS view_3_tab0_1042 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15876,13 +15876,13 @@ SELECT pk FROM tab1 WHERE ((col0 > 16 OR ((col0 < 9 OR col3 IN (SELECT col0 FROM
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab1_1042
+DROP VIEW IF EXISTS view_1_tab1_1042 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1042
+DROP VIEW IF EXISTS view_2_tab1_1042 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1042
+DROP VIEW IF EXISTS view_3_tab1_1042 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15975,13 +15975,13 @@ SELECT pk FROM tab2 WHERE ((col0 > 16 OR ((col0 < 9 OR col3 IN (SELECT col0 FROM
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab2_1042
+DROP VIEW IF EXISTS view_1_tab2_1042 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1042
+DROP VIEW IF EXISTS view_2_tab2_1042 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1042
+DROP VIEW IF EXISTS view_3_tab2_1042 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16074,13 +16074,13 @@ SELECT pk FROM tab3 WHERE ((col0 > 16 OR ((col0 < 9 OR col3 IN (SELECT col0 FROM
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab3_1042
+DROP VIEW IF EXISTS view_1_tab3_1042 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1042
+DROP VIEW IF EXISTS view_2_tab3_1042 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1042
+DROP VIEW IF EXISTS view_3_tab3_1042 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16173,13 +16173,13 @@ SELECT pk FROM tab4 WHERE ((col0 > 16 OR ((col0 < 9 OR col3 IN (SELECT col0 FROM
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab4_1042
+DROP VIEW IF EXISTS view_1_tab4_1042 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1042
+DROP VIEW IF EXISTS view_2_tab4_1042 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1042
+DROP VIEW IF EXISTS view_3_tab4_1042 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16299,13 +16299,13 @@ SELECT pk FROM tab0 WHERE col1 > 21.41
 5
 
 statement ok
-DROP VIEW view_1_tab0_1044
+DROP VIEW IF EXISTS view_1_tab0_1044 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1044
+DROP VIEW IF EXISTS view_2_tab0_1044 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1044
+DROP VIEW IF EXISTS view_3_tab0_1044 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16425,13 +16425,13 @@ SELECT pk FROM tab1 WHERE col1 > 21.41
 5
 
 statement ok
-DROP VIEW view_1_tab1_1044
+DROP VIEW IF EXISTS view_1_tab1_1044 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1044
+DROP VIEW IF EXISTS view_2_tab1_1044 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1044
+DROP VIEW IF EXISTS view_3_tab1_1044 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16551,13 +16551,13 @@ SELECT pk FROM tab2 WHERE col1 > 21.41
 5
 
 statement ok
-DROP VIEW view_1_tab2_1044
+DROP VIEW IF EXISTS view_1_tab2_1044 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1044
+DROP VIEW IF EXISTS view_2_tab2_1044 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1044
+DROP VIEW IF EXISTS view_3_tab2_1044 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16677,13 +16677,13 @@ SELECT pk FROM tab3 WHERE col1 > 21.41
 5
 
 statement ok
-DROP VIEW view_1_tab3_1044
+DROP VIEW IF EXISTS view_1_tab3_1044 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1044
+DROP VIEW IF EXISTS view_2_tab3_1044 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1044
+DROP VIEW IF EXISTS view_3_tab3_1044 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16803,13 +16803,13 @@ SELECT pk FROM tab4 WHERE col1 > 21.41
 5
 
 statement ok
-DROP VIEW view_1_tab4_1044
+DROP VIEW IF EXISTS view_1_tab4_1044 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1044
+DROP VIEW IF EXISTS view_2_tab4_1044 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1044
+DROP VIEW IF EXISTS view_3_tab4_1044 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16923,13 +16923,13 @@ SELECT pk FROM tab0 WHERE col1 >= 61.10 OR col4 > 87.57 AND col0 > 74
 5
 
 statement ok
-DROP VIEW view_1_tab0_1045
+DROP VIEW IF EXISTS view_1_tab0_1045 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1045
+DROP VIEW IF EXISTS view_2_tab0_1045 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1045
+DROP VIEW IF EXISTS view_3_tab0_1045 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17043,13 +17043,13 @@ SELECT pk FROM tab1 WHERE col1 >= 61.10 OR col4 > 87.57 AND col0 > 74
 5
 
 statement ok
-DROP VIEW view_1_tab1_1045
+DROP VIEW IF EXISTS view_1_tab1_1045 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1045
+DROP VIEW IF EXISTS view_2_tab1_1045 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1045
+DROP VIEW IF EXISTS view_3_tab1_1045 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17163,13 +17163,13 @@ SELECT pk FROM tab2 WHERE col1 >= 61.10 OR col4 > 87.57 AND col0 > 74
 5
 
 statement ok
-DROP VIEW view_1_tab2_1045
+DROP VIEW IF EXISTS view_1_tab2_1045 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1045
+DROP VIEW IF EXISTS view_2_tab2_1045 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1045
+DROP VIEW IF EXISTS view_3_tab2_1045 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17283,13 +17283,13 @@ SELECT pk FROM tab3 WHERE col1 >= 61.10 OR col4 > 87.57 AND col0 > 74
 5
 
 statement ok
-DROP VIEW view_1_tab3_1045
+DROP VIEW IF EXISTS view_1_tab3_1045 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1045
+DROP VIEW IF EXISTS view_2_tab3_1045 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1045
+DROP VIEW IF EXISTS view_3_tab3_1045 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17403,13 +17403,13 @@ SELECT pk FROM tab4 WHERE col1 >= 61.10 OR col4 > 87.57 AND col0 > 74
 5
 
 statement ok
-DROP VIEW view_1_tab4_1045
+DROP VIEW IF EXISTS view_1_tab4_1045 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1045
+DROP VIEW IF EXISTS view_2_tab4_1045 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1045
+DROP VIEW IF EXISTS view_3_tab4_1045 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17516,13 +17516,13 @@ SELECT pk FROM tab0 WHERE col4 >= 33.44 AND (col4 > 52.40)
 5
 
 statement ok
-DROP VIEW view_1_tab0_1046
+DROP VIEW IF EXISTS view_1_tab0_1046 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1046
+DROP VIEW IF EXISTS view_2_tab0_1046 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1046
+DROP VIEW IF EXISTS view_3_tab0_1046 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17629,13 +17629,13 @@ SELECT pk FROM tab1 WHERE col4 >= 33.44 AND (col4 > 52.40)
 5
 
 statement ok
-DROP VIEW view_1_tab1_1046
+DROP VIEW IF EXISTS view_1_tab1_1046 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1046
+DROP VIEW IF EXISTS view_2_tab1_1046 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1046
+DROP VIEW IF EXISTS view_3_tab1_1046 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17742,13 +17742,13 @@ SELECT pk FROM tab2 WHERE col4 >= 33.44 AND (col4 > 52.40)
 5
 
 statement ok
-DROP VIEW view_1_tab2_1046
+DROP VIEW IF EXISTS view_1_tab2_1046 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1046
+DROP VIEW IF EXISTS view_2_tab2_1046 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1046
+DROP VIEW IF EXISTS view_3_tab2_1046 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17855,13 +17855,13 @@ SELECT pk FROM tab3 WHERE col4 >= 33.44 AND (col4 > 52.40)
 5
 
 statement ok
-DROP VIEW view_1_tab3_1046
+DROP VIEW IF EXISTS view_1_tab3_1046 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1046
+DROP VIEW IF EXISTS view_2_tab3_1046 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1046
+DROP VIEW IF EXISTS view_3_tab3_1046 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17968,13 +17968,13 @@ SELECT pk FROM tab4 WHERE col4 >= 33.44 AND (col4 > 52.40)
 5
 
 statement ok
-DROP VIEW view_1_tab4_1046
+DROP VIEW IF EXISTS view_1_tab4_1046 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1046
+DROP VIEW IF EXISTS view_2_tab4_1046 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1046
+DROP VIEW IF EXISTS view_3_tab4_1046 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18074,13 +18074,13 @@ SELECT pk FROM tab0 WHERE (((col0 < 13)))
 7
 
 statement ok
-DROP VIEW view_1_tab0_1048
+DROP VIEW IF EXISTS view_1_tab0_1048 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1048
+DROP VIEW IF EXISTS view_2_tab0_1048 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1048
+DROP VIEW IF EXISTS view_3_tab0_1048 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18180,13 +18180,13 @@ SELECT pk FROM tab1 WHERE (((col0 < 13)))
 7
 
 statement ok
-DROP VIEW view_1_tab1_1048
+DROP VIEW IF EXISTS view_1_tab1_1048 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1048
+DROP VIEW IF EXISTS view_2_tab1_1048 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1048
+DROP VIEW IF EXISTS view_3_tab1_1048 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18286,13 +18286,13 @@ SELECT pk FROM tab2 WHERE (((col0 < 13)))
 7
 
 statement ok
-DROP VIEW view_1_tab2_1048
+DROP VIEW IF EXISTS view_1_tab2_1048 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1048
+DROP VIEW IF EXISTS view_2_tab2_1048 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1048
+DROP VIEW IF EXISTS view_3_tab2_1048 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18392,13 +18392,13 @@ SELECT pk FROM tab3 WHERE (((col0 < 13)))
 7
 
 statement ok
-DROP VIEW view_1_tab3_1048
+DROP VIEW IF EXISTS view_1_tab3_1048 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1048
+DROP VIEW IF EXISTS view_2_tab3_1048 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1048
+DROP VIEW IF EXISTS view_3_tab3_1048 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18498,13 +18498,13 @@ SELECT pk FROM tab4 WHERE (((col0 < 13)))
 7
 
 statement ok
-DROP VIEW view_1_tab4_1048
+DROP VIEW IF EXISTS view_1_tab4_1048 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1048
+DROP VIEW IF EXISTS view_2_tab4_1048 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1048
+DROP VIEW IF EXISTS view_3_tab4_1048 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18604,13 +18604,13 @@ SELECT pk FROM tab0 WHERE col0 <= 13
 7
 
 statement ok
-DROP VIEW view_1_tab0_1049
+DROP VIEW IF EXISTS view_1_tab0_1049 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1049
+DROP VIEW IF EXISTS view_2_tab0_1049 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1049
+DROP VIEW IF EXISTS view_3_tab0_1049 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18710,13 +18710,13 @@ SELECT pk FROM tab1 WHERE col0 <= 13
 7
 
 statement ok
-DROP VIEW view_1_tab1_1049
+DROP VIEW IF EXISTS view_1_tab1_1049 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1049
+DROP VIEW IF EXISTS view_2_tab1_1049 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1049
+DROP VIEW IF EXISTS view_3_tab1_1049 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18816,13 +18816,13 @@ SELECT pk FROM tab2 WHERE col0 <= 13
 7
 
 statement ok
-DROP VIEW view_1_tab2_1049
+DROP VIEW IF EXISTS view_1_tab2_1049 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1049
+DROP VIEW IF EXISTS view_2_tab2_1049 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1049
+DROP VIEW IF EXISTS view_3_tab2_1049 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18922,13 +18922,13 @@ SELECT pk FROM tab3 WHERE col0 <= 13
 7
 
 statement ok
-DROP VIEW view_1_tab3_1049
+DROP VIEW IF EXISTS view_1_tab3_1049 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1049
+DROP VIEW IF EXISTS view_2_tab3_1049 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1049
+DROP VIEW IF EXISTS view_3_tab3_1049 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19028,13 +19028,13 @@ SELECT pk FROM tab4 WHERE col0 <= 13
 7
 
 statement ok
-DROP VIEW view_1_tab4_1049
+DROP VIEW IF EXISTS view_1_tab4_1049 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1049
+DROP VIEW IF EXISTS view_2_tab4_1049 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1049
+DROP VIEW IF EXISTS view_3_tab4_1049 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19123,13 +19123,13 @@ SELECT pk FROM tab0 WHERE (((col3 >= 86 OR col0 > 23) OR (col0 <= 84 AND col4 >=
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_1050
+DROP VIEW IF EXISTS view_1_tab0_1050 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1050
+DROP VIEW IF EXISTS view_2_tab0_1050 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1050
+DROP VIEW IF EXISTS view_3_tab0_1050 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19218,13 +19218,13 @@ SELECT pk FROM tab1 WHERE (((col3 >= 86 OR col0 > 23) OR (col0 <= 84 AND col4 >=
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_1050
+DROP VIEW IF EXISTS view_1_tab1_1050 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1050
+DROP VIEW IF EXISTS view_2_tab1_1050 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1050
+DROP VIEW IF EXISTS view_3_tab1_1050 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19313,13 +19313,13 @@ SELECT pk FROM tab2 WHERE (((col3 >= 86 OR col0 > 23) OR (col0 <= 84 AND col4 >=
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_1050
+DROP VIEW IF EXISTS view_1_tab2_1050 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1050
+DROP VIEW IF EXISTS view_2_tab2_1050 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1050
+DROP VIEW IF EXISTS view_3_tab2_1050 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19408,13 +19408,13 @@ SELECT pk FROM tab3 WHERE (((col3 >= 86 OR col0 > 23) OR (col0 <= 84 AND col4 >=
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_1050
+DROP VIEW IF EXISTS view_1_tab3_1050 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1050
+DROP VIEW IF EXISTS view_2_tab3_1050 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1050
+DROP VIEW IF EXISTS view_3_tab3_1050 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19503,13 +19503,13 @@ SELECT pk FROM tab4 WHERE (((col3 >= 86 OR col0 > 23) OR (col0 <= 84 AND col4 >=
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_1050
+DROP VIEW IF EXISTS view_1_tab4_1050 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1050
+DROP VIEW IF EXISTS view_2_tab4_1050 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1050
+DROP VIEW IF EXISTS view_3_tab4_1050 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19629,13 +19629,13 @@ SELECT pk FROM tab0 WHERE col1 > 35.69
 5
 
 statement ok
-DROP VIEW view_1_tab0_1051
+DROP VIEW IF EXISTS view_1_tab0_1051 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1051
+DROP VIEW IF EXISTS view_2_tab0_1051 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1051
+DROP VIEW IF EXISTS view_3_tab0_1051 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19755,13 +19755,13 @@ SELECT pk FROM tab1 WHERE col1 > 35.69
 5
 
 statement ok
-DROP VIEW view_1_tab1_1051
+DROP VIEW IF EXISTS view_1_tab1_1051 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1051
+DROP VIEW IF EXISTS view_2_tab1_1051 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1051
+DROP VIEW IF EXISTS view_3_tab1_1051 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19881,13 +19881,13 @@ SELECT pk FROM tab2 WHERE col1 > 35.69
 5
 
 statement ok
-DROP VIEW view_1_tab2_1051
+DROP VIEW IF EXISTS view_1_tab2_1051 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1051
+DROP VIEW IF EXISTS view_2_tab2_1051 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1051
+DROP VIEW IF EXISTS view_3_tab2_1051 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20007,13 +20007,13 @@ SELECT pk FROM tab3 WHERE col1 > 35.69
 5
 
 statement ok
-DROP VIEW view_1_tab3_1051
+DROP VIEW IF EXISTS view_1_tab3_1051 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1051
+DROP VIEW IF EXISTS view_2_tab3_1051 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1051
+DROP VIEW IF EXISTS view_3_tab3_1051 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20133,13 +20133,13 @@ SELECT pk FROM tab4 WHERE col1 > 35.69
 5
 
 statement ok
-DROP VIEW view_1_tab4_1051
+DROP VIEW IF EXISTS view_1_tab4_1051 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1051
+DROP VIEW IF EXISTS view_2_tab4_1051 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1051
+DROP VIEW IF EXISTS view_3_tab4_1051 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20225,13 +20225,13 @@ SELECT pk FROM tab0 WHERE col1 >= 82.28 AND col4 IN (24.14,1.29,95.94,30.92)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_1052
+DROP VIEW IF EXISTS view_1_tab0_1052 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1052
+DROP VIEW IF EXISTS view_2_tab0_1052 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1052
+DROP VIEW IF EXISTS view_3_tab0_1052 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20317,13 +20317,13 @@ SELECT pk FROM tab1 WHERE col1 >= 82.28 AND col4 IN (24.14,1.29,95.94,30.92)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_1052
+DROP VIEW IF EXISTS view_1_tab1_1052 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1052
+DROP VIEW IF EXISTS view_2_tab1_1052 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1052
+DROP VIEW IF EXISTS view_3_tab1_1052 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20409,13 +20409,13 @@ SELECT pk FROM tab2 WHERE col1 >= 82.28 AND col4 IN (24.14,1.29,95.94,30.92)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_1052
+DROP VIEW IF EXISTS view_1_tab2_1052 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1052
+DROP VIEW IF EXISTS view_2_tab2_1052 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1052
+DROP VIEW IF EXISTS view_3_tab2_1052 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20501,13 +20501,13 @@ SELECT pk FROM tab3 WHERE col1 >= 82.28 AND col4 IN (24.14,1.29,95.94,30.92)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_1052
+DROP VIEW IF EXISTS view_1_tab3_1052 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1052
+DROP VIEW IF EXISTS view_2_tab3_1052 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1052
+DROP VIEW IF EXISTS view_3_tab3_1052 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20593,13 +20593,13 @@ SELECT pk FROM tab4 WHERE col1 >= 82.28 AND col4 IN (24.14,1.29,95.94,30.92)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_1052
+DROP VIEW IF EXISTS view_1_tab4_1052 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1052
+DROP VIEW IF EXISTS view_2_tab4_1052 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1052
+DROP VIEW IF EXISTS view_3_tab4_1052 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20685,13 +20685,13 @@ SELECT pk FROM tab0 WHERE (col1 >= 88.90 AND (col0 = 56)) AND ((col1 >= 39.62))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_1053
+DROP VIEW IF EXISTS view_1_tab0_1053 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1053
+DROP VIEW IF EXISTS view_2_tab0_1053 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1053
+DROP VIEW IF EXISTS view_3_tab0_1053 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20777,13 +20777,13 @@ SELECT pk FROM tab1 WHERE (col1 >= 88.90 AND (col0 = 56)) AND ((col1 >= 39.62))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_1053
+DROP VIEW IF EXISTS view_1_tab1_1053 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1053
+DROP VIEW IF EXISTS view_2_tab1_1053 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1053
+DROP VIEW IF EXISTS view_3_tab1_1053 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20869,13 +20869,13 @@ SELECT pk FROM tab2 WHERE (col1 >= 88.90 AND (col0 = 56)) AND ((col1 >= 39.62))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_1053
+DROP VIEW IF EXISTS view_1_tab2_1053 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1053
+DROP VIEW IF EXISTS view_2_tab2_1053 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1053
+DROP VIEW IF EXISTS view_3_tab2_1053 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20961,13 +20961,13 @@ SELECT pk FROM tab3 WHERE (col1 >= 88.90 AND (col0 = 56)) AND ((col1 >= 39.62))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_1053
+DROP VIEW IF EXISTS view_1_tab3_1053 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1053
+DROP VIEW IF EXISTS view_2_tab3_1053 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1053
+DROP VIEW IF EXISTS view_3_tab3_1053 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21053,13 +21053,13 @@ SELECT pk FROM tab4 WHERE (col1 >= 88.90 AND (col0 = 56)) AND ((col1 >= 39.62))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_1053
+DROP VIEW IF EXISTS view_1_tab4_1053 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1053
+DROP VIEW IF EXISTS view_2_tab4_1053 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1053
+DROP VIEW IF EXISTS view_3_tab4_1053 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21173,13 +21173,13 @@ SELECT pk FROM tab0 WHERE (col0 > 75) AND col4 <= 92.83 OR (col4 > 55.40 AND col
 6
 
 statement ok
-DROP VIEW view_1_tab0_1054
+DROP VIEW IF EXISTS view_1_tab0_1054 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1054
+DROP VIEW IF EXISTS view_2_tab0_1054 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1054
+DROP VIEW IF EXISTS view_3_tab0_1054 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21293,13 +21293,13 @@ SELECT pk FROM tab1 WHERE (col0 > 75) AND col4 <= 92.83 OR (col4 > 55.40 AND col
 6
 
 statement ok
-DROP VIEW view_1_tab1_1054
+DROP VIEW IF EXISTS view_1_tab1_1054 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1054
+DROP VIEW IF EXISTS view_2_tab1_1054 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1054
+DROP VIEW IF EXISTS view_3_tab1_1054 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21413,13 +21413,13 @@ SELECT pk FROM tab2 WHERE (col0 > 75) AND col4 <= 92.83 OR (col4 > 55.40 AND col
 6
 
 statement ok
-DROP VIEW view_1_tab2_1054
+DROP VIEW IF EXISTS view_1_tab2_1054 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1054
+DROP VIEW IF EXISTS view_2_tab2_1054 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1054
+DROP VIEW IF EXISTS view_3_tab2_1054 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21533,13 +21533,13 @@ SELECT pk FROM tab3 WHERE (col0 > 75) AND col4 <= 92.83 OR (col4 > 55.40 AND col
 6
 
 statement ok
-DROP VIEW view_1_tab3_1054
+DROP VIEW IF EXISTS view_1_tab3_1054 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1054
+DROP VIEW IF EXISTS view_2_tab3_1054 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1054
+DROP VIEW IF EXISTS view_3_tab3_1054 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21653,13 +21653,13 @@ SELECT pk FROM tab4 WHERE (col0 > 75) AND col4 <= 92.83 OR (col4 > 55.40 AND col
 6
 
 statement ok
-DROP VIEW view_1_tab4_1054
+DROP VIEW IF EXISTS view_1_tab4_1054 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1054
+DROP VIEW IF EXISTS view_2_tab4_1054 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1054
+DROP VIEW IF EXISTS view_3_tab4_1054 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21766,13 +21766,13 @@ SELECT pk FROM tab0 WHERE (col3 < 27)
 8
 
 statement ok
-DROP VIEW view_1_tab0_1055
+DROP VIEW IF EXISTS view_1_tab0_1055 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1055
+DROP VIEW IF EXISTS view_2_tab0_1055 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1055
+DROP VIEW IF EXISTS view_3_tab0_1055 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21879,13 +21879,13 @@ SELECT pk FROM tab1 WHERE (col3 < 27)
 8
 
 statement ok
-DROP VIEW view_1_tab1_1055
+DROP VIEW IF EXISTS view_1_tab1_1055 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1055
+DROP VIEW IF EXISTS view_2_tab1_1055 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1055
+DROP VIEW IF EXISTS view_3_tab1_1055 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21992,13 +21992,13 @@ SELECT pk FROM tab2 WHERE (col3 < 27)
 8
 
 statement ok
-DROP VIEW view_1_tab2_1055
+DROP VIEW IF EXISTS view_1_tab2_1055 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1055
+DROP VIEW IF EXISTS view_2_tab2_1055 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1055
+DROP VIEW IF EXISTS view_3_tab2_1055 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22105,13 +22105,13 @@ SELECT pk FROM tab3 WHERE (col3 < 27)
 8
 
 statement ok
-DROP VIEW view_1_tab3_1055
+DROP VIEW IF EXISTS view_1_tab3_1055 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1055
+DROP VIEW IF EXISTS view_2_tab3_1055 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1055
+DROP VIEW IF EXISTS view_3_tab3_1055 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22218,13 +22218,13 @@ SELECT pk FROM tab4 WHERE (col3 < 27)
 8
 
 statement ok
-DROP VIEW view_1_tab4_1055
+DROP VIEW IF EXISTS view_1_tab4_1055 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1055
+DROP VIEW IF EXISTS view_2_tab4_1055 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1055
+DROP VIEW IF EXISTS view_3_tab4_1055 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22313,13 +22313,13 @@ SELECT pk FROM tab0 WHERE col1 > 2.15 OR ((col1 <= 28.98 AND (col3 <= 90) OR col
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_1056
+DROP VIEW IF EXISTS view_1_tab0_1056 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1056
+DROP VIEW IF EXISTS view_2_tab0_1056 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1056
+DROP VIEW IF EXISTS view_3_tab0_1056 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22408,13 +22408,13 @@ SELECT pk FROM tab1 WHERE col1 > 2.15 OR ((col1 <= 28.98 AND (col3 <= 90) OR col
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_1056
+DROP VIEW IF EXISTS view_1_tab1_1056 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1056
+DROP VIEW IF EXISTS view_2_tab1_1056 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1056
+DROP VIEW IF EXISTS view_3_tab1_1056 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22503,13 +22503,13 @@ SELECT pk FROM tab2 WHERE col1 > 2.15 OR ((col1 <= 28.98 AND (col3 <= 90) OR col
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_1056
+DROP VIEW IF EXISTS view_1_tab2_1056 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1056
+DROP VIEW IF EXISTS view_2_tab2_1056 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1056
+DROP VIEW IF EXISTS view_3_tab2_1056 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22598,13 +22598,13 @@ SELECT pk FROM tab3 WHERE col1 > 2.15 OR ((col1 <= 28.98 AND (col3 <= 90) OR col
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_1056
+DROP VIEW IF EXISTS view_1_tab3_1056 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1056
+DROP VIEW IF EXISTS view_2_tab3_1056 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1056
+DROP VIEW IF EXISTS view_3_tab3_1056 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22693,13 +22693,13 @@ SELECT pk FROM tab4 WHERE col1 > 2.15 OR ((col1 <= 28.98 AND (col3 <= 90) OR col
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_1056
+DROP VIEW IF EXISTS view_1_tab4_1056 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1056
+DROP VIEW IF EXISTS view_2_tab4_1056 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1056
+DROP VIEW IF EXISTS view_3_tab4_1056 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22819,13 +22819,13 @@ SELECT pk FROM tab0 WHERE col1 < 63.29
 9
 
 statement ok
-DROP VIEW view_1_tab0_1057
+DROP VIEW IF EXISTS view_1_tab0_1057 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1057
+DROP VIEW IF EXISTS view_2_tab0_1057 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1057
+DROP VIEW IF EXISTS view_3_tab0_1057 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22945,13 +22945,13 @@ SELECT pk FROM tab1 WHERE col1 < 63.29
 9
 
 statement ok
-DROP VIEW view_1_tab1_1057
+DROP VIEW IF EXISTS view_1_tab1_1057 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1057
+DROP VIEW IF EXISTS view_2_tab1_1057 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1057
+DROP VIEW IF EXISTS view_3_tab1_1057 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23071,13 +23071,13 @@ SELECT pk FROM tab2 WHERE col1 < 63.29
 9
 
 statement ok
-DROP VIEW view_1_tab2_1057
+DROP VIEW IF EXISTS view_1_tab2_1057 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1057
+DROP VIEW IF EXISTS view_2_tab2_1057 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1057
+DROP VIEW IF EXISTS view_3_tab2_1057 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23197,13 +23197,13 @@ SELECT pk FROM tab3 WHERE col1 < 63.29
 9
 
 statement ok
-DROP VIEW view_1_tab3_1057
+DROP VIEW IF EXISTS view_1_tab3_1057 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1057
+DROP VIEW IF EXISTS view_2_tab3_1057 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1057
+DROP VIEW IF EXISTS view_3_tab3_1057 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23323,13 +23323,13 @@ SELECT pk FROM tab4 WHERE col1 < 63.29
 9
 
 statement ok
-DROP VIEW view_1_tab4_1057
+DROP VIEW IF EXISTS view_1_tab4_1057 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1057
+DROP VIEW IF EXISTS view_2_tab4_1057 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1057
+DROP VIEW IF EXISTS view_3_tab4_1057 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23415,13 +23415,13 @@ SELECT pk FROM tab0 WHERE ((col3 IN (80,75,14,23,85,2) AND col0 IS NULL OR (col0
 ----
 
 statement ok
-DROP VIEW view_1_tab0_1058
+DROP VIEW IF EXISTS view_1_tab0_1058 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1058
+DROP VIEW IF EXISTS view_2_tab0_1058 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1058
+DROP VIEW IF EXISTS view_3_tab0_1058 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23507,13 +23507,13 @@ SELECT pk FROM tab1 WHERE ((col3 IN (80,75,14,23,85,2) AND col0 IS NULL OR (col0
 ----
 
 statement ok
-DROP VIEW view_1_tab1_1058
+DROP VIEW IF EXISTS view_1_tab1_1058 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1058
+DROP VIEW IF EXISTS view_2_tab1_1058 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1058
+DROP VIEW IF EXISTS view_3_tab1_1058 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23599,13 +23599,13 @@ SELECT pk FROM tab2 WHERE ((col3 IN (80,75,14,23,85,2) AND col0 IS NULL OR (col0
 ----
 
 statement ok
-DROP VIEW view_1_tab2_1058
+DROP VIEW IF EXISTS view_1_tab2_1058 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1058
+DROP VIEW IF EXISTS view_2_tab2_1058 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1058
+DROP VIEW IF EXISTS view_3_tab2_1058 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23691,13 +23691,13 @@ SELECT pk FROM tab3 WHERE ((col3 IN (80,75,14,23,85,2) AND col0 IS NULL OR (col0
 ----
 
 statement ok
-DROP VIEW view_1_tab3_1058
+DROP VIEW IF EXISTS view_1_tab3_1058 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1058
+DROP VIEW IF EXISTS view_2_tab3_1058 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1058
+DROP VIEW IF EXISTS view_3_tab3_1058 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23783,13 +23783,13 @@ SELECT pk FROM tab4 WHERE ((col3 IN (80,75,14,23,85,2) AND col0 IS NULL OR (col0
 ----
 
 statement ok
-DROP VIEW view_1_tab4_1058
+DROP VIEW IF EXISTS view_1_tab4_1058 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1058
+DROP VIEW IF EXISTS view_2_tab4_1058 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1058
+DROP VIEW IF EXISTS view_3_tab4_1058 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23896,13 +23896,13 @@ SELECT pk FROM tab0 WHERE col4 >= 58.77
 5
 
 statement ok
-DROP VIEW view_1_tab0_1060
+DROP VIEW IF EXISTS view_1_tab0_1060 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1060
+DROP VIEW IF EXISTS view_2_tab0_1060 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1060
+DROP VIEW IF EXISTS view_3_tab0_1060 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24009,13 +24009,13 @@ SELECT pk FROM tab1 WHERE col4 >= 58.77
 5
 
 statement ok
-DROP VIEW view_1_tab1_1060
+DROP VIEW IF EXISTS view_1_tab1_1060 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1060
+DROP VIEW IF EXISTS view_2_tab1_1060 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1060
+DROP VIEW IF EXISTS view_3_tab1_1060 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24122,13 +24122,13 @@ SELECT pk FROM tab2 WHERE col4 >= 58.77
 5
 
 statement ok
-DROP VIEW view_1_tab2_1060
+DROP VIEW IF EXISTS view_1_tab2_1060 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1060
+DROP VIEW IF EXISTS view_2_tab2_1060 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1060
+DROP VIEW IF EXISTS view_3_tab2_1060 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24235,13 +24235,13 @@ SELECT pk FROM tab3 WHERE col4 >= 58.77
 5
 
 statement ok
-DROP VIEW view_1_tab3_1060
+DROP VIEW IF EXISTS view_1_tab3_1060 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1060
+DROP VIEW IF EXISTS view_2_tab3_1060 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1060
+DROP VIEW IF EXISTS view_3_tab3_1060 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24348,13 +24348,13 @@ SELECT pk FROM tab4 WHERE col4 >= 58.77
 5
 
 statement ok
-DROP VIEW view_1_tab4_1060
+DROP VIEW IF EXISTS view_1_tab4_1060 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1060
+DROP VIEW IF EXISTS view_2_tab4_1060 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1060
+DROP VIEW IF EXISTS view_3_tab4_1060 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24447,13 +24447,13 @@ SELECT pk FROM tab0 WHERE col0 >= 9
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab0_1061
+DROP VIEW IF EXISTS view_1_tab0_1061 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1061
+DROP VIEW IF EXISTS view_2_tab0_1061 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1061
+DROP VIEW IF EXISTS view_3_tab0_1061 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24546,13 +24546,13 @@ SELECT pk FROM tab1 WHERE col0 >= 9
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab1_1061
+DROP VIEW IF EXISTS view_1_tab1_1061 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1061
+DROP VIEW IF EXISTS view_2_tab1_1061 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1061
+DROP VIEW IF EXISTS view_3_tab1_1061 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24645,13 +24645,13 @@ SELECT pk FROM tab2 WHERE col0 >= 9
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab2_1061
+DROP VIEW IF EXISTS view_1_tab2_1061 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1061
+DROP VIEW IF EXISTS view_2_tab2_1061 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1061
+DROP VIEW IF EXISTS view_3_tab2_1061 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24744,13 +24744,13 @@ SELECT pk FROM tab3 WHERE col0 >= 9
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab3_1061
+DROP VIEW IF EXISTS view_1_tab3_1061 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1061
+DROP VIEW IF EXISTS view_2_tab3_1061 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1061
+DROP VIEW IF EXISTS view_3_tab3_1061 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24843,13 +24843,13 @@ SELECT pk FROM tab4 WHERE col0 >= 9
 9 values hashing to 39e3d4d27bae24c9e33e78b000cc7d61
 
 statement ok
-DROP VIEW view_1_tab4_1061
+DROP VIEW IF EXISTS view_1_tab4_1061 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1061
+DROP VIEW IF EXISTS view_2_tab4_1061 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1061
+DROP VIEW IF EXISTS view_3_tab4_1061 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24938,13 +24938,13 @@ SELECT pk FROM tab0 WHERE col4 < 89.93
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_1062
+DROP VIEW IF EXISTS view_1_tab0_1062 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1062
+DROP VIEW IF EXISTS view_2_tab0_1062 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1062
+DROP VIEW IF EXISTS view_3_tab0_1062 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25033,13 +25033,13 @@ SELECT pk FROM tab1 WHERE col4 < 89.93
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_1062
+DROP VIEW IF EXISTS view_1_tab1_1062 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1062
+DROP VIEW IF EXISTS view_2_tab1_1062 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1062
+DROP VIEW IF EXISTS view_3_tab1_1062 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25128,13 +25128,13 @@ SELECT pk FROM tab2 WHERE col4 < 89.93
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_1062
+DROP VIEW IF EXISTS view_1_tab2_1062 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1062
+DROP VIEW IF EXISTS view_2_tab2_1062 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1062
+DROP VIEW IF EXISTS view_3_tab2_1062 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25223,13 +25223,13 @@ SELECT pk FROM tab3 WHERE col4 < 89.93
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_1062
+DROP VIEW IF EXISTS view_1_tab3_1062 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1062
+DROP VIEW IF EXISTS view_2_tab3_1062 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1062
+DROP VIEW IF EXISTS view_3_tab3_1062 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25318,13 +25318,13 @@ SELECT pk FROM tab4 WHERE col4 < 89.93
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_1062
+DROP VIEW IF EXISTS view_1_tab4_1062 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1062
+DROP VIEW IF EXISTS view_2_tab4_1062 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1062
+DROP VIEW IF EXISTS view_3_tab4_1062 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25417,13 +25417,13 @@ SELECT pk FROM tab0 WHERE (col3 > 18) OR col0 > 25 OR col1 IS NULL AND (((col4 >
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab0_1063
+DROP VIEW IF EXISTS view_1_tab0_1063 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1063
+DROP VIEW IF EXISTS view_2_tab0_1063 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1063
+DROP VIEW IF EXISTS view_3_tab0_1063 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25516,13 +25516,13 @@ SELECT pk FROM tab1 WHERE (col3 > 18) OR col0 > 25 OR col1 IS NULL AND (((col4 >
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab1_1063
+DROP VIEW IF EXISTS view_1_tab1_1063 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1063
+DROP VIEW IF EXISTS view_2_tab1_1063 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1063
+DROP VIEW IF EXISTS view_3_tab1_1063 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25615,13 +25615,13 @@ SELECT pk FROM tab2 WHERE (col3 > 18) OR col0 > 25 OR col1 IS NULL AND (((col4 >
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab2_1063
+DROP VIEW IF EXISTS view_1_tab2_1063 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1063
+DROP VIEW IF EXISTS view_2_tab2_1063 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1063
+DROP VIEW IF EXISTS view_3_tab2_1063 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25714,13 +25714,13 @@ SELECT pk FROM tab3 WHERE (col3 > 18) OR col0 > 25 OR col1 IS NULL AND (((col4 >
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab3_1063
+DROP VIEW IF EXISTS view_1_tab3_1063 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1063
+DROP VIEW IF EXISTS view_2_tab3_1063 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1063
+DROP VIEW IF EXISTS view_3_tab3_1063 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25813,13 +25813,13 @@ SELECT pk FROM tab4 WHERE (col3 > 18) OR col0 > 25 OR col1 IS NULL AND (((col4 >
 9 values hashing to 0b2f3ce47428ebec5f2931eddc864093
 
 statement ok
-DROP VIEW view_1_tab4_1063
+DROP VIEW IF EXISTS view_1_tab4_1063 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1063
+DROP VIEW IF EXISTS view_2_tab4_1063 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1063
+DROP VIEW IF EXISTS view_3_tab4_1063 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25912,13 +25912,13 @@ SELECT pk FROM tab0 WHERE col3 > 77
 6
 
 statement ok
-DROP VIEW view_1_tab0_1064
+DROP VIEW IF EXISTS view_1_tab0_1064 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1064
+DROP VIEW IF EXISTS view_2_tab0_1064 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1064
+DROP VIEW IF EXISTS view_3_tab0_1064 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26011,13 +26011,13 @@ SELECT pk FROM tab1 WHERE col3 > 77
 6
 
 statement ok
-DROP VIEW view_1_tab1_1064
+DROP VIEW IF EXISTS view_1_tab1_1064 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1064
+DROP VIEW IF EXISTS view_2_tab1_1064 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1064
+DROP VIEW IF EXISTS view_3_tab1_1064 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26110,13 +26110,13 @@ SELECT pk FROM tab2 WHERE col3 > 77
 6
 
 statement ok
-DROP VIEW view_1_tab2_1064
+DROP VIEW IF EXISTS view_1_tab2_1064 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1064
+DROP VIEW IF EXISTS view_2_tab2_1064 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1064
+DROP VIEW IF EXISTS view_3_tab2_1064 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26209,13 +26209,13 @@ SELECT pk FROM tab3 WHERE col3 > 77
 6
 
 statement ok
-DROP VIEW view_1_tab3_1064
+DROP VIEW IF EXISTS view_1_tab3_1064 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1064
+DROP VIEW IF EXISTS view_2_tab3_1064 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1064
+DROP VIEW IF EXISTS view_3_tab3_1064 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26308,13 +26308,13 @@ SELECT pk FROM tab4 WHERE col3 > 77
 6
 
 statement ok
-DROP VIEW view_1_tab4_1064
+DROP VIEW IF EXISTS view_1_tab4_1064 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1064
+DROP VIEW IF EXISTS view_2_tab4_1064 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1064
+DROP VIEW IF EXISTS view_3_tab4_1064 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26421,13 +26421,13 @@ SELECT pk FROM tab0 WHERE (col0 < 19)
 8
 
 statement ok
-DROP VIEW view_1_tab0_1065
+DROP VIEW IF EXISTS view_1_tab0_1065 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1065
+DROP VIEW IF EXISTS view_2_tab0_1065 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1065
+DROP VIEW IF EXISTS view_3_tab0_1065 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26534,13 +26534,13 @@ SELECT pk FROM tab1 WHERE (col0 < 19)
 8
 
 statement ok
-DROP VIEW view_1_tab1_1065
+DROP VIEW IF EXISTS view_1_tab1_1065 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1065
+DROP VIEW IF EXISTS view_2_tab1_1065 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1065
+DROP VIEW IF EXISTS view_3_tab1_1065 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26647,13 +26647,13 @@ SELECT pk FROM tab2 WHERE (col0 < 19)
 8
 
 statement ok
-DROP VIEW view_1_tab2_1065
+DROP VIEW IF EXISTS view_1_tab2_1065 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1065
+DROP VIEW IF EXISTS view_2_tab2_1065 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1065
+DROP VIEW IF EXISTS view_3_tab2_1065 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26760,13 +26760,13 @@ SELECT pk FROM tab3 WHERE (col0 < 19)
 8
 
 statement ok
-DROP VIEW view_1_tab3_1065
+DROP VIEW IF EXISTS view_1_tab3_1065 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1065
+DROP VIEW IF EXISTS view_2_tab3_1065 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1065
+DROP VIEW IF EXISTS view_3_tab3_1065 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26873,13 +26873,13 @@ SELECT pk FROM tab4 WHERE (col0 < 19)
 8
 
 statement ok
-DROP VIEW view_1_tab4_1065
+DROP VIEW IF EXISTS view_1_tab4_1065 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1065
+DROP VIEW IF EXISTS view_2_tab4_1065 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1065
+DROP VIEW IF EXISTS view_3_tab4_1065 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26972,13 +26972,13 @@ SELECT pk FROM tab0 WHERE col1 > 90.92
 5
 
 statement ok
-DROP VIEW view_1_tab0_1066
+DROP VIEW IF EXISTS view_1_tab0_1066 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1066
+DROP VIEW IF EXISTS view_2_tab0_1066 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1066
+DROP VIEW IF EXISTS view_3_tab0_1066 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27071,13 +27071,13 @@ SELECT pk FROM tab1 WHERE col1 > 90.92
 5
 
 statement ok
-DROP VIEW view_1_tab1_1066
+DROP VIEW IF EXISTS view_1_tab1_1066 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1066
+DROP VIEW IF EXISTS view_2_tab1_1066 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1066
+DROP VIEW IF EXISTS view_3_tab1_1066 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27170,13 +27170,13 @@ SELECT pk FROM tab2 WHERE col1 > 90.92
 5
 
 statement ok
-DROP VIEW view_1_tab2_1066
+DROP VIEW IF EXISTS view_1_tab2_1066 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1066
+DROP VIEW IF EXISTS view_2_tab2_1066 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1066
+DROP VIEW IF EXISTS view_3_tab2_1066 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27269,13 +27269,13 @@ SELECT pk FROM tab3 WHERE col1 > 90.92
 5
 
 statement ok
-DROP VIEW view_1_tab3_1066
+DROP VIEW IF EXISTS view_1_tab3_1066 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1066
+DROP VIEW IF EXISTS view_2_tab3_1066 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1066
+DROP VIEW IF EXISTS view_3_tab3_1066 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27368,13 +27368,13 @@ SELECT pk FROM tab4 WHERE col1 > 90.92
 5
 
 statement ok
-DROP VIEW view_1_tab4_1066
+DROP VIEW IF EXISTS view_1_tab4_1066 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1066
+DROP VIEW IF EXISTS view_2_tab4_1066 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1066
+DROP VIEW IF EXISTS view_3_tab4_1066 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27467,13 +27467,13 @@ SELECT pk FROM tab0 WHERE (col1 <= 80.90)
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab0_1067
+DROP VIEW IF EXISTS view_1_tab0_1067 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1067
+DROP VIEW IF EXISTS view_2_tab0_1067 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1067
+DROP VIEW IF EXISTS view_3_tab0_1067 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27566,13 +27566,13 @@ SELECT pk FROM tab1 WHERE (col1 <= 80.90)
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab1_1067
+DROP VIEW IF EXISTS view_1_tab1_1067 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1067
+DROP VIEW IF EXISTS view_2_tab1_1067 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1067
+DROP VIEW IF EXISTS view_3_tab1_1067 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27665,13 +27665,13 @@ SELECT pk FROM tab2 WHERE (col1 <= 80.90)
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab2_1067
+DROP VIEW IF EXISTS view_1_tab2_1067 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1067
+DROP VIEW IF EXISTS view_2_tab2_1067 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1067
+DROP VIEW IF EXISTS view_3_tab2_1067 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27764,13 +27764,13 @@ SELECT pk FROM tab3 WHERE (col1 <= 80.90)
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab3_1067
+DROP VIEW IF EXISTS view_1_tab3_1067 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1067
+DROP VIEW IF EXISTS view_2_tab3_1067 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1067
+DROP VIEW IF EXISTS view_3_tab3_1067 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27863,13 +27863,13 @@ SELECT pk FROM tab4 WHERE (col1 <= 80.90)
 9 values hashing to 7c052a6f22ec636843783dd115badb9d
 
 statement ok
-DROP VIEW view_1_tab4_1067
+DROP VIEW IF EXISTS view_1_tab4_1067 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1067
+DROP VIEW IF EXISTS view_2_tab4_1067 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1067
+DROP VIEW IF EXISTS view_3_tab4_1067 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27976,13 +27976,13 @@ SELECT pk FROM tab0 WHERE (col0 < 80 OR col3 <= 94 OR (col0 > 2 AND col0 <= 70 O
 8
 
 statement ok
-DROP VIEW view_1_tab0_1068
+DROP VIEW IF EXISTS view_1_tab0_1068 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1068
+DROP VIEW IF EXISTS view_2_tab0_1068 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1068
+DROP VIEW IF EXISTS view_3_tab0_1068 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28089,13 +28089,13 @@ SELECT pk FROM tab1 WHERE (col0 < 80 OR col3 <= 94 OR (col0 > 2 AND col0 <= 70 O
 8
 
 statement ok
-DROP VIEW view_1_tab1_1068
+DROP VIEW IF EXISTS view_1_tab1_1068 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1068
+DROP VIEW IF EXISTS view_2_tab1_1068 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1068
+DROP VIEW IF EXISTS view_3_tab1_1068 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28202,13 +28202,13 @@ SELECT pk FROM tab2 WHERE (col0 < 80 OR col3 <= 94 OR (col0 > 2 AND col0 <= 70 O
 8
 
 statement ok
-DROP VIEW view_1_tab2_1068
+DROP VIEW IF EXISTS view_1_tab2_1068 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1068
+DROP VIEW IF EXISTS view_2_tab2_1068 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1068
+DROP VIEW IF EXISTS view_3_tab2_1068 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28315,13 +28315,13 @@ SELECT pk FROM tab3 WHERE (col0 < 80 OR col3 <= 94 OR (col0 > 2 AND col0 <= 70 O
 8
 
 statement ok
-DROP VIEW view_1_tab3_1068
+DROP VIEW IF EXISTS view_1_tab3_1068 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1068
+DROP VIEW IF EXISTS view_2_tab3_1068 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1068
+DROP VIEW IF EXISTS view_3_tab3_1068 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28428,13 +28428,13 @@ SELECT pk FROM tab4 WHERE (col0 < 80 OR col3 <= 94 OR (col0 > 2 AND col0 <= 70 O
 8
 
 statement ok
-DROP VIEW view_1_tab4_1068
+DROP VIEW IF EXISTS view_1_tab4_1068 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1068
+DROP VIEW IF EXISTS view_2_tab4_1068 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1068
+DROP VIEW IF EXISTS view_3_tab4_1068 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28553,13 +28553,13 @@ SELECT pk FROM tab0 WHERE col3 >= 30
 9
 
 statement ok
-DROP VIEW view_1_tab0_1069
+DROP VIEW IF EXISTS view_1_tab0_1069 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1069
+DROP VIEW IF EXISTS view_2_tab0_1069 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1069
+DROP VIEW IF EXISTS view_3_tab0_1069 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28678,13 +28678,13 @@ SELECT pk FROM tab1 WHERE col3 >= 30
 9
 
 statement ok
-DROP VIEW view_1_tab1_1069
+DROP VIEW IF EXISTS view_1_tab1_1069 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1069
+DROP VIEW IF EXISTS view_2_tab1_1069 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1069
+DROP VIEW IF EXISTS view_3_tab1_1069 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28803,13 +28803,13 @@ SELECT pk FROM tab2 WHERE col3 >= 30
 9
 
 statement ok
-DROP VIEW view_1_tab2_1069
+DROP VIEW IF EXISTS view_1_tab2_1069 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1069
+DROP VIEW IF EXISTS view_2_tab2_1069 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1069
+DROP VIEW IF EXISTS view_3_tab2_1069 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28928,13 +28928,13 @@ SELECT pk FROM tab3 WHERE col3 >= 30
 9
 
 statement ok
-DROP VIEW view_1_tab3_1069
+DROP VIEW IF EXISTS view_1_tab3_1069 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1069
+DROP VIEW IF EXISTS view_2_tab3_1069 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1069
+DROP VIEW IF EXISTS view_3_tab3_1069 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29053,13 +29053,13 @@ SELECT pk FROM tab4 WHERE col3 >= 30
 9
 
 statement ok
-DROP VIEW view_1_tab4_1069
+DROP VIEW IF EXISTS view_1_tab4_1069 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1069
+DROP VIEW IF EXISTS view_2_tab4_1069 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1069
+DROP VIEW IF EXISTS view_3_tab4_1069 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29173,13 +29173,13 @@ SELECT pk FROM tab0 WHERE ((col0 >= 30)) AND col1 <= 34.36 OR (col4 >= 14.91) AN
 9
 
 statement ok
-DROP VIEW view_1_tab0_1070
+DROP VIEW IF EXISTS view_1_tab0_1070 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1070
+DROP VIEW IF EXISTS view_2_tab0_1070 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1070
+DROP VIEW IF EXISTS view_3_tab0_1070 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29293,13 +29293,13 @@ SELECT pk FROM tab1 WHERE ((col0 >= 30)) AND col1 <= 34.36 OR (col4 >= 14.91) AN
 9
 
 statement ok
-DROP VIEW view_1_tab1_1070
+DROP VIEW IF EXISTS view_1_tab1_1070 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1070
+DROP VIEW IF EXISTS view_2_tab1_1070 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1070
+DROP VIEW IF EXISTS view_3_tab1_1070 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29413,13 +29413,13 @@ SELECT pk FROM tab2 WHERE ((col0 >= 30)) AND col1 <= 34.36 OR (col4 >= 14.91) AN
 9
 
 statement ok
-DROP VIEW view_1_tab2_1070
+DROP VIEW IF EXISTS view_1_tab2_1070 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1070
+DROP VIEW IF EXISTS view_2_tab2_1070 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1070
+DROP VIEW IF EXISTS view_3_tab2_1070 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29533,13 +29533,13 @@ SELECT pk FROM tab3 WHERE ((col0 >= 30)) AND col1 <= 34.36 OR (col4 >= 14.91) AN
 9
 
 statement ok
-DROP VIEW view_1_tab3_1070
+DROP VIEW IF EXISTS view_1_tab3_1070 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1070
+DROP VIEW IF EXISTS view_2_tab3_1070 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1070
+DROP VIEW IF EXISTS view_3_tab3_1070 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29653,13 +29653,13 @@ SELECT pk FROM tab4 WHERE ((col0 >= 30)) AND col1 <= 34.36 OR (col4 >= 14.91) AN
 9
 
 statement ok
-DROP VIEW view_1_tab4_1070
+DROP VIEW IF EXISTS view_1_tab4_1070 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1070
+DROP VIEW IF EXISTS view_2_tab4_1070 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1070
+DROP VIEW IF EXISTS view_3_tab4_1070 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29777,13 +29777,13 @@ SELECT pk FROM tab0 WHERE (col3 >= 41 OR col3 <= 61 AND col0 IN (62,59,39,80,86,
 9
 
 statement ok
-DROP VIEW view_1_tab0_1071
+DROP VIEW IF EXISTS view_1_tab0_1071 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1071
+DROP VIEW IF EXISTS view_2_tab0_1071 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1071
+DROP VIEW IF EXISTS view_3_tab0_1071 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29901,13 +29901,13 @@ SELECT pk FROM tab1 WHERE (col3 >= 41 OR col3 <= 61 AND col0 IN (62,59,39,80,86,
 9
 
 statement ok
-DROP VIEW view_1_tab1_1071
+DROP VIEW IF EXISTS view_1_tab1_1071 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1071
+DROP VIEW IF EXISTS view_2_tab1_1071 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1071
+DROP VIEW IF EXISTS view_3_tab1_1071 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30025,13 +30025,13 @@ SELECT pk FROM tab2 WHERE (col3 >= 41 OR col3 <= 61 AND col0 IN (62,59,39,80,86,
 9
 
 statement ok
-DROP VIEW view_1_tab2_1071
+DROP VIEW IF EXISTS view_1_tab2_1071 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1071
+DROP VIEW IF EXISTS view_2_tab2_1071 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1071
+DROP VIEW IF EXISTS view_3_tab2_1071 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30149,13 +30149,13 @@ SELECT pk FROM tab3 WHERE (col3 >= 41 OR col3 <= 61 AND col0 IN (62,59,39,80,86,
 9
 
 statement ok
-DROP VIEW view_1_tab3_1071
+DROP VIEW IF EXISTS view_1_tab3_1071 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1071
+DROP VIEW IF EXISTS view_2_tab3_1071 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1071
+DROP VIEW IF EXISTS view_3_tab3_1071 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30273,13 +30273,13 @@ SELECT pk FROM tab4 WHERE (col3 >= 41 OR col3 <= 61 AND col0 IN (62,59,39,80,86,
 9
 
 statement ok
-DROP VIEW view_1_tab4_1071
+DROP VIEW IF EXISTS view_1_tab4_1071 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1071
+DROP VIEW IF EXISTS view_2_tab4_1071 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1071
+DROP VIEW IF EXISTS view_3_tab4_1071 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30372,13 +30372,13 @@ SELECT pk FROM tab0 WHERE col4 > 57.4 OR col1 < 58.84 OR ((col3 >= 77 AND col1 >
 9 values hashing to 4290bd41ca7ca69dc280e33882d8e9de
 
 statement ok
-DROP VIEW view_1_tab0_1072
+DROP VIEW IF EXISTS view_1_tab0_1072 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1072
+DROP VIEW IF EXISTS view_2_tab0_1072 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1072
+DROP VIEW IF EXISTS view_3_tab0_1072 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30471,13 +30471,13 @@ SELECT pk FROM tab1 WHERE col4 > 57.4 OR col1 < 58.84 OR ((col3 >= 77 AND col1 >
 9 values hashing to 4290bd41ca7ca69dc280e33882d8e9de
 
 statement ok
-DROP VIEW view_1_tab1_1072
+DROP VIEW IF EXISTS view_1_tab1_1072 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1072
+DROP VIEW IF EXISTS view_2_tab1_1072 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1072
+DROP VIEW IF EXISTS view_3_tab1_1072 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30570,13 +30570,13 @@ SELECT pk FROM tab2 WHERE col4 > 57.4 OR col1 < 58.84 OR ((col3 >= 77 AND col1 >
 9 values hashing to 4290bd41ca7ca69dc280e33882d8e9de
 
 statement ok
-DROP VIEW view_1_tab2_1072
+DROP VIEW IF EXISTS view_1_tab2_1072 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1072
+DROP VIEW IF EXISTS view_2_tab2_1072 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1072
+DROP VIEW IF EXISTS view_3_tab2_1072 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30669,13 +30669,13 @@ SELECT pk FROM tab3 WHERE col4 > 57.4 OR col1 < 58.84 OR ((col3 >= 77 AND col1 >
 9 values hashing to 4290bd41ca7ca69dc280e33882d8e9de
 
 statement ok
-DROP VIEW view_1_tab3_1072
+DROP VIEW IF EXISTS view_1_tab3_1072 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1072
+DROP VIEW IF EXISTS view_2_tab3_1072 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1072
+DROP VIEW IF EXISTS view_3_tab3_1072 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30768,13 +30768,13 @@ SELECT pk FROM tab4 WHERE col4 > 57.4 OR col1 < 58.84 OR ((col3 >= 77 AND col1 >
 9 values hashing to 4290bd41ca7ca69dc280e33882d8e9de
 
 statement ok
-DROP VIEW view_1_tab4_1072
+DROP VIEW IF EXISTS view_1_tab4_1072 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1072
+DROP VIEW IF EXISTS view_2_tab4_1072 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1072
+DROP VIEW IF EXISTS view_3_tab4_1072 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30860,13 +30860,13 @@ SELECT pk FROM tab0 WHERE col1 < 2.58 AND col3 < 75
 ----
 
 statement ok
-DROP VIEW view_1_tab0_1073
+DROP VIEW IF EXISTS view_1_tab0_1073 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1073
+DROP VIEW IF EXISTS view_2_tab0_1073 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1073
+DROP VIEW IF EXISTS view_3_tab0_1073 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30952,13 +30952,13 @@ SELECT pk FROM tab1 WHERE col1 < 2.58 AND col3 < 75
 ----
 
 statement ok
-DROP VIEW view_1_tab1_1073
+DROP VIEW IF EXISTS view_1_tab1_1073 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1073
+DROP VIEW IF EXISTS view_2_tab1_1073 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1073
+DROP VIEW IF EXISTS view_3_tab1_1073 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31044,13 +31044,13 @@ SELECT pk FROM tab2 WHERE col1 < 2.58 AND col3 < 75
 ----
 
 statement ok
-DROP VIEW view_1_tab2_1073
+DROP VIEW IF EXISTS view_1_tab2_1073 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1073
+DROP VIEW IF EXISTS view_2_tab2_1073 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1073
+DROP VIEW IF EXISTS view_3_tab2_1073 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31136,13 +31136,13 @@ SELECT pk FROM tab3 WHERE col1 < 2.58 AND col3 < 75
 ----
 
 statement ok
-DROP VIEW view_1_tab3_1073
+DROP VIEW IF EXISTS view_1_tab3_1073 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1073
+DROP VIEW IF EXISTS view_2_tab3_1073 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1073
+DROP VIEW IF EXISTS view_3_tab3_1073 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31228,13 +31228,13 @@ SELECT pk FROM tab4 WHERE col1 < 2.58 AND col3 < 75
 ----
 
 statement ok
-DROP VIEW view_1_tab4_1073
+DROP VIEW IF EXISTS view_1_tab4_1073 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1073
+DROP VIEW IF EXISTS view_2_tab4_1073 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1073
+DROP VIEW IF EXISTS view_3_tab4_1073 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31320,13 +31320,13 @@ SELECT pk FROM tab0 WHERE col0 IS NULL AND ((col3 > 72)) AND (((((((col1 < 93.76
 ----
 
 statement ok
-DROP VIEW view_1_tab0_1074
+DROP VIEW IF EXISTS view_1_tab0_1074 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1074
+DROP VIEW IF EXISTS view_2_tab0_1074 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1074
+DROP VIEW IF EXISTS view_3_tab0_1074 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31412,13 +31412,13 @@ SELECT pk FROM tab1 WHERE col0 IS NULL AND ((col3 > 72)) AND (((((((col1 < 93.76
 ----
 
 statement ok
-DROP VIEW view_1_tab1_1074
+DROP VIEW IF EXISTS view_1_tab1_1074 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1074
+DROP VIEW IF EXISTS view_2_tab1_1074 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1074
+DROP VIEW IF EXISTS view_3_tab1_1074 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31504,13 +31504,13 @@ SELECT pk FROM tab2 WHERE col0 IS NULL AND ((col3 > 72)) AND (((((((col1 < 93.76
 ----
 
 statement ok
-DROP VIEW view_1_tab2_1074
+DROP VIEW IF EXISTS view_1_tab2_1074 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1074
+DROP VIEW IF EXISTS view_2_tab2_1074 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1074
+DROP VIEW IF EXISTS view_3_tab2_1074 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31596,13 +31596,13 @@ SELECT pk FROM tab3 WHERE col0 IS NULL AND ((col3 > 72)) AND (((((((col1 < 93.76
 ----
 
 statement ok
-DROP VIEW view_1_tab3_1074
+DROP VIEW IF EXISTS view_1_tab3_1074 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1074
+DROP VIEW IF EXISTS view_2_tab3_1074 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1074
+DROP VIEW IF EXISTS view_3_tab3_1074 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31688,13 +31688,13 @@ SELECT pk FROM tab4 WHERE col0 IS NULL AND ((col3 > 72)) AND (((((((col1 < 93.76
 ----
 
 statement ok
-DROP VIEW view_1_tab4_1074
+DROP VIEW IF EXISTS view_1_tab4_1074 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1074
+DROP VIEW IF EXISTS view_2_tab4_1074 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1074
+DROP VIEW IF EXISTS view_3_tab4_1074 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31801,13 +31801,13 @@ SELECT pk FROM tab0 WHERE ((col3 > 71))
 6
 
 statement ok
-DROP VIEW view_1_tab0_1075
+DROP VIEW IF EXISTS view_1_tab0_1075 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1075
+DROP VIEW IF EXISTS view_2_tab0_1075 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1075
+DROP VIEW IF EXISTS view_3_tab0_1075 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31914,13 +31914,13 @@ SELECT pk FROM tab1 WHERE ((col3 > 71))
 6
 
 statement ok
-DROP VIEW view_1_tab1_1075
+DROP VIEW IF EXISTS view_1_tab1_1075 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1075
+DROP VIEW IF EXISTS view_2_tab1_1075 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1075
+DROP VIEW IF EXISTS view_3_tab1_1075 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32027,13 +32027,13 @@ SELECT pk FROM tab2 WHERE ((col3 > 71))
 6
 
 statement ok
-DROP VIEW view_1_tab2_1075
+DROP VIEW IF EXISTS view_1_tab2_1075 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1075
+DROP VIEW IF EXISTS view_2_tab2_1075 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1075
+DROP VIEW IF EXISTS view_3_tab2_1075 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32140,13 +32140,13 @@ SELECT pk FROM tab3 WHERE ((col3 > 71))
 6
 
 statement ok
-DROP VIEW view_1_tab3_1075
+DROP VIEW IF EXISTS view_1_tab3_1075 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1075
+DROP VIEW IF EXISTS view_2_tab3_1075 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1075
+DROP VIEW IF EXISTS view_3_tab3_1075 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32253,13 +32253,13 @@ SELECT pk FROM tab4 WHERE ((col3 > 71))
 6
 
 statement ok
-DROP VIEW view_1_tab4_1075
+DROP VIEW IF EXISTS view_1_tab4_1075 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1075
+DROP VIEW IF EXISTS view_2_tab4_1075 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1075
+DROP VIEW IF EXISTS view_3_tab4_1075 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32362,13 +32362,13 @@ SELECT pk FROM tab0 WHERE ((((col3 > 54 OR col0 = 44 AND (((col0 >= 49))) AND ((
 9
 
 statement ok
-DROP VIEW view_1_tab0_1076
+DROP VIEW IF EXISTS view_1_tab0_1076 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1076
+DROP VIEW IF EXISTS view_2_tab0_1076 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1076
+DROP VIEW IF EXISTS view_3_tab0_1076 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32471,13 +32471,13 @@ SELECT pk FROM tab1 WHERE ((((col3 > 54 OR col0 = 44 AND (((col0 >= 49))) AND ((
 9
 
 statement ok
-DROP VIEW view_1_tab1_1076
+DROP VIEW IF EXISTS view_1_tab1_1076 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1076
+DROP VIEW IF EXISTS view_2_tab1_1076 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1076
+DROP VIEW IF EXISTS view_3_tab1_1076 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32580,13 +32580,13 @@ SELECT pk FROM tab2 WHERE ((((col3 > 54 OR col0 = 44 AND (((col0 >= 49))) AND ((
 9
 
 statement ok
-DROP VIEW view_1_tab2_1076
+DROP VIEW IF EXISTS view_1_tab2_1076 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1076
+DROP VIEW IF EXISTS view_2_tab2_1076 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1076
+DROP VIEW IF EXISTS view_3_tab2_1076 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32689,13 +32689,13 @@ SELECT pk FROM tab3 WHERE ((((col3 > 54 OR col0 = 44 AND (((col0 >= 49))) AND ((
 9
 
 statement ok
-DROP VIEW view_1_tab3_1076
+DROP VIEW IF EXISTS view_1_tab3_1076 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1076
+DROP VIEW IF EXISTS view_2_tab3_1076 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1076
+DROP VIEW IF EXISTS view_3_tab3_1076 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32798,13 +32798,13 @@ SELECT pk FROM tab4 WHERE ((((col3 > 54 OR col0 = 44 AND (((col0 >= 49))) AND ((
 9
 
 statement ok
-DROP VIEW view_1_tab4_1076
+DROP VIEW IF EXISTS view_1_tab4_1076 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1076
+DROP VIEW IF EXISTS view_2_tab4_1076 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1076
+DROP VIEW IF EXISTS view_3_tab4_1076 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32918,13 +32918,13 @@ SELECT pk FROM tab0 WHERE col3 < 53
 8
 
 statement ok
-DROP VIEW view_1_tab0_1077
+DROP VIEW IF EXISTS view_1_tab0_1077 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1077
+DROP VIEW IF EXISTS view_2_tab0_1077 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1077
+DROP VIEW IF EXISTS view_3_tab0_1077 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33038,13 +33038,13 @@ SELECT pk FROM tab1 WHERE col3 < 53
 8
 
 statement ok
-DROP VIEW view_1_tab1_1077
+DROP VIEW IF EXISTS view_1_tab1_1077 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1077
+DROP VIEW IF EXISTS view_2_tab1_1077 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1077
+DROP VIEW IF EXISTS view_3_tab1_1077 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33158,13 +33158,13 @@ SELECT pk FROM tab2 WHERE col3 < 53
 8
 
 statement ok
-DROP VIEW view_1_tab2_1077
+DROP VIEW IF EXISTS view_1_tab2_1077 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1077
+DROP VIEW IF EXISTS view_2_tab2_1077 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1077
+DROP VIEW IF EXISTS view_3_tab2_1077 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33278,13 +33278,13 @@ SELECT pk FROM tab3 WHERE col3 < 53
 8
 
 statement ok
-DROP VIEW view_1_tab3_1077
+DROP VIEW IF EXISTS view_1_tab3_1077 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1077
+DROP VIEW IF EXISTS view_2_tab3_1077 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1077
+DROP VIEW IF EXISTS view_3_tab3_1077 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33398,13 +33398,13 @@ SELECT pk FROM tab4 WHERE col3 < 53
 8
 
 statement ok
-DROP VIEW view_1_tab4_1077
+DROP VIEW IF EXISTS view_1_tab4_1077 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1077
+DROP VIEW IF EXISTS view_2_tab4_1077 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1077
+DROP VIEW IF EXISTS view_3_tab4_1077 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33504,13 +33504,13 @@ SELECT pk FROM tab0 WHERE ((col3 <= 22 OR col3 IN (27)))
 8
 
 statement ok
-DROP VIEW view_1_tab0_1078
+DROP VIEW IF EXISTS view_1_tab0_1078 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1078
+DROP VIEW IF EXISTS view_2_tab0_1078 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1078
+DROP VIEW IF EXISTS view_3_tab0_1078 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33610,13 +33610,13 @@ SELECT pk FROM tab1 WHERE ((col3 <= 22 OR col3 IN (27)))
 8
 
 statement ok
-DROP VIEW view_1_tab1_1078
+DROP VIEW IF EXISTS view_1_tab1_1078 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1078
+DROP VIEW IF EXISTS view_2_tab1_1078 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1078
+DROP VIEW IF EXISTS view_3_tab1_1078 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33716,13 +33716,13 @@ SELECT pk FROM tab2 WHERE ((col3 <= 22 OR col3 IN (27)))
 8
 
 statement ok
-DROP VIEW view_1_tab2_1078
+DROP VIEW IF EXISTS view_1_tab2_1078 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1078
+DROP VIEW IF EXISTS view_2_tab2_1078 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1078
+DROP VIEW IF EXISTS view_3_tab2_1078 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33822,13 +33822,13 @@ SELECT pk FROM tab3 WHERE ((col3 <= 22 OR col3 IN (27)))
 8
 
 statement ok
-DROP VIEW view_1_tab3_1078
+DROP VIEW IF EXISTS view_1_tab3_1078 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1078
+DROP VIEW IF EXISTS view_2_tab3_1078 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1078
+DROP VIEW IF EXISTS view_3_tab3_1078 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33928,13 +33928,13 @@ SELECT pk FROM tab4 WHERE ((col3 <= 22 OR col3 IN (27)))
 8
 
 statement ok
-DROP VIEW view_1_tab4_1078
+DROP VIEW IF EXISTS view_1_tab4_1078 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1078
+DROP VIEW IF EXISTS view_2_tab4_1078 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1078
+DROP VIEW IF EXISTS view_3_tab4_1078 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34041,13 +34041,13 @@ SELECT pk FROM tab0 WHERE (col1 >= 68.67)
 5
 
 statement ok
-DROP VIEW view_1_tab0_1079
+DROP VIEW IF EXISTS view_1_tab0_1079 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1079
+DROP VIEW IF EXISTS view_2_tab0_1079 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1079
+DROP VIEW IF EXISTS view_3_tab0_1079 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34154,13 +34154,13 @@ SELECT pk FROM tab1 WHERE (col1 >= 68.67)
 5
 
 statement ok
-DROP VIEW view_1_tab1_1079
+DROP VIEW IF EXISTS view_1_tab1_1079 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1079
+DROP VIEW IF EXISTS view_2_tab1_1079 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1079
+DROP VIEW IF EXISTS view_3_tab1_1079 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34267,13 +34267,13 @@ SELECT pk FROM tab2 WHERE (col1 >= 68.67)
 5
 
 statement ok
-DROP VIEW view_1_tab2_1079
+DROP VIEW IF EXISTS view_1_tab2_1079 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1079
+DROP VIEW IF EXISTS view_2_tab2_1079 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1079
+DROP VIEW IF EXISTS view_3_tab2_1079 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34380,13 +34380,13 @@ SELECT pk FROM tab3 WHERE (col1 >= 68.67)
 5
 
 statement ok
-DROP VIEW view_1_tab3_1079
+DROP VIEW IF EXISTS view_1_tab3_1079 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1079
+DROP VIEW IF EXISTS view_2_tab3_1079 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1079
+DROP VIEW IF EXISTS view_3_tab3_1079 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34493,13 +34493,13 @@ SELECT pk FROM tab4 WHERE (col1 >= 68.67)
 5
 
 statement ok
-DROP VIEW view_1_tab4_1079
+DROP VIEW IF EXISTS view_1_tab4_1079 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1079
+DROP VIEW IF EXISTS view_2_tab4_1079 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1079
+DROP VIEW IF EXISTS view_3_tab4_1079 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34617,13 +34617,13 @@ SELECT pk FROM tab0 WHERE col3 >= 24
 9
 
 statement ok
-DROP VIEW view_1_tab0_1080
+DROP VIEW IF EXISTS view_1_tab0_1080 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1080
+DROP VIEW IF EXISTS view_2_tab0_1080 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1080
+DROP VIEW IF EXISTS view_3_tab0_1080 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34741,13 +34741,13 @@ SELECT pk FROM tab1 WHERE col3 >= 24
 9
 
 statement ok
-DROP VIEW view_1_tab1_1080
+DROP VIEW IF EXISTS view_1_tab1_1080 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1080
+DROP VIEW IF EXISTS view_2_tab1_1080 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1080
+DROP VIEW IF EXISTS view_3_tab1_1080 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34865,13 +34865,13 @@ SELECT pk FROM tab2 WHERE col3 >= 24
 9
 
 statement ok
-DROP VIEW view_1_tab2_1080
+DROP VIEW IF EXISTS view_1_tab2_1080 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1080
+DROP VIEW IF EXISTS view_2_tab2_1080 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1080
+DROP VIEW IF EXISTS view_3_tab2_1080 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34989,13 +34989,13 @@ SELECT pk FROM tab3 WHERE col3 >= 24
 9
 
 statement ok
-DROP VIEW view_1_tab3_1080
+DROP VIEW IF EXISTS view_1_tab3_1080 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1080
+DROP VIEW IF EXISTS view_2_tab3_1080 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1080
+DROP VIEW IF EXISTS view_3_tab3_1080 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35113,13 +35113,13 @@ SELECT pk FROM tab4 WHERE col3 >= 24
 9
 
 statement ok
-DROP VIEW view_1_tab4_1080
+DROP VIEW IF EXISTS view_1_tab4_1080 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1080
+DROP VIEW IF EXISTS view_2_tab4_1080 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1080
+DROP VIEW IF EXISTS view_3_tab4_1080 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35208,13 +35208,13 @@ SELECT pk FROM tab0 WHERE col3 > 48 OR col3 <= 29 OR col0 >= 55
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab0_1081
+DROP VIEW IF EXISTS view_1_tab0_1081 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1081
+DROP VIEW IF EXISTS view_2_tab0_1081 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1081
+DROP VIEW IF EXISTS view_3_tab0_1081 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35303,13 +35303,13 @@ SELECT pk FROM tab1 WHERE col3 > 48 OR col3 <= 29 OR col0 >= 55
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab1_1081
+DROP VIEW IF EXISTS view_1_tab1_1081 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1081
+DROP VIEW IF EXISTS view_2_tab1_1081 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1081
+DROP VIEW IF EXISTS view_3_tab1_1081 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35398,13 +35398,13 @@ SELECT pk FROM tab2 WHERE col3 > 48 OR col3 <= 29 OR col0 >= 55
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab2_1081
+DROP VIEW IF EXISTS view_1_tab2_1081 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1081
+DROP VIEW IF EXISTS view_2_tab2_1081 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1081
+DROP VIEW IF EXISTS view_3_tab2_1081 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35493,13 +35493,13 @@ SELECT pk FROM tab3 WHERE col3 > 48 OR col3 <= 29 OR col0 >= 55
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab3_1081
+DROP VIEW IF EXISTS view_1_tab3_1081 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1081
+DROP VIEW IF EXISTS view_2_tab3_1081 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1081
+DROP VIEW IF EXISTS view_3_tab3_1081 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35588,13 +35588,13 @@ SELECT pk FROM tab4 WHERE col3 > 48 OR col3 <= 29 OR col0 >= 55
 10 values hashing to e20b902b49a98b1a05ed62804c757f94
 
 statement ok
-DROP VIEW view_1_tab4_1081
+DROP VIEW IF EXISTS view_1_tab4_1081 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1081
+DROP VIEW IF EXISTS view_2_tab4_1081 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1081
+DROP VIEW IF EXISTS view_3_tab4_1081 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35680,13 +35680,13 @@ SELECT pk FROM tab0 WHERE (col3 = 24)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_1082
+DROP VIEW IF EXISTS view_1_tab0_1082 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1082
+DROP VIEW IF EXISTS view_2_tab0_1082 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1082
+DROP VIEW IF EXISTS view_3_tab0_1082 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35772,13 +35772,13 @@ SELECT pk FROM tab1 WHERE (col3 = 24)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_1082
+DROP VIEW IF EXISTS view_1_tab1_1082 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1082
+DROP VIEW IF EXISTS view_2_tab1_1082 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1082
+DROP VIEW IF EXISTS view_3_tab1_1082 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35864,13 +35864,13 @@ SELECT pk FROM tab2 WHERE (col3 = 24)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_1082
+DROP VIEW IF EXISTS view_1_tab2_1082 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1082
+DROP VIEW IF EXISTS view_2_tab2_1082 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1082
+DROP VIEW IF EXISTS view_3_tab2_1082 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35956,13 +35956,13 @@ SELECT pk FROM tab3 WHERE (col3 = 24)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_1082
+DROP VIEW IF EXISTS view_1_tab3_1082 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1082
+DROP VIEW IF EXISTS view_2_tab3_1082 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1082
+DROP VIEW IF EXISTS view_3_tab3_1082 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36048,13 +36048,13 @@ SELECT pk FROM tab4 WHERE (col3 = 24)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_1082
+DROP VIEW IF EXISTS view_1_tab4_1082 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1082
+DROP VIEW IF EXISTS view_2_tab4_1082 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1082
+DROP VIEW IF EXISTS view_3_tab4_1082 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36174,13 +36174,13 @@ SELECT pk FROM tab0 WHERE col4 > 27.68 OR col1 >= 59.78
 5
 
 statement ok
-DROP VIEW view_1_tab0_1083
+DROP VIEW IF EXISTS view_1_tab0_1083 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1083
+DROP VIEW IF EXISTS view_2_tab0_1083 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1083
+DROP VIEW IF EXISTS view_3_tab0_1083 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36300,13 +36300,13 @@ SELECT pk FROM tab1 WHERE col4 > 27.68 OR col1 >= 59.78
 5
 
 statement ok
-DROP VIEW view_1_tab1_1083
+DROP VIEW IF EXISTS view_1_tab1_1083 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1083
+DROP VIEW IF EXISTS view_2_tab1_1083 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1083
+DROP VIEW IF EXISTS view_3_tab1_1083 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36426,13 +36426,13 @@ SELECT pk FROM tab2 WHERE col4 > 27.68 OR col1 >= 59.78
 5
 
 statement ok
-DROP VIEW view_1_tab2_1083
+DROP VIEW IF EXISTS view_1_tab2_1083 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1083
+DROP VIEW IF EXISTS view_2_tab2_1083 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1083
+DROP VIEW IF EXISTS view_3_tab2_1083 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36552,13 +36552,13 @@ SELECT pk FROM tab3 WHERE col4 > 27.68 OR col1 >= 59.78
 5
 
 statement ok
-DROP VIEW view_1_tab3_1083
+DROP VIEW IF EXISTS view_1_tab3_1083 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1083
+DROP VIEW IF EXISTS view_2_tab3_1083 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1083
+DROP VIEW IF EXISTS view_3_tab3_1083 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36678,13 +36678,13 @@ SELECT pk FROM tab4 WHERE col4 > 27.68 OR col1 >= 59.78
 5
 
 statement ok
-DROP VIEW view_1_tab4_1083
+DROP VIEW IF EXISTS view_1_tab4_1083 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1083
+DROP VIEW IF EXISTS view_2_tab4_1083 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1083
+DROP VIEW IF EXISTS view_3_tab4_1083 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36770,13 +36770,13 @@ SELECT pk FROM tab0 WHERE col3 >= 89
 ----
 
 statement ok
-DROP VIEW view_1_tab0_1084
+DROP VIEW IF EXISTS view_1_tab0_1084 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1084
+DROP VIEW IF EXISTS view_2_tab0_1084 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1084
+DROP VIEW IF EXISTS view_3_tab0_1084 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36862,13 +36862,13 @@ SELECT pk FROM tab1 WHERE col3 >= 89
 ----
 
 statement ok
-DROP VIEW view_1_tab1_1084
+DROP VIEW IF EXISTS view_1_tab1_1084 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1084
+DROP VIEW IF EXISTS view_2_tab1_1084 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1084
+DROP VIEW IF EXISTS view_3_tab1_1084 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36954,13 +36954,13 @@ SELECT pk FROM tab2 WHERE col3 >= 89
 ----
 
 statement ok
-DROP VIEW view_1_tab2_1084
+DROP VIEW IF EXISTS view_1_tab2_1084 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1084
+DROP VIEW IF EXISTS view_2_tab2_1084 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1084
+DROP VIEW IF EXISTS view_3_tab2_1084 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37046,13 +37046,13 @@ SELECT pk FROM tab3 WHERE col3 >= 89
 ----
 
 statement ok
-DROP VIEW view_1_tab3_1084
+DROP VIEW IF EXISTS view_1_tab3_1084 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1084
+DROP VIEW IF EXISTS view_2_tab3_1084 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1084
+DROP VIEW IF EXISTS view_3_tab3_1084 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -37138,11 +37138,11 @@ SELECT pk FROM tab4 WHERE col3 >= 89
 ----
 
 statement ok
-DROP VIEW view_1_tab4_1084
+DROP VIEW IF EXISTS view_1_tab4_1084 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1084
+DROP VIEW IF EXISTS view_2_tab4_1084 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1084
+DROP VIEW IF EXISTS view_3_tab4_1084 CASCADE
 

--- a/test/index/view/100/slt_good_0.test
+++ b/test/index/view/100/slt_good_0.test
@@ -470,13 +470,13 @@ SELECT pk FROM tab0 WHERE (((col1 < 229.92)))
 25 values hashing to d078a1d99e009ef6330aaf53e9578de9
 
 statement ok
-DROP VIEW view_1_tab0_77
+DROP VIEW IF EXISTS view_1_tab0_77 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_77
+DROP VIEW IF EXISTS view_2_tab0_77 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_77
+DROP VIEW IF EXISTS view_3_tab0_77 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -567,13 +567,13 @@ SELECT pk FROM tab1 WHERE (((col1 < 229.92)))
 25 values hashing to d078a1d99e009ef6330aaf53e9578de9
 
 statement ok
-DROP VIEW view_1_tab1_77
+DROP VIEW IF EXISTS view_1_tab1_77 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_77
+DROP VIEW IF EXISTS view_2_tab1_77 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_77
+DROP VIEW IF EXISTS view_3_tab1_77 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -664,13 +664,13 @@ SELECT pk FROM tab2 WHERE (((col1 < 229.92)))
 25 values hashing to d078a1d99e009ef6330aaf53e9578de9
 
 statement ok
-DROP VIEW view_1_tab2_77
+DROP VIEW IF EXISTS view_1_tab2_77 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_77
+DROP VIEW IF EXISTS view_2_tab2_77 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_77
+DROP VIEW IF EXISTS view_3_tab2_77 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -761,13 +761,13 @@ SELECT pk FROM tab3 WHERE (((col1 < 229.92)))
 25 values hashing to d078a1d99e009ef6330aaf53e9578de9
 
 statement ok
-DROP VIEW view_1_tab3_77
+DROP VIEW IF EXISTS view_1_tab3_77 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_77
+DROP VIEW IF EXISTS view_2_tab3_77 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_77
+DROP VIEW IF EXISTS view_3_tab3_77 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -858,13 +858,13 @@ SELECT pk FROM tab4 WHERE (((col1 < 229.92)))
 25 values hashing to d078a1d99e009ef6330aaf53e9578de9
 
 statement ok
-DROP VIEW view_1_tab4_77
+DROP VIEW IF EXISTS view_1_tab4_77 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_77
+DROP VIEW IF EXISTS view_2_tab4_77 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_77
+DROP VIEW IF EXISTS view_3_tab4_77 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -955,13 +955,13 @@ SELECT pk FROM tab0 WHERE (col0 >= 309) OR col0 > 879 OR col0 > 380 AND (col3 > 
 68 values hashing to fdd63f76396edb29f6ea34897ae9fefc
 
 statement ok
-DROP VIEW view_1_tab0_78
+DROP VIEW IF EXISTS view_1_tab0_78 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_78
+DROP VIEW IF EXISTS view_2_tab0_78 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_78
+DROP VIEW IF EXISTS view_3_tab0_78 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1052,13 +1052,13 @@ SELECT pk FROM tab1 WHERE (col0 >= 309) OR col0 > 879 OR col0 > 380 AND (col3 > 
 68 values hashing to fdd63f76396edb29f6ea34897ae9fefc
 
 statement ok
-DROP VIEW view_1_tab1_78
+DROP VIEW IF EXISTS view_1_tab1_78 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_78
+DROP VIEW IF EXISTS view_2_tab1_78 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_78
+DROP VIEW IF EXISTS view_3_tab1_78 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1149,13 +1149,13 @@ SELECT pk FROM tab2 WHERE (col0 >= 309) OR col0 > 879 OR col0 > 380 AND (col3 > 
 68 values hashing to fdd63f76396edb29f6ea34897ae9fefc
 
 statement ok
-DROP VIEW view_1_tab2_78
+DROP VIEW IF EXISTS view_1_tab2_78 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_78
+DROP VIEW IF EXISTS view_2_tab2_78 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_78
+DROP VIEW IF EXISTS view_3_tab2_78 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1246,13 +1246,13 @@ SELECT pk FROM tab3 WHERE (col0 >= 309) OR col0 > 879 OR col0 > 380 AND (col3 > 
 68 values hashing to fdd63f76396edb29f6ea34897ae9fefc
 
 statement ok
-DROP VIEW view_1_tab3_78
+DROP VIEW IF EXISTS view_1_tab3_78 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_78
+DROP VIEW IF EXISTS view_2_tab3_78 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_78
+DROP VIEW IF EXISTS view_3_tab3_78 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1343,13 +1343,13 @@ SELECT pk FROM tab4 WHERE (col0 >= 309) OR col0 > 879 OR col0 > 380 AND (col3 > 
 68 values hashing to fdd63f76396edb29f6ea34897ae9fefc
 
 statement ok
-DROP VIEW view_1_tab4_78
+DROP VIEW IF EXISTS view_1_tab4_78 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_78
+DROP VIEW IF EXISTS view_2_tab4_78 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_78
+DROP VIEW IF EXISTS view_3_tab4_78 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1440,13 +1440,13 @@ SELECT pk FROM tab0 WHERE col4 <= 73.63 OR col4 > 372.90
 65 values hashing to e3580df6b2ce11f6afbfc6d0c2936954
 
 statement ok
-DROP VIEW view_1_tab0_79
+DROP VIEW IF EXISTS view_1_tab0_79 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_79
+DROP VIEW IF EXISTS view_2_tab0_79 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_79
+DROP VIEW IF EXISTS view_3_tab0_79 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1537,13 +1537,13 @@ SELECT pk FROM tab1 WHERE col4 <= 73.63 OR col4 > 372.90
 65 values hashing to e3580df6b2ce11f6afbfc6d0c2936954
 
 statement ok
-DROP VIEW view_1_tab1_79
+DROP VIEW IF EXISTS view_1_tab1_79 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_79
+DROP VIEW IF EXISTS view_2_tab1_79 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_79
+DROP VIEW IF EXISTS view_3_tab1_79 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1634,13 +1634,13 @@ SELECT pk FROM tab2 WHERE col4 <= 73.63 OR col4 > 372.90
 65 values hashing to e3580df6b2ce11f6afbfc6d0c2936954
 
 statement ok
-DROP VIEW view_1_tab2_79
+DROP VIEW IF EXISTS view_1_tab2_79 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_79
+DROP VIEW IF EXISTS view_2_tab2_79 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_79
+DROP VIEW IF EXISTS view_3_tab2_79 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1731,13 +1731,13 @@ SELECT pk FROM tab3 WHERE col4 <= 73.63 OR col4 > 372.90
 65 values hashing to e3580df6b2ce11f6afbfc6d0c2936954
 
 statement ok
-DROP VIEW view_1_tab3_79
+DROP VIEW IF EXISTS view_1_tab3_79 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_79
+DROP VIEW IF EXISTS view_2_tab3_79 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_79
+DROP VIEW IF EXISTS view_3_tab3_79 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1828,13 +1828,13 @@ SELECT pk FROM tab4 WHERE col4 <= 73.63 OR col4 > 372.90
 65 values hashing to e3580df6b2ce11f6afbfc6d0c2936954
 
 statement ok
-DROP VIEW view_1_tab4_79
+DROP VIEW IF EXISTS view_1_tab4_79 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_79
+DROP VIEW IF EXISTS view_2_tab4_79 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_79
+DROP VIEW IF EXISTS view_3_tab4_79 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1925,13 +1925,13 @@ SELECT pk FROM tab0 WHERE col1 >= 397.64
 65 values hashing to c3f2c42fc210d93874f1298f43d76efe
 
 statement ok
-DROP VIEW view_1_tab0_80
+DROP VIEW IF EXISTS view_1_tab0_80 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_80
+DROP VIEW IF EXISTS view_2_tab0_80 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_80
+DROP VIEW IF EXISTS view_3_tab0_80 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2022,13 +2022,13 @@ SELECT pk FROM tab1 WHERE col1 >= 397.64
 65 values hashing to c3f2c42fc210d93874f1298f43d76efe
 
 statement ok
-DROP VIEW view_1_tab1_80
+DROP VIEW IF EXISTS view_1_tab1_80 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_80
+DROP VIEW IF EXISTS view_2_tab1_80 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_80
+DROP VIEW IF EXISTS view_3_tab1_80 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2119,13 +2119,13 @@ SELECT pk FROM tab2 WHERE col1 >= 397.64
 65 values hashing to c3f2c42fc210d93874f1298f43d76efe
 
 statement ok
-DROP VIEW view_1_tab2_80
+DROP VIEW IF EXISTS view_1_tab2_80 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_80
+DROP VIEW IF EXISTS view_2_tab2_80 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_80
+DROP VIEW IF EXISTS view_3_tab2_80 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2216,13 +2216,13 @@ SELECT pk FROM tab3 WHERE col1 >= 397.64
 65 values hashing to c3f2c42fc210d93874f1298f43d76efe
 
 statement ok
-DROP VIEW view_1_tab3_80
+DROP VIEW IF EXISTS view_1_tab3_80 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_80
+DROP VIEW IF EXISTS view_2_tab3_80 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_80
+DROP VIEW IF EXISTS view_3_tab3_80 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2313,13 +2313,13 @@ SELECT pk FROM tab4 WHERE col1 >= 397.64
 65 values hashing to c3f2c42fc210d93874f1298f43d76efe
 
 statement ok
-DROP VIEW view_1_tab4_80
+DROP VIEW IF EXISTS view_1_tab4_80 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_80
+DROP VIEW IF EXISTS view_2_tab4_80 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_80
+DROP VIEW IF EXISTS view_3_tab4_80 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2410,13 +2410,13 @@ SELECT pk FROM tab0 WHERE col0 < 230
 22 values hashing to 897b23cba09a5eae07c56aef834a68e0
 
 statement ok
-DROP VIEW view_1_tab0_81
+DROP VIEW IF EXISTS view_1_tab0_81 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_81
+DROP VIEW IF EXISTS view_2_tab0_81 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_81
+DROP VIEW IF EXISTS view_3_tab0_81 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2507,13 +2507,13 @@ SELECT pk FROM tab1 WHERE col0 < 230
 22 values hashing to 897b23cba09a5eae07c56aef834a68e0
 
 statement ok
-DROP VIEW view_1_tab1_81
+DROP VIEW IF EXISTS view_1_tab1_81 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_81
+DROP VIEW IF EXISTS view_2_tab1_81 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_81
+DROP VIEW IF EXISTS view_3_tab1_81 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2604,13 +2604,13 @@ SELECT pk FROM tab2 WHERE col0 < 230
 22 values hashing to 897b23cba09a5eae07c56aef834a68e0
 
 statement ok
-DROP VIEW view_1_tab2_81
+DROP VIEW IF EXISTS view_1_tab2_81 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_81
+DROP VIEW IF EXISTS view_2_tab2_81 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_81
+DROP VIEW IF EXISTS view_3_tab2_81 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2701,13 +2701,13 @@ SELECT pk FROM tab3 WHERE col0 < 230
 22 values hashing to 897b23cba09a5eae07c56aef834a68e0
 
 statement ok
-DROP VIEW view_1_tab3_81
+DROP VIEW IF EXISTS view_1_tab3_81 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_81
+DROP VIEW IF EXISTS view_2_tab3_81 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_81
+DROP VIEW IF EXISTS view_3_tab3_81 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2798,13 +2798,13 @@ SELECT pk FROM tab4 WHERE col0 < 230
 22 values hashing to 897b23cba09a5eae07c56aef834a68e0
 
 statement ok
-DROP VIEW view_1_tab4_81
+DROP VIEW IF EXISTS view_1_tab4_81 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_81
+DROP VIEW IF EXISTS view_2_tab4_81 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_81
+DROP VIEW IF EXISTS view_3_tab4_81 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2895,13 +2895,13 @@ SELECT pk FROM tab0 WHERE (col1 < 654.68 OR col1 > 91.43 AND (col3 > 136 AND col
 69 values hashing to 1fd5d8e361875938646773aa12b7f2ea
 
 statement ok
-DROP VIEW view_1_tab0_82
+DROP VIEW IF EXISTS view_1_tab0_82 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_82
+DROP VIEW IF EXISTS view_2_tab0_82 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_82
+DROP VIEW IF EXISTS view_3_tab0_82 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2992,13 +2992,13 @@ SELECT pk FROM tab1 WHERE (col1 < 654.68 OR col1 > 91.43 AND (col3 > 136 AND col
 69 values hashing to 1fd5d8e361875938646773aa12b7f2ea
 
 statement ok
-DROP VIEW view_1_tab1_82
+DROP VIEW IF EXISTS view_1_tab1_82 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_82
+DROP VIEW IF EXISTS view_2_tab1_82 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_82
+DROP VIEW IF EXISTS view_3_tab1_82 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3089,13 +3089,13 @@ SELECT pk FROM tab2 WHERE (col1 < 654.68 OR col1 > 91.43 AND (col3 > 136 AND col
 69 values hashing to 1fd5d8e361875938646773aa12b7f2ea
 
 statement ok
-DROP VIEW view_1_tab2_82
+DROP VIEW IF EXISTS view_1_tab2_82 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_82
+DROP VIEW IF EXISTS view_2_tab2_82 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_82
+DROP VIEW IF EXISTS view_3_tab2_82 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3186,13 +3186,13 @@ SELECT pk FROM tab3 WHERE (col1 < 654.68 OR col1 > 91.43 AND (col3 > 136 AND col
 69 values hashing to 1fd5d8e361875938646773aa12b7f2ea
 
 statement ok
-DROP VIEW view_1_tab3_82
+DROP VIEW IF EXISTS view_1_tab3_82 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_82
+DROP VIEW IF EXISTS view_2_tab3_82 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_82
+DROP VIEW IF EXISTS view_3_tab3_82 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3283,13 +3283,13 @@ SELECT pk FROM tab4 WHERE (col1 < 654.68 OR col1 > 91.43 AND (col3 > 136 AND col
 69 values hashing to 1fd5d8e361875938646773aa12b7f2ea
 
 statement ok
-DROP VIEW view_1_tab4_82
+DROP VIEW IF EXISTS view_1_tab4_82 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_82
+DROP VIEW IF EXISTS view_2_tab4_82 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_82
+DROP VIEW IF EXISTS view_3_tab4_82 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3375,13 +3375,13 @@ SELECT pk FROM tab0 WHERE ((col1 = 459.6) OR col4 IS NULL) OR (col0 = 426)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_83
+DROP VIEW IF EXISTS view_1_tab0_83 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_83
+DROP VIEW IF EXISTS view_2_tab0_83 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_83
+DROP VIEW IF EXISTS view_3_tab0_83 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3467,13 +3467,13 @@ SELECT pk FROM tab1 WHERE ((col1 = 459.6) OR col4 IS NULL) OR (col0 = 426)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_83
+DROP VIEW IF EXISTS view_1_tab1_83 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_83
+DROP VIEW IF EXISTS view_2_tab1_83 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_83
+DROP VIEW IF EXISTS view_3_tab1_83 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3559,13 +3559,13 @@ SELECT pk FROM tab2 WHERE ((col1 = 459.6) OR col4 IS NULL) OR (col0 = 426)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_83
+DROP VIEW IF EXISTS view_1_tab2_83 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_83
+DROP VIEW IF EXISTS view_2_tab2_83 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_83
+DROP VIEW IF EXISTS view_3_tab2_83 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3651,13 +3651,13 @@ SELECT pk FROM tab3 WHERE ((col1 = 459.6) OR col4 IS NULL) OR (col0 = 426)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_83
+DROP VIEW IF EXISTS view_1_tab3_83 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_83
+DROP VIEW IF EXISTS view_2_tab3_83 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_83
+DROP VIEW IF EXISTS view_3_tab3_83 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3743,13 +3743,13 @@ SELECT pk FROM tab4 WHERE ((col1 = 459.6) OR col4 IS NULL) OR (col0 = 426)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_83
+DROP VIEW IF EXISTS view_1_tab4_83 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_83
+DROP VIEW IF EXISTS view_2_tab4_83 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_83
+DROP VIEW IF EXISTS view_3_tab4_83 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3855,13 +3855,13 @@ SELECT pk FROM tab0 WHERE col0 > 979
 94
 
 statement ok
-DROP VIEW view_1_tab0_84
+DROP VIEW IF EXISTS view_1_tab0_84 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_84
+DROP VIEW IF EXISTS view_2_tab0_84 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_84
+DROP VIEW IF EXISTS view_3_tab0_84 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3967,13 +3967,13 @@ SELECT pk FROM tab1 WHERE col0 > 979
 94
 
 statement ok
-DROP VIEW view_1_tab1_84
+DROP VIEW IF EXISTS view_1_tab1_84 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_84
+DROP VIEW IF EXISTS view_2_tab1_84 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_84
+DROP VIEW IF EXISTS view_3_tab1_84 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4079,13 +4079,13 @@ SELECT pk FROM tab2 WHERE col0 > 979
 94
 
 statement ok
-DROP VIEW view_1_tab2_84
+DROP VIEW IF EXISTS view_1_tab2_84 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_84
+DROP VIEW IF EXISTS view_2_tab2_84 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_84
+DROP VIEW IF EXISTS view_3_tab2_84 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4191,13 +4191,13 @@ SELECT pk FROM tab3 WHERE col0 > 979
 94
 
 statement ok
-DROP VIEW view_1_tab3_84
+DROP VIEW IF EXISTS view_1_tab3_84 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_84
+DROP VIEW IF EXISTS view_2_tab3_84 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_84
+DROP VIEW IF EXISTS view_3_tab3_84 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4303,13 +4303,13 @@ SELECT pk FROM tab4 WHERE col0 > 979
 94
 
 statement ok
-DROP VIEW view_1_tab4_84
+DROP VIEW IF EXISTS view_1_tab4_84 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_84
+DROP VIEW IF EXISTS view_2_tab4_84 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_84
+DROP VIEW IF EXISTS view_3_tab4_84 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4400,13 +4400,13 @@ SELECT pk FROM tab0 WHERE col4 < 377.40
 37 values hashing to 0e1fc7c2beb54031c52913072fedc723
 
 statement ok
-DROP VIEW view_1_tab0_85
+DROP VIEW IF EXISTS view_1_tab0_85 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_85
+DROP VIEW IF EXISTS view_2_tab0_85 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_85
+DROP VIEW IF EXISTS view_3_tab0_85 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4497,13 +4497,13 @@ SELECT pk FROM tab1 WHERE col4 < 377.40
 37 values hashing to 0e1fc7c2beb54031c52913072fedc723
 
 statement ok
-DROP VIEW view_1_tab1_85
+DROP VIEW IF EXISTS view_1_tab1_85 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_85
+DROP VIEW IF EXISTS view_2_tab1_85 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_85
+DROP VIEW IF EXISTS view_3_tab1_85 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4594,13 +4594,13 @@ SELECT pk FROM tab2 WHERE col4 < 377.40
 37 values hashing to 0e1fc7c2beb54031c52913072fedc723
 
 statement ok
-DROP VIEW view_1_tab2_85
+DROP VIEW IF EXISTS view_1_tab2_85 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_85
+DROP VIEW IF EXISTS view_2_tab2_85 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_85
+DROP VIEW IF EXISTS view_3_tab2_85 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4691,13 +4691,13 @@ SELECT pk FROM tab3 WHERE col4 < 377.40
 37 values hashing to 0e1fc7c2beb54031c52913072fedc723
 
 statement ok
-DROP VIEW view_1_tab3_85
+DROP VIEW IF EXISTS view_1_tab3_85 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_85
+DROP VIEW IF EXISTS view_2_tab3_85 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_85
+DROP VIEW IF EXISTS view_3_tab3_85 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4788,13 +4788,13 @@ SELECT pk FROM tab4 WHERE col4 < 377.40
 37 values hashing to 0e1fc7c2beb54031c52913072fedc723
 
 statement ok
-DROP VIEW view_1_tab4_85
+DROP VIEW IF EXISTS view_1_tab4_85 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_85
+DROP VIEW IF EXISTS view_2_tab4_85 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_85
+DROP VIEW IF EXISTS view_3_tab4_85 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4880,13 +4880,13 @@ SELECT pk FROM tab0 WHERE col0 IN (455,415)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_86
+DROP VIEW IF EXISTS view_1_tab0_86 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_86
+DROP VIEW IF EXISTS view_2_tab0_86 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_86
+DROP VIEW IF EXISTS view_3_tab0_86 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4972,13 +4972,13 @@ SELECT pk FROM tab1 WHERE col0 IN (455,415)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_86
+DROP VIEW IF EXISTS view_1_tab1_86 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_86
+DROP VIEW IF EXISTS view_2_tab1_86 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_86
+DROP VIEW IF EXISTS view_3_tab1_86 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5064,13 +5064,13 @@ SELECT pk FROM tab2 WHERE col0 IN (455,415)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_86
+DROP VIEW IF EXISTS view_1_tab2_86 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_86
+DROP VIEW IF EXISTS view_2_tab2_86 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_86
+DROP VIEW IF EXISTS view_3_tab2_86 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5156,13 +5156,13 @@ SELECT pk FROM tab3 WHERE col0 IN (455,415)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_86
+DROP VIEW IF EXISTS view_1_tab3_86 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_86
+DROP VIEW IF EXISTS view_2_tab3_86 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_86
+DROP VIEW IF EXISTS view_3_tab3_86 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5248,13 +5248,13 @@ SELECT pk FROM tab4 WHERE col0 IN (455,415)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_86
+DROP VIEW IF EXISTS view_1_tab4_86 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_86
+DROP VIEW IF EXISTS view_2_tab4_86 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_86
+DROP VIEW IF EXISTS view_3_tab4_86 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5345,13 +5345,13 @@ SELECT pk FROM tab0 WHERE (col1 <= 669.80 AND col4 <= 570.92)
 36 values hashing to 647aaf7f098ca164d04fce68f94bea9b
 
 statement ok
-DROP VIEW view_1_tab0_87
+DROP VIEW IF EXISTS view_1_tab0_87 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_87
+DROP VIEW IF EXISTS view_2_tab0_87 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_87
+DROP VIEW IF EXISTS view_3_tab0_87 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5442,13 +5442,13 @@ SELECT pk FROM tab1 WHERE (col1 <= 669.80 AND col4 <= 570.92)
 36 values hashing to 647aaf7f098ca164d04fce68f94bea9b
 
 statement ok
-DROP VIEW view_1_tab1_87
+DROP VIEW IF EXISTS view_1_tab1_87 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_87
+DROP VIEW IF EXISTS view_2_tab1_87 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_87
+DROP VIEW IF EXISTS view_3_tab1_87 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5539,13 +5539,13 @@ SELECT pk FROM tab2 WHERE (col1 <= 669.80 AND col4 <= 570.92)
 36 values hashing to 647aaf7f098ca164d04fce68f94bea9b
 
 statement ok
-DROP VIEW view_1_tab2_87
+DROP VIEW IF EXISTS view_1_tab2_87 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_87
+DROP VIEW IF EXISTS view_2_tab2_87 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_87
+DROP VIEW IF EXISTS view_3_tab2_87 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5636,13 +5636,13 @@ SELECT pk FROM tab3 WHERE (col1 <= 669.80 AND col4 <= 570.92)
 36 values hashing to 647aaf7f098ca164d04fce68f94bea9b
 
 statement ok
-DROP VIEW view_1_tab3_87
+DROP VIEW IF EXISTS view_1_tab3_87 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_87
+DROP VIEW IF EXISTS view_2_tab3_87 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_87
+DROP VIEW IF EXISTS view_3_tab3_87 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5733,13 +5733,13 @@ SELECT pk FROM tab4 WHERE (col1 <= 669.80 AND col4 <= 570.92)
 36 values hashing to 647aaf7f098ca164d04fce68f94bea9b
 
 statement ok
-DROP VIEW view_1_tab4_87
+DROP VIEW IF EXISTS view_1_tab4_87 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_87
+DROP VIEW IF EXISTS view_2_tab4_87 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_87
+DROP VIEW IF EXISTS view_3_tab4_87 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5830,13 +5830,13 @@ SELECT pk FROM tab0 WHERE col0 <= 229 OR col3 >= 292 AND col0 < 669 AND col4 IS 
 28 values hashing to e2d6a6ad99408ddb68912faa60a84d36
 
 statement ok
-DROP VIEW view_1_tab0_88
+DROP VIEW IF EXISTS view_1_tab0_88 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_88
+DROP VIEW IF EXISTS view_2_tab0_88 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_88
+DROP VIEW IF EXISTS view_3_tab0_88 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5927,13 +5927,13 @@ SELECT pk FROM tab1 WHERE col0 <= 229 OR col3 >= 292 AND col0 < 669 AND col4 IS 
 28 values hashing to e2d6a6ad99408ddb68912faa60a84d36
 
 statement ok
-DROP VIEW view_1_tab1_88
+DROP VIEW IF EXISTS view_1_tab1_88 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_88
+DROP VIEW IF EXISTS view_2_tab1_88 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_88
+DROP VIEW IF EXISTS view_3_tab1_88 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6024,13 +6024,13 @@ SELECT pk FROM tab2 WHERE col0 <= 229 OR col3 >= 292 AND col0 < 669 AND col4 IS 
 28 values hashing to e2d6a6ad99408ddb68912faa60a84d36
 
 statement ok
-DROP VIEW view_1_tab2_88
+DROP VIEW IF EXISTS view_1_tab2_88 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_88
+DROP VIEW IF EXISTS view_2_tab2_88 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_88
+DROP VIEW IF EXISTS view_3_tab2_88 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6121,13 +6121,13 @@ SELECT pk FROM tab3 WHERE col0 <= 229 OR col3 >= 292 AND col0 < 669 AND col4 IS 
 28 values hashing to e2d6a6ad99408ddb68912faa60a84d36
 
 statement ok
-DROP VIEW view_1_tab3_88
+DROP VIEW IF EXISTS view_1_tab3_88 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_88
+DROP VIEW IF EXISTS view_2_tab3_88 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_88
+DROP VIEW IF EXISTS view_3_tab3_88 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6218,13 +6218,13 @@ SELECT pk FROM tab4 WHERE col0 <= 229 OR col3 >= 292 AND col0 < 669 AND col4 IS 
 28 values hashing to e2d6a6ad99408ddb68912faa60a84d36
 
 statement ok
-DROP VIEW view_1_tab4_88
+DROP VIEW IF EXISTS view_1_tab4_88 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_88
+DROP VIEW IF EXISTS view_2_tab4_88 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_88
+DROP VIEW IF EXISTS view_3_tab4_88 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6315,13 +6315,13 @@ SELECT pk FROM tab0 WHERE col1 <= 38.96 AND col4 IN (717.97,930.23,946.43,274.22
 77 values hashing to d40f878ba822143dafeedb997ca66916
 
 statement ok
-DROP VIEW view_1_tab0_89
+DROP VIEW IF EXISTS view_1_tab0_89 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_89
+DROP VIEW IF EXISTS view_2_tab0_89 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_89
+DROP VIEW IF EXISTS view_3_tab0_89 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6412,13 +6412,13 @@ SELECT pk FROM tab1 WHERE col1 <= 38.96 AND col4 IN (717.97,930.23,946.43,274.22
 77 values hashing to d40f878ba822143dafeedb997ca66916
 
 statement ok
-DROP VIEW view_1_tab1_89
+DROP VIEW IF EXISTS view_1_tab1_89 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_89
+DROP VIEW IF EXISTS view_2_tab1_89 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_89
+DROP VIEW IF EXISTS view_3_tab1_89 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6509,13 +6509,13 @@ SELECT pk FROM tab2 WHERE col1 <= 38.96 AND col4 IN (717.97,930.23,946.43,274.22
 77 values hashing to d40f878ba822143dafeedb997ca66916
 
 statement ok
-DROP VIEW view_1_tab2_89
+DROP VIEW IF EXISTS view_1_tab2_89 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_89
+DROP VIEW IF EXISTS view_2_tab2_89 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_89
+DROP VIEW IF EXISTS view_3_tab2_89 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6606,13 +6606,13 @@ SELECT pk FROM tab3 WHERE col1 <= 38.96 AND col4 IN (717.97,930.23,946.43,274.22
 77 values hashing to d40f878ba822143dafeedb997ca66916
 
 statement ok
-DROP VIEW view_1_tab3_89
+DROP VIEW IF EXISTS view_1_tab3_89 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_89
+DROP VIEW IF EXISTS view_2_tab3_89 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_89
+DROP VIEW IF EXISTS view_3_tab3_89 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6703,13 +6703,13 @@ SELECT pk FROM tab4 WHERE col1 <= 38.96 AND col4 IN (717.97,930.23,946.43,274.22
 77 values hashing to d40f878ba822143dafeedb997ca66916
 
 statement ok
-DROP VIEW view_1_tab4_89
+DROP VIEW IF EXISTS view_1_tab4_89 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_89
+DROP VIEW IF EXISTS view_2_tab4_89 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_89
+DROP VIEW IF EXISTS view_3_tab4_89 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6800,13 +6800,13 @@ SELECT pk FROM tab0 WHERE ((col1 < 929.98 AND col0 = 621 AND col0 >= 647 AND col
 94 values hashing to 93b27a702d8af5b7b85020665d777fba
 
 statement ok
-DROP VIEW view_1_tab0_90
+DROP VIEW IF EXISTS view_1_tab0_90 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_90
+DROP VIEW IF EXISTS view_2_tab0_90 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_90
+DROP VIEW IF EXISTS view_3_tab0_90 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6897,13 +6897,13 @@ SELECT pk FROM tab1 WHERE ((col1 < 929.98 AND col0 = 621 AND col0 >= 647 AND col
 94 values hashing to 93b27a702d8af5b7b85020665d777fba
 
 statement ok
-DROP VIEW view_1_tab1_90
+DROP VIEW IF EXISTS view_1_tab1_90 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_90
+DROP VIEW IF EXISTS view_2_tab1_90 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_90
+DROP VIEW IF EXISTS view_3_tab1_90 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6994,13 +6994,13 @@ SELECT pk FROM tab2 WHERE ((col1 < 929.98 AND col0 = 621 AND col0 >= 647 AND col
 94 values hashing to 93b27a702d8af5b7b85020665d777fba
 
 statement ok
-DROP VIEW view_1_tab2_90
+DROP VIEW IF EXISTS view_1_tab2_90 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_90
+DROP VIEW IF EXISTS view_2_tab2_90 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_90
+DROP VIEW IF EXISTS view_3_tab2_90 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7091,13 +7091,13 @@ SELECT pk FROM tab3 WHERE ((col1 < 929.98 AND col0 = 621 AND col0 >= 647 AND col
 94 values hashing to 93b27a702d8af5b7b85020665d777fba
 
 statement ok
-DROP VIEW view_1_tab3_90
+DROP VIEW IF EXISTS view_1_tab3_90 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_90
+DROP VIEW IF EXISTS view_2_tab3_90 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_90
+DROP VIEW IF EXISTS view_3_tab3_90 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7188,13 +7188,13 @@ SELECT pk FROM tab4 WHERE ((col1 < 929.98 AND col0 = 621 AND col0 >= 647 AND col
 94 values hashing to 93b27a702d8af5b7b85020665d777fba
 
 statement ok
-DROP VIEW view_1_tab4_90
+DROP VIEW IF EXISTS view_1_tab4_90 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_90
+DROP VIEW IF EXISTS view_2_tab4_90 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_90
+DROP VIEW IF EXISTS view_3_tab4_90 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7285,13 +7285,13 @@ SELECT pk FROM tab0 WHERE col0 BETWEEN 426 AND 515
 11 values hashing to d10d6c7a3d9afe6ea0ed494345f2e84f
 
 statement ok
-DROP VIEW view_1_tab0_91
+DROP VIEW IF EXISTS view_1_tab0_91 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_91
+DROP VIEW IF EXISTS view_2_tab0_91 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_91
+DROP VIEW IF EXISTS view_3_tab0_91 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7382,13 +7382,13 @@ SELECT pk FROM tab1 WHERE col0 BETWEEN 426 AND 515
 11 values hashing to d10d6c7a3d9afe6ea0ed494345f2e84f
 
 statement ok
-DROP VIEW view_1_tab1_91
+DROP VIEW IF EXISTS view_1_tab1_91 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_91
+DROP VIEW IF EXISTS view_2_tab1_91 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_91
+DROP VIEW IF EXISTS view_3_tab1_91 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7479,13 +7479,13 @@ SELECT pk FROM tab2 WHERE col0 BETWEEN 426 AND 515
 11 values hashing to d10d6c7a3d9afe6ea0ed494345f2e84f
 
 statement ok
-DROP VIEW view_1_tab2_91
+DROP VIEW IF EXISTS view_1_tab2_91 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_91
+DROP VIEW IF EXISTS view_2_tab2_91 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_91
+DROP VIEW IF EXISTS view_3_tab2_91 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7576,13 +7576,13 @@ SELECT pk FROM tab3 WHERE col0 BETWEEN 426 AND 515
 11 values hashing to d10d6c7a3d9afe6ea0ed494345f2e84f
 
 statement ok
-DROP VIEW view_1_tab3_91
+DROP VIEW IF EXISTS view_1_tab3_91 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_91
+DROP VIEW IF EXISTS view_2_tab3_91 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_91
+DROP VIEW IF EXISTS view_3_tab3_91 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7673,13 +7673,13 @@ SELECT pk FROM tab4 WHERE col0 BETWEEN 426 AND 515
 11 values hashing to d10d6c7a3d9afe6ea0ed494345f2e84f
 
 statement ok
-DROP VIEW view_1_tab4_91
+DROP VIEW IF EXISTS view_1_tab4_91 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_91
+DROP VIEW IF EXISTS view_2_tab4_91 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_91
+DROP VIEW IF EXISTS view_3_tab4_91 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7770,13 +7770,13 @@ SELECT pk FROM tab0 WHERE col0 >= 278 AND col3 <= 409
 26 values hashing to 79bf8f02e02e8a02771e4851ea70cda9
 
 statement ok
-DROP VIEW view_1_tab0_92
+DROP VIEW IF EXISTS view_1_tab0_92 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_92
+DROP VIEW IF EXISTS view_2_tab0_92 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_92
+DROP VIEW IF EXISTS view_3_tab0_92 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7867,13 +7867,13 @@ SELECT pk FROM tab1 WHERE col0 >= 278 AND col3 <= 409
 26 values hashing to 79bf8f02e02e8a02771e4851ea70cda9
 
 statement ok
-DROP VIEW view_1_tab1_92
+DROP VIEW IF EXISTS view_1_tab1_92 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_92
+DROP VIEW IF EXISTS view_2_tab1_92 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_92
+DROP VIEW IF EXISTS view_3_tab1_92 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7964,13 +7964,13 @@ SELECT pk FROM tab2 WHERE col0 >= 278 AND col3 <= 409
 26 values hashing to 79bf8f02e02e8a02771e4851ea70cda9
 
 statement ok
-DROP VIEW view_1_tab2_92
+DROP VIEW IF EXISTS view_1_tab2_92 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_92
+DROP VIEW IF EXISTS view_2_tab2_92 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_92
+DROP VIEW IF EXISTS view_3_tab2_92 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8061,13 +8061,13 @@ SELECT pk FROM tab3 WHERE col0 >= 278 AND col3 <= 409
 26 values hashing to 79bf8f02e02e8a02771e4851ea70cda9
 
 statement ok
-DROP VIEW view_1_tab3_92
+DROP VIEW IF EXISTS view_1_tab3_92 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_92
+DROP VIEW IF EXISTS view_2_tab3_92 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_92
+DROP VIEW IF EXISTS view_3_tab3_92 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8158,13 +8158,13 @@ SELECT pk FROM tab4 WHERE col0 >= 278 AND col3 <= 409
 26 values hashing to 79bf8f02e02e8a02771e4851ea70cda9
 
 statement ok
-DROP VIEW view_1_tab4_92
+DROP VIEW IF EXISTS view_1_tab4_92 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_92
+DROP VIEW IF EXISTS view_2_tab4_92 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_92
+DROP VIEW IF EXISTS view_3_tab4_92 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8250,13 +8250,13 @@ SELECT pk FROM tab0 WHERE col4 < 813.50 AND col0 >= 561 AND (col4 >= 32.37 AND c
 ----
 
 statement ok
-DROP VIEW view_1_tab0_93
+DROP VIEW IF EXISTS view_1_tab0_93 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_93
+DROP VIEW IF EXISTS view_2_tab0_93 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_93
+DROP VIEW IF EXISTS view_3_tab0_93 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8342,13 +8342,13 @@ SELECT pk FROM tab1 WHERE col4 < 813.50 AND col0 >= 561 AND (col4 >= 32.37 AND c
 ----
 
 statement ok
-DROP VIEW view_1_tab1_93
+DROP VIEW IF EXISTS view_1_tab1_93 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_93
+DROP VIEW IF EXISTS view_2_tab1_93 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_93
+DROP VIEW IF EXISTS view_3_tab1_93 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8434,13 +8434,13 @@ SELECT pk FROM tab2 WHERE col4 < 813.50 AND col0 >= 561 AND (col4 >= 32.37 AND c
 ----
 
 statement ok
-DROP VIEW view_1_tab2_93
+DROP VIEW IF EXISTS view_1_tab2_93 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_93
+DROP VIEW IF EXISTS view_2_tab2_93 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_93
+DROP VIEW IF EXISTS view_3_tab2_93 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8526,13 +8526,13 @@ SELECT pk FROM tab3 WHERE col4 < 813.50 AND col0 >= 561 AND (col4 >= 32.37 AND c
 ----
 
 statement ok
-DROP VIEW view_1_tab3_93
+DROP VIEW IF EXISTS view_1_tab3_93 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_93
+DROP VIEW IF EXISTS view_2_tab3_93 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_93
+DROP VIEW IF EXISTS view_3_tab3_93 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8618,13 +8618,13 @@ SELECT pk FROM tab4 WHERE col4 < 813.50 AND col0 >= 561 AND (col4 >= 32.37 AND c
 ----
 
 statement ok
-DROP VIEW view_1_tab4_93
+DROP VIEW IF EXISTS view_1_tab4_93 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_93
+DROP VIEW IF EXISTS view_2_tab4_93 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_93
+DROP VIEW IF EXISTS view_3_tab4_93 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8715,13 +8715,13 @@ SELECT pk FROM tab0 WHERE (col4 > 594.73)
 44 values hashing to 97899427adf8dd5eb55e8597a1de5b1e
 
 statement ok
-DROP VIEW view_1_tab0_94
+DROP VIEW IF EXISTS view_1_tab0_94 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_94
+DROP VIEW IF EXISTS view_2_tab0_94 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_94
+DROP VIEW IF EXISTS view_3_tab0_94 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8812,13 +8812,13 @@ SELECT pk FROM tab1 WHERE (col4 > 594.73)
 44 values hashing to 97899427adf8dd5eb55e8597a1de5b1e
 
 statement ok
-DROP VIEW view_1_tab1_94
+DROP VIEW IF EXISTS view_1_tab1_94 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_94
+DROP VIEW IF EXISTS view_2_tab1_94 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_94
+DROP VIEW IF EXISTS view_3_tab1_94 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8909,13 +8909,13 @@ SELECT pk FROM tab2 WHERE (col4 > 594.73)
 44 values hashing to 97899427adf8dd5eb55e8597a1de5b1e
 
 statement ok
-DROP VIEW view_1_tab2_94
+DROP VIEW IF EXISTS view_1_tab2_94 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_94
+DROP VIEW IF EXISTS view_2_tab2_94 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_94
+DROP VIEW IF EXISTS view_3_tab2_94 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9006,13 +9006,13 @@ SELECT pk FROM tab3 WHERE (col4 > 594.73)
 44 values hashing to 97899427adf8dd5eb55e8597a1de5b1e
 
 statement ok
-DROP VIEW view_1_tab3_94
+DROP VIEW IF EXISTS view_1_tab3_94 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_94
+DROP VIEW IF EXISTS view_2_tab3_94 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_94
+DROP VIEW IF EXISTS view_3_tab3_94 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9103,13 +9103,13 @@ SELECT pk FROM tab4 WHERE (col4 > 594.73)
 44 values hashing to 97899427adf8dd5eb55e8597a1de5b1e
 
 statement ok
-DROP VIEW view_1_tab4_94
+DROP VIEW IF EXISTS view_1_tab4_94 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_94
+DROP VIEW IF EXISTS view_2_tab4_94 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_94
+DROP VIEW IF EXISTS view_3_tab4_94 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9218,13 +9218,13 @@ SELECT pk FROM tab0 WHERE col4 <= 119.8
 91
 
 statement ok
-DROP VIEW view_1_tab0_95
+DROP VIEW IF EXISTS view_1_tab0_95 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_95
+DROP VIEW IF EXISTS view_2_tab0_95 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_95
+DROP VIEW IF EXISTS view_3_tab0_95 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9333,13 +9333,13 @@ SELECT pk FROM tab1 WHERE col4 <= 119.8
 91
 
 statement ok
-DROP VIEW view_1_tab1_95
+DROP VIEW IF EXISTS view_1_tab1_95 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_95
+DROP VIEW IF EXISTS view_2_tab1_95 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_95
+DROP VIEW IF EXISTS view_3_tab1_95 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9448,13 +9448,13 @@ SELECT pk FROM tab2 WHERE col4 <= 119.8
 91
 
 statement ok
-DROP VIEW view_1_tab2_95
+DROP VIEW IF EXISTS view_1_tab2_95 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_95
+DROP VIEW IF EXISTS view_2_tab2_95 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_95
+DROP VIEW IF EXISTS view_3_tab2_95 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9563,13 +9563,13 @@ SELECT pk FROM tab3 WHERE col4 <= 119.8
 91
 
 statement ok
-DROP VIEW view_1_tab3_95
+DROP VIEW IF EXISTS view_1_tab3_95 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_95
+DROP VIEW IF EXISTS view_2_tab3_95 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_95
+DROP VIEW IF EXISTS view_3_tab3_95 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9678,13 +9678,13 @@ SELECT pk FROM tab4 WHERE col4 <= 119.8
 91
 
 statement ok
-DROP VIEW view_1_tab4_95
+DROP VIEW IF EXISTS view_1_tab4_95 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_95
+DROP VIEW IF EXISTS view_2_tab4_95 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_95
+DROP VIEW IF EXISTS view_3_tab4_95 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9775,13 +9775,13 @@ SELECT pk FROM tab0 WHERE col0 > 890
 10 values hashing to 86f2cd8bf65b00633f344fa0732f6ea7
 
 statement ok
-DROP VIEW view_1_tab0_96
+DROP VIEW IF EXISTS view_1_tab0_96 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_96
+DROP VIEW IF EXISTS view_2_tab0_96 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_96
+DROP VIEW IF EXISTS view_3_tab0_96 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9872,13 +9872,13 @@ SELECT pk FROM tab1 WHERE col0 > 890
 10 values hashing to 86f2cd8bf65b00633f344fa0732f6ea7
 
 statement ok
-DROP VIEW view_1_tab1_96
+DROP VIEW IF EXISTS view_1_tab1_96 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_96
+DROP VIEW IF EXISTS view_2_tab1_96 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_96
+DROP VIEW IF EXISTS view_3_tab1_96 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9969,13 +9969,13 @@ SELECT pk FROM tab2 WHERE col0 > 890
 10 values hashing to 86f2cd8bf65b00633f344fa0732f6ea7
 
 statement ok
-DROP VIEW view_1_tab2_96
+DROP VIEW IF EXISTS view_1_tab2_96 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_96
+DROP VIEW IF EXISTS view_2_tab2_96 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_96
+DROP VIEW IF EXISTS view_3_tab2_96 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10066,13 +10066,13 @@ SELECT pk FROM tab3 WHERE col0 > 890
 10 values hashing to 86f2cd8bf65b00633f344fa0732f6ea7
 
 statement ok
-DROP VIEW view_1_tab3_96
+DROP VIEW IF EXISTS view_1_tab3_96 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_96
+DROP VIEW IF EXISTS view_2_tab3_96 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_96
+DROP VIEW IF EXISTS view_3_tab3_96 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10163,13 +10163,13 @@ SELECT pk FROM tab4 WHERE col0 > 890
 10 values hashing to 86f2cd8bf65b00633f344fa0732f6ea7
 
 statement ok
-DROP VIEW view_1_tab4_96
+DROP VIEW IF EXISTS view_1_tab4_96 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_96
+DROP VIEW IF EXISTS view_2_tab4_96 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_96
+DROP VIEW IF EXISTS view_3_tab4_96 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10255,13 +10255,13 @@ SELECT pk FROM tab0 WHERE ((col0 < 462 AND col1 < 533.61 AND (col4 >= 315.98) OR
 ----
 
 statement ok
-DROP VIEW view_1_tab0_97
+DROP VIEW IF EXISTS view_1_tab0_97 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_97
+DROP VIEW IF EXISTS view_2_tab0_97 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_97
+DROP VIEW IF EXISTS view_3_tab0_97 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10347,13 +10347,13 @@ SELECT pk FROM tab1 WHERE ((col0 < 462 AND col1 < 533.61 AND (col4 >= 315.98) OR
 ----
 
 statement ok
-DROP VIEW view_1_tab1_97
+DROP VIEW IF EXISTS view_1_tab1_97 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_97
+DROP VIEW IF EXISTS view_2_tab1_97 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_97
+DROP VIEW IF EXISTS view_3_tab1_97 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10439,13 +10439,13 @@ SELECT pk FROM tab2 WHERE ((col0 < 462 AND col1 < 533.61 AND (col4 >= 315.98) OR
 ----
 
 statement ok
-DROP VIEW view_1_tab2_97
+DROP VIEW IF EXISTS view_1_tab2_97 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_97
+DROP VIEW IF EXISTS view_2_tab2_97 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_97
+DROP VIEW IF EXISTS view_3_tab2_97 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10531,13 +10531,13 @@ SELECT pk FROM tab3 WHERE ((col0 < 462 AND col1 < 533.61 AND (col4 >= 315.98) OR
 ----
 
 statement ok
-DROP VIEW view_1_tab3_97
+DROP VIEW IF EXISTS view_1_tab3_97 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_97
+DROP VIEW IF EXISTS view_2_tab3_97 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_97
+DROP VIEW IF EXISTS view_3_tab3_97 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10623,13 +10623,13 @@ SELECT pk FROM tab4 WHERE ((col0 < 462 AND col1 < 533.61 AND (col4 >= 315.98) OR
 ----
 
 statement ok
-DROP VIEW view_1_tab4_97
+DROP VIEW IF EXISTS view_1_tab4_97 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_97
+DROP VIEW IF EXISTS view_2_tab4_97 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_97
+DROP VIEW IF EXISTS view_3_tab4_97 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10715,13 +10715,13 @@ SELECT pk FROM tab0 WHERE col0 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab0_98
+DROP VIEW IF EXISTS view_1_tab0_98 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_98
+DROP VIEW IF EXISTS view_2_tab0_98 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_98
+DROP VIEW IF EXISTS view_3_tab0_98 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10807,13 +10807,13 @@ SELECT pk FROM tab1 WHERE col0 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab1_98
+DROP VIEW IF EXISTS view_1_tab1_98 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_98
+DROP VIEW IF EXISTS view_2_tab1_98 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_98
+DROP VIEW IF EXISTS view_3_tab1_98 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10899,13 +10899,13 @@ SELECT pk FROM tab2 WHERE col0 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab2_98
+DROP VIEW IF EXISTS view_1_tab2_98 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_98
+DROP VIEW IF EXISTS view_2_tab2_98 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_98
+DROP VIEW IF EXISTS view_3_tab2_98 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10991,13 +10991,13 @@ SELECT pk FROM tab3 WHERE col0 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab3_98
+DROP VIEW IF EXISTS view_1_tab3_98 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_98
+DROP VIEW IF EXISTS view_2_tab3_98 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_98
+DROP VIEW IF EXISTS view_3_tab3_98 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11083,13 +11083,13 @@ SELECT pk FROM tab4 WHERE col0 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab4_98
+DROP VIEW IF EXISTS view_1_tab4_98 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_98
+DROP VIEW IF EXISTS view_2_tab4_98 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_98
+DROP VIEW IF EXISTS view_3_tab4_98 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11175,13 +11175,13 @@ SELECT pk FROM tab0 WHERE col4 <= 142.77 AND col4 = 64.41 AND col1 >= 487.86 AND
 ----
 
 statement ok
-DROP VIEW view_1_tab0_99
+DROP VIEW IF EXISTS view_1_tab0_99 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_99
+DROP VIEW IF EXISTS view_2_tab0_99 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_99
+DROP VIEW IF EXISTS view_3_tab0_99 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11267,13 +11267,13 @@ SELECT pk FROM tab1 WHERE col4 <= 142.77 AND col4 = 64.41 AND col1 >= 487.86 AND
 ----
 
 statement ok
-DROP VIEW view_1_tab1_99
+DROP VIEW IF EXISTS view_1_tab1_99 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_99
+DROP VIEW IF EXISTS view_2_tab1_99 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_99
+DROP VIEW IF EXISTS view_3_tab1_99 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11359,13 +11359,13 @@ SELECT pk FROM tab2 WHERE col4 <= 142.77 AND col4 = 64.41 AND col1 >= 487.86 AND
 ----
 
 statement ok
-DROP VIEW view_1_tab2_99
+DROP VIEW IF EXISTS view_1_tab2_99 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_99
+DROP VIEW IF EXISTS view_2_tab2_99 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_99
+DROP VIEW IF EXISTS view_3_tab2_99 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11451,13 +11451,13 @@ SELECT pk FROM tab3 WHERE col4 <= 142.77 AND col4 = 64.41 AND col1 >= 487.86 AND
 ----
 
 statement ok
-DROP VIEW view_1_tab3_99
+DROP VIEW IF EXISTS view_1_tab3_99 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_99
+DROP VIEW IF EXISTS view_2_tab3_99 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_99
+DROP VIEW IF EXISTS view_3_tab3_99 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11543,13 +11543,13 @@ SELECT pk FROM tab4 WHERE col4 <= 142.77 AND col4 = 64.41 AND col1 >= 487.86 AND
 ----
 
 statement ok
-DROP VIEW view_1_tab4_99
+DROP VIEW IF EXISTS view_1_tab4_99 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_99
+DROP VIEW IF EXISTS view_2_tab4_99 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_99
+DROP VIEW IF EXISTS view_3_tab4_99 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11640,13 +11640,13 @@ SELECT pk FROM tab0 WHERE col1 >= 922.41
 9 values hashing to c67b78b3e1f8977787f19fde8e0446be
 
 statement ok
-DROP VIEW view_1_tab0_100
+DROP VIEW IF EXISTS view_1_tab0_100 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_100
+DROP VIEW IF EXISTS view_2_tab0_100 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_100
+DROP VIEW IF EXISTS view_3_tab0_100 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11737,13 +11737,13 @@ SELECT pk FROM tab1 WHERE col1 >= 922.41
 9 values hashing to c67b78b3e1f8977787f19fde8e0446be
 
 statement ok
-DROP VIEW view_1_tab1_100
+DROP VIEW IF EXISTS view_1_tab1_100 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_100
+DROP VIEW IF EXISTS view_2_tab1_100 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_100
+DROP VIEW IF EXISTS view_3_tab1_100 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11834,13 +11834,13 @@ SELECT pk FROM tab2 WHERE col1 >= 922.41
 9 values hashing to c67b78b3e1f8977787f19fde8e0446be
 
 statement ok
-DROP VIEW view_1_tab2_100
+DROP VIEW IF EXISTS view_1_tab2_100 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_100
+DROP VIEW IF EXISTS view_2_tab2_100 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_100
+DROP VIEW IF EXISTS view_3_tab2_100 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11931,13 +11931,13 @@ SELECT pk FROM tab3 WHERE col1 >= 922.41
 9 values hashing to c67b78b3e1f8977787f19fde8e0446be
 
 statement ok
-DROP VIEW view_1_tab3_100
+DROP VIEW IF EXISTS view_1_tab3_100 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_100
+DROP VIEW IF EXISTS view_2_tab3_100 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_100
+DROP VIEW IF EXISTS view_3_tab3_100 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12028,13 +12028,13 @@ SELECT pk FROM tab4 WHERE col1 >= 922.41
 9 values hashing to c67b78b3e1f8977787f19fde8e0446be
 
 statement ok
-DROP VIEW view_1_tab4_100
+DROP VIEW IF EXISTS view_1_tab4_100 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_100
+DROP VIEW IF EXISTS view_2_tab4_100 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_100
+DROP VIEW IF EXISTS view_3_tab4_100 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12120,13 +12120,13 @@ SELECT pk FROM tab0 WHERE (col0 = 858)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_101
+DROP VIEW IF EXISTS view_1_tab0_101 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_101
+DROP VIEW IF EXISTS view_2_tab0_101 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_101
+DROP VIEW IF EXISTS view_3_tab0_101 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12212,13 +12212,13 @@ SELECT pk FROM tab1 WHERE (col0 = 858)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_101
+DROP VIEW IF EXISTS view_1_tab1_101 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_101
+DROP VIEW IF EXISTS view_2_tab1_101 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_101
+DROP VIEW IF EXISTS view_3_tab1_101 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12304,13 +12304,13 @@ SELECT pk FROM tab2 WHERE (col0 = 858)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_101
+DROP VIEW IF EXISTS view_1_tab2_101 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_101
+DROP VIEW IF EXISTS view_2_tab2_101 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_101
+DROP VIEW IF EXISTS view_3_tab2_101 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12396,13 +12396,13 @@ SELECT pk FROM tab3 WHERE (col0 = 858)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_101
+DROP VIEW IF EXISTS view_1_tab3_101 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_101
+DROP VIEW IF EXISTS view_2_tab3_101 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_101
+DROP VIEW IF EXISTS view_3_tab3_101 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12488,13 +12488,13 @@ SELECT pk FROM tab4 WHERE (col0 = 858)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_101
+DROP VIEW IF EXISTS view_1_tab4_101 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_101
+DROP VIEW IF EXISTS view_2_tab4_101 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_101
+DROP VIEW IF EXISTS view_3_tab4_101 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12585,13 +12585,13 @@ SELECT pk FROM tab0 WHERE (col4 < 188.32)
 12 values hashing to 739b120412276ab962961f15c98b0703
 
 statement ok
-DROP VIEW view_1_tab0_102
+DROP VIEW IF EXISTS view_1_tab0_102 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_102
+DROP VIEW IF EXISTS view_2_tab0_102 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_102
+DROP VIEW IF EXISTS view_3_tab0_102 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12682,13 +12682,13 @@ SELECT pk FROM tab1 WHERE (col4 < 188.32)
 12 values hashing to 739b120412276ab962961f15c98b0703
 
 statement ok
-DROP VIEW view_1_tab1_102
+DROP VIEW IF EXISTS view_1_tab1_102 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_102
+DROP VIEW IF EXISTS view_2_tab1_102 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_102
+DROP VIEW IF EXISTS view_3_tab1_102 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12779,13 +12779,13 @@ SELECT pk FROM tab2 WHERE (col4 < 188.32)
 12 values hashing to 739b120412276ab962961f15c98b0703
 
 statement ok
-DROP VIEW view_1_tab2_102
+DROP VIEW IF EXISTS view_1_tab2_102 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_102
+DROP VIEW IF EXISTS view_2_tab2_102 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_102
+DROP VIEW IF EXISTS view_3_tab2_102 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12876,13 +12876,13 @@ SELECT pk FROM tab3 WHERE (col4 < 188.32)
 12 values hashing to 739b120412276ab962961f15c98b0703
 
 statement ok
-DROP VIEW view_1_tab3_102
+DROP VIEW IF EXISTS view_1_tab3_102 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_102
+DROP VIEW IF EXISTS view_2_tab3_102 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_102
+DROP VIEW IF EXISTS view_3_tab3_102 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12973,13 +12973,13 @@ SELECT pk FROM tab4 WHERE (col4 < 188.32)
 12 values hashing to 739b120412276ab962961f15c98b0703
 
 statement ok
-DROP VIEW view_1_tab4_102
+DROP VIEW IF EXISTS view_1_tab4_102 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_102
+DROP VIEW IF EXISTS view_2_tab4_102 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_102
+DROP VIEW IF EXISTS view_3_tab4_102 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13070,13 +13070,13 @@ SELECT pk FROM tab0 WHERE col0 <= 326 OR col4 <= 179.10
 39 values hashing to a552913939e31430a1ce36ec5a1c45d0
 
 statement ok
-DROP VIEW view_1_tab0_103
+DROP VIEW IF EXISTS view_1_tab0_103 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_103
+DROP VIEW IF EXISTS view_2_tab0_103 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_103
+DROP VIEW IF EXISTS view_3_tab0_103 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13167,13 +13167,13 @@ SELECT pk FROM tab1 WHERE col0 <= 326 OR col4 <= 179.10
 39 values hashing to a552913939e31430a1ce36ec5a1c45d0
 
 statement ok
-DROP VIEW view_1_tab1_103
+DROP VIEW IF EXISTS view_1_tab1_103 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_103
+DROP VIEW IF EXISTS view_2_tab1_103 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_103
+DROP VIEW IF EXISTS view_3_tab1_103 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13264,13 +13264,13 @@ SELECT pk FROM tab2 WHERE col0 <= 326 OR col4 <= 179.10
 39 values hashing to a552913939e31430a1ce36ec5a1c45d0
 
 statement ok
-DROP VIEW view_1_tab2_103
+DROP VIEW IF EXISTS view_1_tab2_103 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_103
+DROP VIEW IF EXISTS view_2_tab2_103 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_103
+DROP VIEW IF EXISTS view_3_tab2_103 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13361,13 +13361,13 @@ SELECT pk FROM tab3 WHERE col0 <= 326 OR col4 <= 179.10
 39 values hashing to a552913939e31430a1ce36ec5a1c45d0
 
 statement ok
-DROP VIEW view_1_tab3_103
+DROP VIEW IF EXISTS view_1_tab3_103 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_103
+DROP VIEW IF EXISTS view_2_tab3_103 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_103
+DROP VIEW IF EXISTS view_3_tab3_103 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13458,13 +13458,13 @@ SELECT pk FROM tab4 WHERE col0 <= 326 OR col4 <= 179.10
 39 values hashing to a552913939e31430a1ce36ec5a1c45d0
 
 statement ok
-DROP VIEW view_1_tab4_103
+DROP VIEW IF EXISTS view_1_tab4_103 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_103
+DROP VIEW IF EXISTS view_2_tab4_103 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_103
+DROP VIEW IF EXISTS view_3_tab4_103 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13555,13 +13555,13 @@ SELECT pk FROM tab0 WHERE (col3 <= 358)
 28 values hashing to 7c3ff06455f966a5d9476a288ad77110
 
 statement ok
-DROP VIEW view_1_tab0_104
+DROP VIEW IF EXISTS view_1_tab0_104 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_104
+DROP VIEW IF EXISTS view_2_tab0_104 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_104
+DROP VIEW IF EXISTS view_3_tab0_104 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13652,13 +13652,13 @@ SELECT pk FROM tab1 WHERE (col3 <= 358)
 28 values hashing to 7c3ff06455f966a5d9476a288ad77110
 
 statement ok
-DROP VIEW view_1_tab1_104
+DROP VIEW IF EXISTS view_1_tab1_104 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_104
+DROP VIEW IF EXISTS view_2_tab1_104 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_104
+DROP VIEW IF EXISTS view_3_tab1_104 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13749,13 +13749,13 @@ SELECT pk FROM tab2 WHERE (col3 <= 358)
 28 values hashing to 7c3ff06455f966a5d9476a288ad77110
 
 statement ok
-DROP VIEW view_1_tab2_104
+DROP VIEW IF EXISTS view_1_tab2_104 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_104
+DROP VIEW IF EXISTS view_2_tab2_104 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_104
+DROP VIEW IF EXISTS view_3_tab2_104 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13846,13 +13846,13 @@ SELECT pk FROM tab3 WHERE (col3 <= 358)
 28 values hashing to 7c3ff06455f966a5d9476a288ad77110
 
 statement ok
-DROP VIEW view_1_tab3_104
+DROP VIEW IF EXISTS view_1_tab3_104 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_104
+DROP VIEW IF EXISTS view_2_tab3_104 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_104
+DROP VIEW IF EXISTS view_3_tab3_104 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13943,13 +13943,13 @@ SELECT pk FROM tab4 WHERE (col3 <= 358)
 28 values hashing to 7c3ff06455f966a5d9476a288ad77110
 
 statement ok
-DROP VIEW view_1_tab4_104
+DROP VIEW IF EXISTS view_1_tab4_104 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_104
+DROP VIEW IF EXISTS view_2_tab4_104 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_104
+DROP VIEW IF EXISTS view_3_tab4_104 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14040,13 +14040,13 @@ SELECT pk FROM tab0 WHERE (col3 > 370)
 70 values hashing to 1902449bfa79559a8d14647d720e1848
 
 statement ok
-DROP VIEW view_1_tab0_105
+DROP VIEW IF EXISTS view_1_tab0_105 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_105
+DROP VIEW IF EXISTS view_2_tab0_105 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_105
+DROP VIEW IF EXISTS view_3_tab0_105 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14137,13 +14137,13 @@ SELECT pk FROM tab1 WHERE (col3 > 370)
 70 values hashing to 1902449bfa79559a8d14647d720e1848
 
 statement ok
-DROP VIEW view_1_tab1_105
+DROP VIEW IF EXISTS view_1_tab1_105 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_105
+DROP VIEW IF EXISTS view_2_tab1_105 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_105
+DROP VIEW IF EXISTS view_3_tab1_105 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14234,13 +14234,13 @@ SELECT pk FROM tab2 WHERE (col3 > 370)
 70 values hashing to 1902449bfa79559a8d14647d720e1848
 
 statement ok
-DROP VIEW view_1_tab2_105
+DROP VIEW IF EXISTS view_1_tab2_105 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_105
+DROP VIEW IF EXISTS view_2_tab2_105 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_105
+DROP VIEW IF EXISTS view_3_tab2_105 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14331,13 +14331,13 @@ SELECT pk FROM tab3 WHERE (col3 > 370)
 70 values hashing to 1902449bfa79559a8d14647d720e1848
 
 statement ok
-DROP VIEW view_1_tab3_105
+DROP VIEW IF EXISTS view_1_tab3_105 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_105
+DROP VIEW IF EXISTS view_2_tab3_105 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_105
+DROP VIEW IF EXISTS view_3_tab3_105 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14428,13 +14428,13 @@ SELECT pk FROM tab4 WHERE (col3 > 370)
 70 values hashing to 1902449bfa79559a8d14647d720e1848
 
 statement ok
-DROP VIEW view_1_tab4_105
+DROP VIEW IF EXISTS view_1_tab4_105 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_105
+DROP VIEW IF EXISTS view_2_tab4_105 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_105
+DROP VIEW IF EXISTS view_3_tab4_105 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14525,13 +14525,13 @@ SELECT pk FROM tab0 WHERE (col3 <= 512)
 46 values hashing to f1faf4f09cdc4cdbdddf5c4414354847
 
 statement ok
-DROP VIEW view_1_tab0_106
+DROP VIEW IF EXISTS view_1_tab0_106 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_106
+DROP VIEW IF EXISTS view_2_tab0_106 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_106
+DROP VIEW IF EXISTS view_3_tab0_106 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14622,13 +14622,13 @@ SELECT pk FROM tab1 WHERE (col3 <= 512)
 46 values hashing to f1faf4f09cdc4cdbdddf5c4414354847
 
 statement ok
-DROP VIEW view_1_tab1_106
+DROP VIEW IF EXISTS view_1_tab1_106 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_106
+DROP VIEW IF EXISTS view_2_tab1_106 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_106
+DROP VIEW IF EXISTS view_3_tab1_106 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14719,13 +14719,13 @@ SELECT pk FROM tab2 WHERE (col3 <= 512)
 46 values hashing to f1faf4f09cdc4cdbdddf5c4414354847
 
 statement ok
-DROP VIEW view_1_tab2_106
+DROP VIEW IF EXISTS view_1_tab2_106 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_106
+DROP VIEW IF EXISTS view_2_tab2_106 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_106
+DROP VIEW IF EXISTS view_3_tab2_106 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14816,13 +14816,13 @@ SELECT pk FROM tab3 WHERE (col3 <= 512)
 46 values hashing to f1faf4f09cdc4cdbdddf5c4414354847
 
 statement ok
-DROP VIEW view_1_tab3_106
+DROP VIEW IF EXISTS view_1_tab3_106 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_106
+DROP VIEW IF EXISTS view_2_tab3_106 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_106
+DROP VIEW IF EXISTS view_3_tab3_106 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14913,13 +14913,13 @@ SELECT pk FROM tab4 WHERE (col3 <= 512)
 46 values hashing to f1faf4f09cdc4cdbdddf5c4414354847
 
 statement ok
-DROP VIEW view_1_tab4_106
+DROP VIEW IF EXISTS view_1_tab4_106 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_106
+DROP VIEW IF EXISTS view_2_tab4_106 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_106
+DROP VIEW IF EXISTS view_3_tab4_106 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15010,13 +15010,13 @@ SELECT pk FROM tab0 WHERE (col3 < 404)
 36 values hashing to ab30dd380edf664856d7911c09f31c10
 
 statement ok
-DROP VIEW view_1_tab0_107
+DROP VIEW IF EXISTS view_1_tab0_107 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_107
+DROP VIEW IF EXISTS view_2_tab0_107 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_107
+DROP VIEW IF EXISTS view_3_tab0_107 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15107,13 +15107,13 @@ SELECT pk FROM tab1 WHERE (col3 < 404)
 36 values hashing to ab30dd380edf664856d7911c09f31c10
 
 statement ok
-DROP VIEW view_1_tab1_107
+DROP VIEW IF EXISTS view_1_tab1_107 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_107
+DROP VIEW IF EXISTS view_2_tab1_107 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_107
+DROP VIEW IF EXISTS view_3_tab1_107 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15204,13 +15204,13 @@ SELECT pk FROM tab2 WHERE (col3 < 404)
 36 values hashing to ab30dd380edf664856d7911c09f31c10
 
 statement ok
-DROP VIEW view_1_tab2_107
+DROP VIEW IF EXISTS view_1_tab2_107 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_107
+DROP VIEW IF EXISTS view_2_tab2_107 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_107
+DROP VIEW IF EXISTS view_3_tab2_107 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15301,13 +15301,13 @@ SELECT pk FROM tab3 WHERE (col3 < 404)
 36 values hashing to ab30dd380edf664856d7911c09f31c10
 
 statement ok
-DROP VIEW view_1_tab3_107
+DROP VIEW IF EXISTS view_1_tab3_107 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_107
+DROP VIEW IF EXISTS view_2_tab3_107 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_107
+DROP VIEW IF EXISTS view_3_tab3_107 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15398,13 +15398,13 @@ SELECT pk FROM tab4 WHERE (col3 < 404)
 36 values hashing to ab30dd380edf664856d7911c09f31c10
 
 statement ok
-DROP VIEW view_1_tab4_107
+DROP VIEW IF EXISTS view_1_tab4_107 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_107
+DROP VIEW IF EXISTS view_2_tab4_107 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_107
+DROP VIEW IF EXISTS view_3_tab4_107 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15490,13 +15490,13 @@ SELECT pk FROM tab0 WHERE (col1 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_108
+DROP VIEW IF EXISTS view_1_tab0_108 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_108
+DROP VIEW IF EXISTS view_2_tab0_108 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_108
+DROP VIEW IF EXISTS view_3_tab0_108 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15582,13 +15582,13 @@ SELECT pk FROM tab1 WHERE (col1 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_108
+DROP VIEW IF EXISTS view_1_tab1_108 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_108
+DROP VIEW IF EXISTS view_2_tab1_108 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_108
+DROP VIEW IF EXISTS view_3_tab1_108 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15674,13 +15674,13 @@ SELECT pk FROM tab2 WHERE (col1 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_108
+DROP VIEW IF EXISTS view_1_tab2_108 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_108
+DROP VIEW IF EXISTS view_2_tab2_108 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_108
+DROP VIEW IF EXISTS view_3_tab2_108 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15766,13 +15766,13 @@ SELECT pk FROM tab3 WHERE (col1 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_108
+DROP VIEW IF EXISTS view_1_tab3_108 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_108
+DROP VIEW IF EXISTS view_2_tab3_108 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_108
+DROP VIEW IF EXISTS view_3_tab3_108 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15858,13 +15858,13 @@ SELECT pk FROM tab4 WHERE (col1 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_108
+DROP VIEW IF EXISTS view_1_tab4_108 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_108
+DROP VIEW IF EXISTS view_2_tab4_108 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_108
+DROP VIEW IF EXISTS view_3_tab4_108 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15950,13 +15950,13 @@ SELECT pk FROM tab0 WHERE col3 IN (719,781)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_109
+DROP VIEW IF EXISTS view_1_tab0_109 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_109
+DROP VIEW IF EXISTS view_2_tab0_109 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_109
+DROP VIEW IF EXISTS view_3_tab0_109 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16042,13 +16042,13 @@ SELECT pk FROM tab1 WHERE col3 IN (719,781)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_109
+DROP VIEW IF EXISTS view_1_tab1_109 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_109
+DROP VIEW IF EXISTS view_2_tab1_109 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_109
+DROP VIEW IF EXISTS view_3_tab1_109 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16134,13 +16134,13 @@ SELECT pk FROM tab2 WHERE col3 IN (719,781)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_109
+DROP VIEW IF EXISTS view_1_tab2_109 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_109
+DROP VIEW IF EXISTS view_2_tab2_109 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_109
+DROP VIEW IF EXISTS view_3_tab2_109 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16226,13 +16226,13 @@ SELECT pk FROM tab3 WHERE col3 IN (719,781)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_109
+DROP VIEW IF EXISTS view_1_tab3_109 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_109
+DROP VIEW IF EXISTS view_2_tab3_109 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_109
+DROP VIEW IF EXISTS view_3_tab3_109 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16318,13 +16318,13 @@ SELECT pk FROM tab4 WHERE col3 IN (719,781)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_109
+DROP VIEW IF EXISTS view_1_tab4_109 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_109
+DROP VIEW IF EXISTS view_2_tab4_109 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_109
+DROP VIEW IF EXISTS view_3_tab4_109 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16415,13 +16415,13 @@ SELECT pk FROM tab0 WHERE col0 > 241 OR col0 >= 539 AND (col4 < 975.45) AND col3
 76 values hashing to 65591a833b5fb766298b2d75ea6bca50
 
 statement ok
-DROP VIEW view_1_tab0_110
+DROP VIEW IF EXISTS view_1_tab0_110 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_110
+DROP VIEW IF EXISTS view_2_tab0_110 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_110
+DROP VIEW IF EXISTS view_3_tab0_110 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16512,13 +16512,13 @@ SELECT pk FROM tab1 WHERE col0 > 241 OR col0 >= 539 AND (col4 < 975.45) AND col3
 76 values hashing to 65591a833b5fb766298b2d75ea6bca50
 
 statement ok
-DROP VIEW view_1_tab1_110
+DROP VIEW IF EXISTS view_1_tab1_110 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_110
+DROP VIEW IF EXISTS view_2_tab1_110 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_110
+DROP VIEW IF EXISTS view_3_tab1_110 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16609,13 +16609,13 @@ SELECT pk FROM tab2 WHERE col0 > 241 OR col0 >= 539 AND (col4 < 975.45) AND col3
 76 values hashing to 65591a833b5fb766298b2d75ea6bca50
 
 statement ok
-DROP VIEW view_1_tab2_110
+DROP VIEW IF EXISTS view_1_tab2_110 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_110
+DROP VIEW IF EXISTS view_2_tab2_110 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_110
+DROP VIEW IF EXISTS view_3_tab2_110 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16706,13 +16706,13 @@ SELECT pk FROM tab3 WHERE col0 > 241 OR col0 >= 539 AND (col4 < 975.45) AND col3
 76 values hashing to 65591a833b5fb766298b2d75ea6bca50
 
 statement ok
-DROP VIEW view_1_tab3_110
+DROP VIEW IF EXISTS view_1_tab3_110 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_110
+DROP VIEW IF EXISTS view_2_tab3_110 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_110
+DROP VIEW IF EXISTS view_3_tab3_110 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16803,13 +16803,13 @@ SELECT pk FROM tab4 WHERE col0 > 241 OR col0 >= 539 AND (col4 < 975.45) AND col3
 76 values hashing to 65591a833b5fb766298b2d75ea6bca50
 
 statement ok
-DROP VIEW view_1_tab4_110
+DROP VIEW IF EXISTS view_1_tab4_110 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_110
+DROP VIEW IF EXISTS view_2_tab4_110 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_110
+DROP VIEW IF EXISTS view_3_tab4_110 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16900,13 +16900,13 @@ SELECT pk FROM tab0 WHERE (col0 > 743)
 23 values hashing to 7851cf1c1a2901b56d646c71f8ebf7d6
 
 statement ok
-DROP VIEW view_1_tab0_111
+DROP VIEW IF EXISTS view_1_tab0_111 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_111
+DROP VIEW IF EXISTS view_2_tab0_111 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_111
+DROP VIEW IF EXISTS view_3_tab0_111 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16997,13 +16997,13 @@ SELECT pk FROM tab1 WHERE (col0 > 743)
 23 values hashing to 7851cf1c1a2901b56d646c71f8ebf7d6
 
 statement ok
-DROP VIEW view_1_tab1_111
+DROP VIEW IF EXISTS view_1_tab1_111 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_111
+DROP VIEW IF EXISTS view_2_tab1_111 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_111
+DROP VIEW IF EXISTS view_3_tab1_111 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17094,13 +17094,13 @@ SELECT pk FROM tab2 WHERE (col0 > 743)
 23 values hashing to 7851cf1c1a2901b56d646c71f8ebf7d6
 
 statement ok
-DROP VIEW view_1_tab2_111
+DROP VIEW IF EXISTS view_1_tab2_111 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_111
+DROP VIEW IF EXISTS view_2_tab2_111 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_111
+DROP VIEW IF EXISTS view_3_tab2_111 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17191,13 +17191,13 @@ SELECT pk FROM tab3 WHERE (col0 > 743)
 23 values hashing to 7851cf1c1a2901b56d646c71f8ebf7d6
 
 statement ok
-DROP VIEW view_1_tab3_111
+DROP VIEW IF EXISTS view_1_tab3_111 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_111
+DROP VIEW IF EXISTS view_2_tab3_111 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_111
+DROP VIEW IF EXISTS view_3_tab3_111 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17288,13 +17288,13 @@ SELECT pk FROM tab4 WHERE (col0 > 743)
 23 values hashing to 7851cf1c1a2901b56d646c71f8ebf7d6
 
 statement ok
-DROP VIEW view_1_tab4_111
+DROP VIEW IF EXISTS view_1_tab4_111 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_111
+DROP VIEW IF EXISTS view_2_tab4_111 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_111
+DROP VIEW IF EXISTS view_3_tab4_111 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17385,13 +17385,13 @@ SELECT pk FROM tab0 WHERE (col0 IN (90,830,168,405,662) AND ((col0 > 840)) OR co
 94 values hashing to 79f1ee446fbfdadb2f5f7bae0ecf4205
 
 statement ok
-DROP VIEW view_1_tab0_112
+DROP VIEW IF EXISTS view_1_tab0_112 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_112
+DROP VIEW IF EXISTS view_2_tab0_112 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_112
+DROP VIEW IF EXISTS view_3_tab0_112 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17482,13 +17482,13 @@ SELECT pk FROM tab1 WHERE (col0 IN (90,830,168,405,662) AND ((col0 > 840)) OR co
 94 values hashing to 79f1ee446fbfdadb2f5f7bae0ecf4205
 
 statement ok
-DROP VIEW view_1_tab1_112
+DROP VIEW IF EXISTS view_1_tab1_112 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_112
+DROP VIEW IF EXISTS view_2_tab1_112 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_112
+DROP VIEW IF EXISTS view_3_tab1_112 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17579,13 +17579,13 @@ SELECT pk FROM tab2 WHERE (col0 IN (90,830,168,405,662) AND ((col0 > 840)) OR co
 94 values hashing to 79f1ee446fbfdadb2f5f7bae0ecf4205
 
 statement ok
-DROP VIEW view_1_tab2_112
+DROP VIEW IF EXISTS view_1_tab2_112 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_112
+DROP VIEW IF EXISTS view_2_tab2_112 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_112
+DROP VIEW IF EXISTS view_3_tab2_112 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17676,13 +17676,13 @@ SELECT pk FROM tab3 WHERE (col0 IN (90,830,168,405,662) AND ((col0 > 840)) OR co
 94 values hashing to 79f1ee446fbfdadb2f5f7bae0ecf4205
 
 statement ok
-DROP VIEW view_1_tab3_112
+DROP VIEW IF EXISTS view_1_tab3_112 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_112
+DROP VIEW IF EXISTS view_2_tab3_112 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_112
+DROP VIEW IF EXISTS view_3_tab3_112 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17773,13 +17773,13 @@ SELECT pk FROM tab4 WHERE (col0 IN (90,830,168,405,662) AND ((col0 > 840)) OR co
 94 values hashing to 79f1ee446fbfdadb2f5f7bae0ecf4205
 
 statement ok
-DROP VIEW view_1_tab4_112
+DROP VIEW IF EXISTS view_1_tab4_112 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_112
+DROP VIEW IF EXISTS view_2_tab4_112 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_112
+DROP VIEW IF EXISTS view_3_tab4_112 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17870,13 +17870,13 @@ SELECT pk FROM tab0 WHERE col1 < 482.39
 44 values hashing to 2428bd479c766e78ae64346283b669ea
 
 statement ok
-DROP VIEW view_1_tab0_113
+DROP VIEW IF EXISTS view_1_tab0_113 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_113
+DROP VIEW IF EXISTS view_2_tab0_113 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_113
+DROP VIEW IF EXISTS view_3_tab0_113 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17967,13 +17967,13 @@ SELECT pk FROM tab1 WHERE col1 < 482.39
 44 values hashing to 2428bd479c766e78ae64346283b669ea
 
 statement ok
-DROP VIEW view_1_tab1_113
+DROP VIEW IF EXISTS view_1_tab1_113 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_113
+DROP VIEW IF EXISTS view_2_tab1_113 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_113
+DROP VIEW IF EXISTS view_3_tab1_113 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18064,13 +18064,13 @@ SELECT pk FROM tab2 WHERE col1 < 482.39
 44 values hashing to 2428bd479c766e78ae64346283b669ea
 
 statement ok
-DROP VIEW view_1_tab2_113
+DROP VIEW IF EXISTS view_1_tab2_113 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_113
+DROP VIEW IF EXISTS view_2_tab2_113 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_113
+DROP VIEW IF EXISTS view_3_tab2_113 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18161,13 +18161,13 @@ SELECT pk FROM tab3 WHERE col1 < 482.39
 44 values hashing to 2428bd479c766e78ae64346283b669ea
 
 statement ok
-DROP VIEW view_1_tab3_113
+DROP VIEW IF EXISTS view_1_tab3_113 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_113
+DROP VIEW IF EXISTS view_2_tab3_113 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_113
+DROP VIEW IF EXISTS view_3_tab3_113 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18258,13 +18258,13 @@ SELECT pk FROM tab4 WHERE col1 < 482.39
 44 values hashing to 2428bd479c766e78ae64346283b669ea
 
 statement ok
-DROP VIEW view_1_tab4_113
+DROP VIEW IF EXISTS view_1_tab4_113 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_113
+DROP VIEW IF EXISTS view_2_tab4_113 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_113
+DROP VIEW IF EXISTS view_3_tab4_113 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18355,13 +18355,13 @@ SELECT pk FROM tab0 WHERE col0 <= 850 OR col3 > 609 AND col3 <= 569
 86 values hashing to 7e6d83ef58a9970a4a61bdd6dd3ad1e1
 
 statement ok
-DROP VIEW view_1_tab0_114
+DROP VIEW IF EXISTS view_1_tab0_114 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_114
+DROP VIEW IF EXISTS view_2_tab0_114 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_114
+DROP VIEW IF EXISTS view_3_tab0_114 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18452,13 +18452,13 @@ SELECT pk FROM tab1 WHERE col0 <= 850 OR col3 > 609 AND col3 <= 569
 86 values hashing to 7e6d83ef58a9970a4a61bdd6dd3ad1e1
 
 statement ok
-DROP VIEW view_1_tab1_114
+DROP VIEW IF EXISTS view_1_tab1_114 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_114
+DROP VIEW IF EXISTS view_2_tab1_114 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_114
+DROP VIEW IF EXISTS view_3_tab1_114 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18549,13 +18549,13 @@ SELECT pk FROM tab2 WHERE col0 <= 850 OR col3 > 609 AND col3 <= 569
 86 values hashing to 7e6d83ef58a9970a4a61bdd6dd3ad1e1
 
 statement ok
-DROP VIEW view_1_tab2_114
+DROP VIEW IF EXISTS view_1_tab2_114 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_114
+DROP VIEW IF EXISTS view_2_tab2_114 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_114
+DROP VIEW IF EXISTS view_3_tab2_114 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18646,13 +18646,13 @@ SELECT pk FROM tab3 WHERE col0 <= 850 OR col3 > 609 AND col3 <= 569
 86 values hashing to 7e6d83ef58a9970a4a61bdd6dd3ad1e1
 
 statement ok
-DROP VIEW view_1_tab3_114
+DROP VIEW IF EXISTS view_1_tab3_114 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_114
+DROP VIEW IF EXISTS view_2_tab3_114 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_114
+DROP VIEW IF EXISTS view_3_tab3_114 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18743,13 +18743,13 @@ SELECT pk FROM tab4 WHERE col0 <= 850 OR col3 > 609 AND col3 <= 569
 86 values hashing to 7e6d83ef58a9970a4a61bdd6dd3ad1e1
 
 statement ok
-DROP VIEW view_1_tab4_114
+DROP VIEW IF EXISTS view_1_tab4_114 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_114
+DROP VIEW IF EXISTS view_2_tab4_114 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_114
+DROP VIEW IF EXISTS view_3_tab4_114 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18840,13 +18840,13 @@ SELECT pk FROM tab0 WHERE (col3 < 709) OR (col0 < 335) AND (col4 >= 411.50) AND 
 90 values hashing to fcea6b0a3aa954baf30fe063840c3d61
 
 statement ok
-DROP VIEW view_1_tab0_115
+DROP VIEW IF EXISTS view_1_tab0_115 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_115
+DROP VIEW IF EXISTS view_2_tab0_115 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_115
+DROP VIEW IF EXISTS view_3_tab0_115 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18937,13 +18937,13 @@ SELECT pk FROM tab1 WHERE (col3 < 709) OR (col0 < 335) AND (col4 >= 411.50) AND 
 90 values hashing to fcea6b0a3aa954baf30fe063840c3d61
 
 statement ok
-DROP VIEW view_1_tab1_115
+DROP VIEW IF EXISTS view_1_tab1_115 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_115
+DROP VIEW IF EXISTS view_2_tab1_115 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_115
+DROP VIEW IF EXISTS view_3_tab1_115 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19034,13 +19034,13 @@ SELECT pk FROM tab2 WHERE (col3 < 709) OR (col0 < 335) AND (col4 >= 411.50) AND 
 90 values hashing to fcea6b0a3aa954baf30fe063840c3d61
 
 statement ok
-DROP VIEW view_1_tab2_115
+DROP VIEW IF EXISTS view_1_tab2_115 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_115
+DROP VIEW IF EXISTS view_2_tab2_115 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_115
+DROP VIEW IF EXISTS view_3_tab2_115 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19131,13 +19131,13 @@ SELECT pk FROM tab3 WHERE (col3 < 709) OR (col0 < 335) AND (col4 >= 411.50) AND 
 90 values hashing to fcea6b0a3aa954baf30fe063840c3d61
 
 statement ok
-DROP VIEW view_1_tab3_115
+DROP VIEW IF EXISTS view_1_tab3_115 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_115
+DROP VIEW IF EXISTS view_2_tab3_115 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_115
+DROP VIEW IF EXISTS view_3_tab3_115 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19228,13 +19228,13 @@ SELECT pk FROM tab4 WHERE (col3 < 709) OR (col0 < 335) AND (col4 >= 411.50) AND 
 90 values hashing to fcea6b0a3aa954baf30fe063840c3d61
 
 statement ok
-DROP VIEW view_1_tab4_115
+DROP VIEW IF EXISTS view_1_tab4_115 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_115
+DROP VIEW IF EXISTS view_2_tab4_115 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_115
+DROP VIEW IF EXISTS view_3_tab4_115 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19325,13 +19325,13 @@ SELECT pk FROM tab0 WHERE col0 > 143
 87 values hashing to f4d20c2c69dd9e7170050ac55a814aa8
 
 statement ok
-DROP VIEW view_1_tab0_116
+DROP VIEW IF EXISTS view_1_tab0_116 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_116
+DROP VIEW IF EXISTS view_2_tab0_116 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_116
+DROP VIEW IF EXISTS view_3_tab0_116 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19422,13 +19422,13 @@ SELECT pk FROM tab1 WHERE col0 > 143
 87 values hashing to f4d20c2c69dd9e7170050ac55a814aa8
 
 statement ok
-DROP VIEW view_1_tab1_116
+DROP VIEW IF EXISTS view_1_tab1_116 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_116
+DROP VIEW IF EXISTS view_2_tab1_116 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_116
+DROP VIEW IF EXISTS view_3_tab1_116 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19519,13 +19519,13 @@ SELECT pk FROM tab2 WHERE col0 > 143
 87 values hashing to f4d20c2c69dd9e7170050ac55a814aa8
 
 statement ok
-DROP VIEW view_1_tab2_116
+DROP VIEW IF EXISTS view_1_tab2_116 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_116
+DROP VIEW IF EXISTS view_2_tab2_116 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_116
+DROP VIEW IF EXISTS view_3_tab2_116 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19616,13 +19616,13 @@ SELECT pk FROM tab3 WHERE col0 > 143
 87 values hashing to f4d20c2c69dd9e7170050ac55a814aa8
 
 statement ok
-DROP VIEW view_1_tab3_116
+DROP VIEW IF EXISTS view_1_tab3_116 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_116
+DROP VIEW IF EXISTS view_2_tab3_116 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_116
+DROP VIEW IF EXISTS view_3_tab3_116 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19713,13 +19713,13 @@ SELECT pk FROM tab4 WHERE col0 > 143
 87 values hashing to f4d20c2c69dd9e7170050ac55a814aa8
 
 statement ok
-DROP VIEW view_1_tab4_116
+DROP VIEW IF EXISTS view_1_tab4_116 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_116
+DROP VIEW IF EXISTS view_2_tab4_116 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_116
+DROP VIEW IF EXISTS view_3_tab4_116 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19810,13 +19810,13 @@ SELECT pk FROM tab0 WHERE ((col3 < 151))
 11 values hashing to 159c582f33b030d95ac693c9cb0828a4
 
 statement ok
-DROP VIEW view_1_tab0_117
+DROP VIEW IF EXISTS view_1_tab0_117 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_117
+DROP VIEW IF EXISTS view_2_tab0_117 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_117
+DROP VIEW IF EXISTS view_3_tab0_117 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19907,13 +19907,13 @@ SELECT pk FROM tab1 WHERE ((col3 < 151))
 11 values hashing to 159c582f33b030d95ac693c9cb0828a4
 
 statement ok
-DROP VIEW view_1_tab1_117
+DROP VIEW IF EXISTS view_1_tab1_117 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_117
+DROP VIEW IF EXISTS view_2_tab1_117 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_117
+DROP VIEW IF EXISTS view_3_tab1_117 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20004,13 +20004,13 @@ SELECT pk FROM tab2 WHERE ((col3 < 151))
 11 values hashing to 159c582f33b030d95ac693c9cb0828a4
 
 statement ok
-DROP VIEW view_1_tab2_117
+DROP VIEW IF EXISTS view_1_tab2_117 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_117
+DROP VIEW IF EXISTS view_2_tab2_117 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_117
+DROP VIEW IF EXISTS view_3_tab2_117 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20101,13 +20101,13 @@ SELECT pk FROM tab3 WHERE ((col3 < 151))
 11 values hashing to 159c582f33b030d95ac693c9cb0828a4
 
 statement ok
-DROP VIEW view_1_tab3_117
+DROP VIEW IF EXISTS view_1_tab3_117 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_117
+DROP VIEW IF EXISTS view_2_tab3_117 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_117
+DROP VIEW IF EXISTS view_3_tab3_117 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20198,13 +20198,13 @@ SELECT pk FROM tab4 WHERE ((col3 < 151))
 11 values hashing to 159c582f33b030d95ac693c9cb0828a4
 
 statement ok
-DROP VIEW view_1_tab4_117
+DROP VIEW IF EXISTS view_1_tab4_117 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_117
+DROP VIEW IF EXISTS view_2_tab4_117 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_117
+DROP VIEW IF EXISTS view_3_tab4_117 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20295,13 +20295,13 @@ SELECT pk FROM tab0 WHERE col0 > 697
 28 values hashing to 1158411ddea503b1dcf1da18d695826d
 
 statement ok
-DROP VIEW view_1_tab0_118
+DROP VIEW IF EXISTS view_1_tab0_118 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_118
+DROP VIEW IF EXISTS view_2_tab0_118 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_118
+DROP VIEW IF EXISTS view_3_tab0_118 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20392,13 +20392,13 @@ SELECT pk FROM tab1 WHERE col0 > 697
 28 values hashing to 1158411ddea503b1dcf1da18d695826d
 
 statement ok
-DROP VIEW view_1_tab1_118
+DROP VIEW IF EXISTS view_1_tab1_118 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_118
+DROP VIEW IF EXISTS view_2_tab1_118 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_118
+DROP VIEW IF EXISTS view_3_tab1_118 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20489,13 +20489,13 @@ SELECT pk FROM tab2 WHERE col0 > 697
 28 values hashing to 1158411ddea503b1dcf1da18d695826d
 
 statement ok
-DROP VIEW view_1_tab2_118
+DROP VIEW IF EXISTS view_1_tab2_118 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_118
+DROP VIEW IF EXISTS view_2_tab2_118 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_118
+DROP VIEW IF EXISTS view_3_tab2_118 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20586,13 +20586,13 @@ SELECT pk FROM tab3 WHERE col0 > 697
 28 values hashing to 1158411ddea503b1dcf1da18d695826d
 
 statement ok
-DROP VIEW view_1_tab3_118
+DROP VIEW IF EXISTS view_1_tab3_118 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_118
+DROP VIEW IF EXISTS view_2_tab3_118 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_118
+DROP VIEW IF EXISTS view_3_tab3_118 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20683,13 +20683,13 @@ SELECT pk FROM tab4 WHERE col0 > 697
 28 values hashing to 1158411ddea503b1dcf1da18d695826d
 
 statement ok
-DROP VIEW view_1_tab4_118
+DROP VIEW IF EXISTS view_1_tab4_118 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_118
+DROP VIEW IF EXISTS view_2_tab4_118 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_118
+DROP VIEW IF EXISTS view_3_tab4_118 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20780,13 +20780,13 @@ SELECT pk FROM tab0 WHERE (col3 < 731 OR (col0 > 218 AND col0 > 858 AND col3 > 6
 77 values hashing to d40f878ba822143dafeedb997ca66916
 
 statement ok
-DROP VIEW view_1_tab0_119
+DROP VIEW IF EXISTS view_1_tab0_119 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_119
+DROP VIEW IF EXISTS view_2_tab0_119 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_119
+DROP VIEW IF EXISTS view_3_tab0_119 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20877,13 +20877,13 @@ SELECT pk FROM tab1 WHERE (col3 < 731 OR (col0 > 218 AND col0 > 858 AND col3 > 6
 77 values hashing to d40f878ba822143dafeedb997ca66916
 
 statement ok
-DROP VIEW view_1_tab1_119
+DROP VIEW IF EXISTS view_1_tab1_119 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_119
+DROP VIEW IF EXISTS view_2_tab1_119 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_119
+DROP VIEW IF EXISTS view_3_tab1_119 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20974,13 +20974,13 @@ SELECT pk FROM tab2 WHERE (col3 < 731 OR (col0 > 218 AND col0 > 858 AND col3 > 6
 77 values hashing to d40f878ba822143dafeedb997ca66916
 
 statement ok
-DROP VIEW view_1_tab2_119
+DROP VIEW IF EXISTS view_1_tab2_119 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_119
+DROP VIEW IF EXISTS view_2_tab2_119 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_119
+DROP VIEW IF EXISTS view_3_tab2_119 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21071,13 +21071,13 @@ SELECT pk FROM tab3 WHERE (col3 < 731 OR (col0 > 218 AND col0 > 858 AND col3 > 6
 77 values hashing to d40f878ba822143dafeedb997ca66916
 
 statement ok
-DROP VIEW view_1_tab3_119
+DROP VIEW IF EXISTS view_1_tab3_119 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_119
+DROP VIEW IF EXISTS view_2_tab3_119 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_119
+DROP VIEW IF EXISTS view_3_tab3_119 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21168,13 +21168,13 @@ SELECT pk FROM tab4 WHERE (col3 < 731 OR (col0 > 218 AND col0 > 858 AND col3 > 6
 77 values hashing to d40f878ba822143dafeedb997ca66916
 
 statement ok
-DROP VIEW view_1_tab4_119
+DROP VIEW IF EXISTS view_1_tab4_119 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_119
+DROP VIEW IF EXISTS view_2_tab4_119 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_119
+DROP VIEW IF EXISTS view_3_tab4_119 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21265,13 +21265,13 @@ SELECT pk FROM tab0 WHERE col0 > 556 OR col0 IN (910,813) AND col0 IS NULL AND (
 61 values hashing to 12f835fc26533ad56f69059c549b8f91
 
 statement ok
-DROP VIEW view_1_tab0_120
+DROP VIEW IF EXISTS view_1_tab0_120 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_120
+DROP VIEW IF EXISTS view_2_tab0_120 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_120
+DROP VIEW IF EXISTS view_3_tab0_120 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21362,13 +21362,13 @@ SELECT pk FROM tab1 WHERE col0 > 556 OR col0 IN (910,813) AND col0 IS NULL AND (
 61 values hashing to 12f835fc26533ad56f69059c549b8f91
 
 statement ok
-DROP VIEW view_1_tab1_120
+DROP VIEW IF EXISTS view_1_tab1_120 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_120
+DROP VIEW IF EXISTS view_2_tab1_120 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_120
+DROP VIEW IF EXISTS view_3_tab1_120 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21459,13 +21459,13 @@ SELECT pk FROM tab2 WHERE col0 > 556 OR col0 IN (910,813) AND col0 IS NULL AND (
 61 values hashing to 12f835fc26533ad56f69059c549b8f91
 
 statement ok
-DROP VIEW view_1_tab2_120
+DROP VIEW IF EXISTS view_1_tab2_120 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_120
+DROP VIEW IF EXISTS view_2_tab2_120 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_120
+DROP VIEW IF EXISTS view_3_tab2_120 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21556,13 +21556,13 @@ SELECT pk FROM tab3 WHERE col0 > 556 OR col0 IN (910,813) AND col0 IS NULL AND (
 61 values hashing to 12f835fc26533ad56f69059c549b8f91
 
 statement ok
-DROP VIEW view_1_tab3_120
+DROP VIEW IF EXISTS view_1_tab3_120 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_120
+DROP VIEW IF EXISTS view_2_tab3_120 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_120
+DROP VIEW IF EXISTS view_3_tab3_120 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21653,13 +21653,13 @@ SELECT pk FROM tab4 WHERE col0 > 556 OR col0 IN (910,813) AND col0 IS NULL AND (
 61 values hashing to 12f835fc26533ad56f69059c549b8f91
 
 statement ok
-DROP VIEW view_1_tab4_120
+DROP VIEW IF EXISTS view_1_tab4_120 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_120
+DROP VIEW IF EXISTS view_2_tab4_120 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_120
+DROP VIEW IF EXISTS view_3_tab4_120 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21750,13 +21750,13 @@ SELECT pk FROM tab0 WHERE col1 >= 211.12
 80 values hashing to 889d0d0ea1e1ac27a86b998a9a37a24f
 
 statement ok
-DROP VIEW view_1_tab0_121
+DROP VIEW IF EXISTS view_1_tab0_121 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_121
+DROP VIEW IF EXISTS view_2_tab0_121 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_121
+DROP VIEW IF EXISTS view_3_tab0_121 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21847,13 +21847,13 @@ SELECT pk FROM tab1 WHERE col1 >= 211.12
 80 values hashing to 889d0d0ea1e1ac27a86b998a9a37a24f
 
 statement ok
-DROP VIEW view_1_tab1_121
+DROP VIEW IF EXISTS view_1_tab1_121 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_121
+DROP VIEW IF EXISTS view_2_tab1_121 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_121
+DROP VIEW IF EXISTS view_3_tab1_121 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21944,13 +21944,13 @@ SELECT pk FROM tab2 WHERE col1 >= 211.12
 80 values hashing to 889d0d0ea1e1ac27a86b998a9a37a24f
 
 statement ok
-DROP VIEW view_1_tab2_121
+DROP VIEW IF EXISTS view_1_tab2_121 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_121
+DROP VIEW IF EXISTS view_2_tab2_121 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_121
+DROP VIEW IF EXISTS view_3_tab2_121 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22041,13 +22041,13 @@ SELECT pk FROM tab3 WHERE col1 >= 211.12
 80 values hashing to 889d0d0ea1e1ac27a86b998a9a37a24f
 
 statement ok
-DROP VIEW view_1_tab3_121
+DROP VIEW IF EXISTS view_1_tab3_121 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_121
+DROP VIEW IF EXISTS view_2_tab3_121 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_121
+DROP VIEW IF EXISTS view_3_tab3_121 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22138,13 +22138,13 @@ SELECT pk FROM tab4 WHERE col1 >= 211.12
 80 values hashing to 889d0d0ea1e1ac27a86b998a9a37a24f
 
 statement ok
-DROP VIEW view_1_tab4_121
+DROP VIEW IF EXISTS view_1_tab4_121 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_121
+DROP VIEW IF EXISTS view_2_tab4_121 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_121
+DROP VIEW IF EXISTS view_3_tab4_121 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22235,13 +22235,13 @@ SELECT pk FROM tab0 WHERE col3 < 635
 62 values hashing to ddc442c3953a99cb16dabc0e52a2b09f
 
 statement ok
-DROP VIEW view_1_tab0_122
+DROP VIEW IF EXISTS view_1_tab0_122 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_122
+DROP VIEW IF EXISTS view_2_tab0_122 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_122
+DROP VIEW IF EXISTS view_3_tab0_122 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22332,13 +22332,13 @@ SELECT pk FROM tab1 WHERE col3 < 635
 62 values hashing to ddc442c3953a99cb16dabc0e52a2b09f
 
 statement ok
-DROP VIEW view_1_tab1_122
+DROP VIEW IF EXISTS view_1_tab1_122 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_122
+DROP VIEW IF EXISTS view_2_tab1_122 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_122
+DROP VIEW IF EXISTS view_3_tab1_122 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22429,13 +22429,13 @@ SELECT pk FROM tab2 WHERE col3 < 635
 62 values hashing to ddc442c3953a99cb16dabc0e52a2b09f
 
 statement ok
-DROP VIEW view_1_tab2_122
+DROP VIEW IF EXISTS view_1_tab2_122 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_122
+DROP VIEW IF EXISTS view_2_tab2_122 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_122
+DROP VIEW IF EXISTS view_3_tab2_122 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22526,13 +22526,13 @@ SELECT pk FROM tab3 WHERE col3 < 635
 62 values hashing to ddc442c3953a99cb16dabc0e52a2b09f
 
 statement ok
-DROP VIEW view_1_tab3_122
+DROP VIEW IF EXISTS view_1_tab3_122 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_122
+DROP VIEW IF EXISTS view_2_tab3_122 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_122
+DROP VIEW IF EXISTS view_3_tab3_122 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22623,13 +22623,13 @@ SELECT pk FROM tab4 WHERE col3 < 635
 62 values hashing to ddc442c3953a99cb16dabc0e52a2b09f
 
 statement ok
-DROP VIEW view_1_tab4_122
+DROP VIEW IF EXISTS view_1_tab4_122 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_122
+DROP VIEW IF EXISTS view_2_tab4_122 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_122
+DROP VIEW IF EXISTS view_3_tab4_122 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22720,13 +22720,13 @@ SELECT pk FROM tab0 WHERE col3 >= 582
 47 values hashing to 6fad0d011ae6ef61ebc63fc1a2be6e2c
 
 statement ok
-DROP VIEW view_1_tab0_123
+DROP VIEW IF EXISTS view_1_tab0_123 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_123
+DROP VIEW IF EXISTS view_2_tab0_123 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_123
+DROP VIEW IF EXISTS view_3_tab0_123 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22817,13 +22817,13 @@ SELECT pk FROM tab1 WHERE col3 >= 582
 47 values hashing to 6fad0d011ae6ef61ebc63fc1a2be6e2c
 
 statement ok
-DROP VIEW view_1_tab1_123
+DROP VIEW IF EXISTS view_1_tab1_123 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_123
+DROP VIEW IF EXISTS view_2_tab1_123 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_123
+DROP VIEW IF EXISTS view_3_tab1_123 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22914,13 +22914,13 @@ SELECT pk FROM tab2 WHERE col3 >= 582
 47 values hashing to 6fad0d011ae6ef61ebc63fc1a2be6e2c
 
 statement ok
-DROP VIEW view_1_tab2_123
+DROP VIEW IF EXISTS view_1_tab2_123 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_123
+DROP VIEW IF EXISTS view_2_tab2_123 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_123
+DROP VIEW IF EXISTS view_3_tab2_123 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23011,13 +23011,13 @@ SELECT pk FROM tab3 WHERE col3 >= 582
 47 values hashing to 6fad0d011ae6ef61ebc63fc1a2be6e2c
 
 statement ok
-DROP VIEW view_1_tab3_123
+DROP VIEW IF EXISTS view_1_tab3_123 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_123
+DROP VIEW IF EXISTS view_2_tab3_123 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_123
+DROP VIEW IF EXISTS view_3_tab3_123 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23108,13 +23108,13 @@ SELECT pk FROM tab4 WHERE col3 >= 582
 47 values hashing to 6fad0d011ae6ef61ebc63fc1a2be6e2c
 
 statement ok
-DROP VIEW view_1_tab4_123
+DROP VIEW IF EXISTS view_1_tab4_123 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_123
+DROP VIEW IF EXISTS view_2_tab4_123 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_123
+DROP VIEW IF EXISTS view_3_tab4_123 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23205,13 +23205,13 @@ SELECT pk FROM tab0 WHERE (col0 > 82)
 91 values hashing to cde23c08f0754e0a76c4654d4e83426d
 
 statement ok
-DROP VIEW view_1_tab0_124
+DROP VIEW IF EXISTS view_1_tab0_124 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_124
+DROP VIEW IF EXISTS view_2_tab0_124 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_124
+DROP VIEW IF EXISTS view_3_tab0_124 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23302,13 +23302,13 @@ SELECT pk FROM tab1 WHERE (col0 > 82)
 91 values hashing to cde23c08f0754e0a76c4654d4e83426d
 
 statement ok
-DROP VIEW view_1_tab1_124
+DROP VIEW IF EXISTS view_1_tab1_124 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_124
+DROP VIEW IF EXISTS view_2_tab1_124 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_124
+DROP VIEW IF EXISTS view_3_tab1_124 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23399,13 +23399,13 @@ SELECT pk FROM tab2 WHERE (col0 > 82)
 91 values hashing to cde23c08f0754e0a76c4654d4e83426d
 
 statement ok
-DROP VIEW view_1_tab2_124
+DROP VIEW IF EXISTS view_1_tab2_124 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_124
+DROP VIEW IF EXISTS view_2_tab2_124 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_124
+DROP VIEW IF EXISTS view_3_tab2_124 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23496,13 +23496,13 @@ SELECT pk FROM tab3 WHERE (col0 > 82)
 91 values hashing to cde23c08f0754e0a76c4654d4e83426d
 
 statement ok
-DROP VIEW view_1_tab3_124
+DROP VIEW IF EXISTS view_1_tab3_124 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_124
+DROP VIEW IF EXISTS view_2_tab3_124 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_124
+DROP VIEW IF EXISTS view_3_tab3_124 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23593,13 +23593,13 @@ SELECT pk FROM tab4 WHERE (col0 > 82)
 91 values hashing to cde23c08f0754e0a76c4654d4e83426d
 
 statement ok
-DROP VIEW view_1_tab4_124
+DROP VIEW IF EXISTS view_1_tab4_124 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_124
+DROP VIEW IF EXISTS view_2_tab4_124 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_124
+DROP VIEW IF EXISTS view_3_tab4_124 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23690,13 +23690,13 @@ SELECT pk FROM tab0 WHERE (col3 < 661)
 66 values hashing to 13d047cfaa6cf14db03589091965336e
 
 statement ok
-DROP VIEW view_1_tab0_125
+DROP VIEW IF EXISTS view_1_tab0_125 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_125
+DROP VIEW IF EXISTS view_2_tab0_125 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_125
+DROP VIEW IF EXISTS view_3_tab0_125 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23787,13 +23787,13 @@ SELECT pk FROM tab1 WHERE (col3 < 661)
 66 values hashing to 13d047cfaa6cf14db03589091965336e
 
 statement ok
-DROP VIEW view_1_tab1_125
+DROP VIEW IF EXISTS view_1_tab1_125 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_125
+DROP VIEW IF EXISTS view_2_tab1_125 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_125
+DROP VIEW IF EXISTS view_3_tab1_125 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23884,13 +23884,13 @@ SELECT pk FROM tab2 WHERE (col3 < 661)
 66 values hashing to 13d047cfaa6cf14db03589091965336e
 
 statement ok
-DROP VIEW view_1_tab2_125
+DROP VIEW IF EXISTS view_1_tab2_125 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_125
+DROP VIEW IF EXISTS view_2_tab2_125 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_125
+DROP VIEW IF EXISTS view_3_tab2_125 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23981,13 +23981,13 @@ SELECT pk FROM tab3 WHERE (col3 < 661)
 66 values hashing to 13d047cfaa6cf14db03589091965336e
 
 statement ok
-DROP VIEW view_1_tab3_125
+DROP VIEW IF EXISTS view_1_tab3_125 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_125
+DROP VIEW IF EXISTS view_2_tab3_125 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_125
+DROP VIEW IF EXISTS view_3_tab3_125 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24078,13 +24078,13 @@ SELECT pk FROM tab4 WHERE (col3 < 661)
 66 values hashing to 13d047cfaa6cf14db03589091965336e
 
 statement ok
-DROP VIEW view_1_tab4_125
+DROP VIEW IF EXISTS view_1_tab4_125 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_125
+DROP VIEW IF EXISTS view_2_tab4_125 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_125
+DROP VIEW IF EXISTS view_3_tab4_125 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24175,13 +24175,13 @@ SELECT pk FROM tab0 WHERE (((col0 > 575))) OR col4 > 776.46 AND col1 <= 716.71 A
 43 values hashing to 597e8911b174a59bc5afc80faa81641c
 
 statement ok
-DROP VIEW view_1_tab0_126
+DROP VIEW IF EXISTS view_1_tab0_126 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_126
+DROP VIEW IF EXISTS view_2_tab0_126 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_126
+DROP VIEW IF EXISTS view_3_tab0_126 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24272,13 +24272,13 @@ SELECT pk FROM tab1 WHERE (((col0 > 575))) OR col4 > 776.46 AND col1 <= 716.71 A
 43 values hashing to 597e8911b174a59bc5afc80faa81641c
 
 statement ok
-DROP VIEW view_1_tab1_126
+DROP VIEW IF EXISTS view_1_tab1_126 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_126
+DROP VIEW IF EXISTS view_2_tab1_126 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_126
+DROP VIEW IF EXISTS view_3_tab1_126 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24369,13 +24369,13 @@ SELECT pk FROM tab2 WHERE (((col0 > 575))) OR col4 > 776.46 AND col1 <= 716.71 A
 43 values hashing to 597e8911b174a59bc5afc80faa81641c
 
 statement ok
-DROP VIEW view_1_tab2_126
+DROP VIEW IF EXISTS view_1_tab2_126 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_126
+DROP VIEW IF EXISTS view_2_tab2_126 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_126
+DROP VIEW IF EXISTS view_3_tab2_126 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24466,13 +24466,13 @@ SELECT pk FROM tab3 WHERE (((col0 > 575))) OR col4 > 776.46 AND col1 <= 716.71 A
 43 values hashing to 597e8911b174a59bc5afc80faa81641c
 
 statement ok
-DROP VIEW view_1_tab3_126
+DROP VIEW IF EXISTS view_1_tab3_126 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_126
+DROP VIEW IF EXISTS view_2_tab3_126 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_126
+DROP VIEW IF EXISTS view_3_tab3_126 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24563,13 +24563,13 @@ SELECT pk FROM tab4 WHERE (((col0 > 575))) OR col4 > 776.46 AND col1 <= 716.71 A
 43 values hashing to 597e8911b174a59bc5afc80faa81641c
 
 statement ok
-DROP VIEW view_1_tab4_126
+DROP VIEW IF EXISTS view_1_tab4_126 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_126
+DROP VIEW IF EXISTS view_2_tab4_126 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_126
+DROP VIEW IF EXISTS view_3_tab4_126 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24660,13 +24660,13 @@ SELECT pk FROM tab0 WHERE col1 = 349.5 OR (col0 >= 101 AND col3 > 11 AND (col1 >
 42 values hashing to 7384eaeb71de8c039b40ba47c69e49a8
 
 statement ok
-DROP VIEW view_1_tab0_127
+DROP VIEW IF EXISTS view_1_tab0_127 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_127
+DROP VIEW IF EXISTS view_2_tab0_127 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_127
+DROP VIEW IF EXISTS view_3_tab0_127 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24757,13 +24757,13 @@ SELECT pk FROM tab1 WHERE col1 = 349.5 OR (col0 >= 101 AND col3 > 11 AND (col1 >
 42 values hashing to 7384eaeb71de8c039b40ba47c69e49a8
 
 statement ok
-DROP VIEW view_1_tab1_127
+DROP VIEW IF EXISTS view_1_tab1_127 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_127
+DROP VIEW IF EXISTS view_2_tab1_127 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_127
+DROP VIEW IF EXISTS view_3_tab1_127 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24854,13 +24854,13 @@ SELECT pk FROM tab2 WHERE col1 = 349.5 OR (col0 >= 101 AND col3 > 11 AND (col1 >
 42 values hashing to 7384eaeb71de8c039b40ba47c69e49a8
 
 statement ok
-DROP VIEW view_1_tab2_127
+DROP VIEW IF EXISTS view_1_tab2_127 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_127
+DROP VIEW IF EXISTS view_2_tab2_127 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_127
+DROP VIEW IF EXISTS view_3_tab2_127 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24951,13 +24951,13 @@ SELECT pk FROM tab3 WHERE col1 = 349.5 OR (col0 >= 101 AND col3 > 11 AND (col1 >
 42 values hashing to 7384eaeb71de8c039b40ba47c69e49a8
 
 statement ok
-DROP VIEW view_1_tab3_127
+DROP VIEW IF EXISTS view_1_tab3_127 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_127
+DROP VIEW IF EXISTS view_2_tab3_127 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_127
+DROP VIEW IF EXISTS view_3_tab3_127 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25048,13 +25048,13 @@ SELECT pk FROM tab4 WHERE col1 = 349.5 OR (col0 >= 101 AND col3 > 11 AND (col1 >
 42 values hashing to 7384eaeb71de8c039b40ba47c69e49a8
 
 statement ok
-DROP VIEW view_1_tab4_127
+DROP VIEW IF EXISTS view_1_tab4_127 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_127
+DROP VIEW IF EXISTS view_2_tab4_127 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_127
+DROP VIEW IF EXISTS view_3_tab4_127 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25145,13 +25145,13 @@ SELECT pk FROM tab0 WHERE col1 IN (251.46,161.18,26.98,725.14,623.64) OR col3 = 
 21 values hashing to 751f31a580ac0598030bf541f659ff8f
 
 statement ok
-DROP VIEW view_1_tab0_128
+DROP VIEW IF EXISTS view_1_tab0_128 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_128
+DROP VIEW IF EXISTS view_2_tab0_128 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_128
+DROP VIEW IF EXISTS view_3_tab0_128 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25242,13 +25242,13 @@ SELECT pk FROM tab1 WHERE col1 IN (251.46,161.18,26.98,725.14,623.64) OR col3 = 
 21 values hashing to 751f31a580ac0598030bf541f659ff8f
 
 statement ok
-DROP VIEW view_1_tab1_128
+DROP VIEW IF EXISTS view_1_tab1_128 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_128
+DROP VIEW IF EXISTS view_2_tab1_128 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_128
+DROP VIEW IF EXISTS view_3_tab1_128 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25339,13 +25339,13 @@ SELECT pk FROM tab2 WHERE col1 IN (251.46,161.18,26.98,725.14,623.64) OR col3 = 
 21 values hashing to 751f31a580ac0598030bf541f659ff8f
 
 statement ok
-DROP VIEW view_1_tab2_128
+DROP VIEW IF EXISTS view_1_tab2_128 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_128
+DROP VIEW IF EXISTS view_2_tab2_128 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_128
+DROP VIEW IF EXISTS view_3_tab2_128 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25436,13 +25436,13 @@ SELECT pk FROM tab3 WHERE col1 IN (251.46,161.18,26.98,725.14,623.64) OR col3 = 
 21 values hashing to 751f31a580ac0598030bf541f659ff8f
 
 statement ok
-DROP VIEW view_1_tab3_128
+DROP VIEW IF EXISTS view_1_tab3_128 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_128
+DROP VIEW IF EXISTS view_2_tab3_128 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_128
+DROP VIEW IF EXISTS view_3_tab3_128 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25533,13 +25533,13 @@ SELECT pk FROM tab4 WHERE col1 IN (251.46,161.18,26.98,725.14,623.64) OR col3 = 
 21 values hashing to 751f31a580ac0598030bf541f659ff8f
 
 statement ok
-DROP VIEW view_1_tab4_128
+DROP VIEW IF EXISTS view_1_tab4_128 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_128
+DROP VIEW IF EXISTS view_2_tab4_128 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_128
+DROP VIEW IF EXISTS view_3_tab4_128 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25625,13 +25625,13 @@ SELECT pk FROM tab0 WHERE ((col0 IS NULL AND (col4 >= 979.17)))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_129
+DROP VIEW IF EXISTS view_1_tab0_129 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_129
+DROP VIEW IF EXISTS view_2_tab0_129 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_129
+DROP VIEW IF EXISTS view_3_tab0_129 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25717,13 +25717,13 @@ SELECT pk FROM tab1 WHERE ((col0 IS NULL AND (col4 >= 979.17)))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_129
+DROP VIEW IF EXISTS view_1_tab1_129 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_129
+DROP VIEW IF EXISTS view_2_tab1_129 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_129
+DROP VIEW IF EXISTS view_3_tab1_129 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25809,13 +25809,13 @@ SELECT pk FROM tab2 WHERE ((col0 IS NULL AND (col4 >= 979.17)))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_129
+DROP VIEW IF EXISTS view_1_tab2_129 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_129
+DROP VIEW IF EXISTS view_2_tab2_129 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_129
+DROP VIEW IF EXISTS view_3_tab2_129 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25901,13 +25901,13 @@ SELECT pk FROM tab3 WHERE ((col0 IS NULL AND (col4 >= 979.17)))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_129
+DROP VIEW IF EXISTS view_1_tab3_129 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_129
+DROP VIEW IF EXISTS view_2_tab3_129 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_129
+DROP VIEW IF EXISTS view_3_tab3_129 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25993,13 +25993,13 @@ SELECT pk FROM tab4 WHERE ((col0 IS NULL AND (col4 >= 979.17)))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_129
+DROP VIEW IF EXISTS view_1_tab4_129 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_129
+DROP VIEW IF EXISTS view_2_tab4_129 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_129
+DROP VIEW IF EXISTS view_3_tab4_129 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26085,13 +26085,13 @@ SELECT pk FROM tab0 WHERE (col4 = 874.67) AND col1 < 834.73
 ----
 
 statement ok
-DROP VIEW view_1_tab0_130
+DROP VIEW IF EXISTS view_1_tab0_130 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_130
+DROP VIEW IF EXISTS view_2_tab0_130 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_130
+DROP VIEW IF EXISTS view_3_tab0_130 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26177,13 +26177,13 @@ SELECT pk FROM tab1 WHERE (col4 = 874.67) AND col1 < 834.73
 ----
 
 statement ok
-DROP VIEW view_1_tab1_130
+DROP VIEW IF EXISTS view_1_tab1_130 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_130
+DROP VIEW IF EXISTS view_2_tab1_130 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_130
+DROP VIEW IF EXISTS view_3_tab1_130 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26269,13 +26269,13 @@ SELECT pk FROM tab2 WHERE (col4 = 874.67) AND col1 < 834.73
 ----
 
 statement ok
-DROP VIEW view_1_tab2_130
+DROP VIEW IF EXISTS view_1_tab2_130 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_130
+DROP VIEW IF EXISTS view_2_tab2_130 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_130
+DROP VIEW IF EXISTS view_3_tab2_130 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26361,13 +26361,13 @@ SELECT pk FROM tab3 WHERE (col4 = 874.67) AND col1 < 834.73
 ----
 
 statement ok
-DROP VIEW view_1_tab3_130
+DROP VIEW IF EXISTS view_1_tab3_130 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_130
+DROP VIEW IF EXISTS view_2_tab3_130 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_130
+DROP VIEW IF EXISTS view_3_tab3_130 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26453,13 +26453,13 @@ SELECT pk FROM tab4 WHERE (col4 = 874.67) AND col1 < 834.73
 ----
 
 statement ok
-DROP VIEW view_1_tab4_130
+DROP VIEW IF EXISTS view_1_tab4_130 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_130
+DROP VIEW IF EXISTS view_2_tab4_130 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_130
+DROP VIEW IF EXISTS view_3_tab4_130 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26552,13 +26552,13 @@ SELECT pk FROM tab0 WHERE col4 >= 637.76 AND col4 IS NULL OR (((col1 BETWEEN 85.
 40
 
 statement ok
-DROP VIEW view_1_tab0_131
+DROP VIEW IF EXISTS view_1_tab0_131 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_131
+DROP VIEW IF EXISTS view_2_tab0_131 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_131
+DROP VIEW IF EXISTS view_3_tab0_131 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26651,13 +26651,13 @@ SELECT pk FROM tab1 WHERE col4 >= 637.76 AND col4 IS NULL OR (((col1 BETWEEN 85.
 40
 
 statement ok
-DROP VIEW view_1_tab1_131
+DROP VIEW IF EXISTS view_1_tab1_131 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_131
+DROP VIEW IF EXISTS view_2_tab1_131 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_131
+DROP VIEW IF EXISTS view_3_tab1_131 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26750,13 +26750,13 @@ SELECT pk FROM tab2 WHERE col4 >= 637.76 AND col4 IS NULL OR (((col1 BETWEEN 85.
 40
 
 statement ok
-DROP VIEW view_1_tab2_131
+DROP VIEW IF EXISTS view_1_tab2_131 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_131
+DROP VIEW IF EXISTS view_2_tab2_131 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_131
+DROP VIEW IF EXISTS view_3_tab2_131 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26849,13 +26849,13 @@ SELECT pk FROM tab3 WHERE col4 >= 637.76 AND col4 IS NULL OR (((col1 BETWEEN 85.
 40
 
 statement ok
-DROP VIEW view_1_tab3_131
+DROP VIEW IF EXISTS view_1_tab3_131 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_131
+DROP VIEW IF EXISTS view_2_tab3_131 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_131
+DROP VIEW IF EXISTS view_3_tab3_131 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26948,13 +26948,13 @@ SELECT pk FROM tab4 WHERE col4 >= 637.76 AND col4 IS NULL OR (((col1 BETWEEN 85.
 40
 
 statement ok
-DROP VIEW view_1_tab4_131
+DROP VIEW IF EXISTS view_1_tab4_131 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_131
+DROP VIEW IF EXISTS view_2_tab4_131 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_131
+DROP VIEW IF EXISTS view_3_tab4_131 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27045,13 +27045,13 @@ SELECT pk FROM tab0 WHERE col0 > 595
 39 values hashing to f0ea3cb18fb878f5cfd132fa1288f943
 
 statement ok
-DROP VIEW view_1_tab0_132
+DROP VIEW IF EXISTS view_1_tab0_132 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_132
+DROP VIEW IF EXISTS view_2_tab0_132 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_132
+DROP VIEW IF EXISTS view_3_tab0_132 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27142,13 +27142,13 @@ SELECT pk FROM tab1 WHERE col0 > 595
 39 values hashing to f0ea3cb18fb878f5cfd132fa1288f943
 
 statement ok
-DROP VIEW view_1_tab1_132
+DROP VIEW IF EXISTS view_1_tab1_132 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_132
+DROP VIEW IF EXISTS view_2_tab1_132 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_132
+DROP VIEW IF EXISTS view_3_tab1_132 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27239,13 +27239,13 @@ SELECT pk FROM tab2 WHERE col0 > 595
 39 values hashing to f0ea3cb18fb878f5cfd132fa1288f943
 
 statement ok
-DROP VIEW view_1_tab2_132
+DROP VIEW IF EXISTS view_1_tab2_132 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_132
+DROP VIEW IF EXISTS view_2_tab2_132 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_132
+DROP VIEW IF EXISTS view_3_tab2_132 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27336,13 +27336,13 @@ SELECT pk FROM tab3 WHERE col0 > 595
 39 values hashing to f0ea3cb18fb878f5cfd132fa1288f943
 
 statement ok
-DROP VIEW view_1_tab3_132
+DROP VIEW IF EXISTS view_1_tab3_132 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_132
+DROP VIEW IF EXISTS view_2_tab3_132 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_132
+DROP VIEW IF EXISTS view_3_tab3_132 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27433,13 +27433,13 @@ SELECT pk FROM tab4 WHERE col0 > 595
 39 values hashing to f0ea3cb18fb878f5cfd132fa1288f943
 
 statement ok
-DROP VIEW view_1_tab4_132
+DROP VIEW IF EXISTS view_1_tab4_132 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_132
+DROP VIEW IF EXISTS view_2_tab4_132 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_132
+DROP VIEW IF EXISTS view_3_tab4_132 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27525,13 +27525,13 @@ SELECT pk FROM tab0 WHERE col3 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab0_133
+DROP VIEW IF EXISTS view_1_tab0_133 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_133
+DROP VIEW IF EXISTS view_2_tab0_133 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_133
+DROP VIEW IF EXISTS view_3_tab0_133 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27617,13 +27617,13 @@ SELECT pk FROM tab1 WHERE col3 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab1_133
+DROP VIEW IF EXISTS view_1_tab1_133 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_133
+DROP VIEW IF EXISTS view_2_tab1_133 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_133
+DROP VIEW IF EXISTS view_3_tab1_133 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27709,13 +27709,13 @@ SELECT pk FROM tab2 WHERE col3 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab2_133
+DROP VIEW IF EXISTS view_1_tab2_133 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_133
+DROP VIEW IF EXISTS view_2_tab2_133 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_133
+DROP VIEW IF EXISTS view_3_tab2_133 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27801,13 +27801,13 @@ SELECT pk FROM tab3 WHERE col3 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab3_133
+DROP VIEW IF EXISTS view_1_tab3_133 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_133
+DROP VIEW IF EXISTS view_2_tab3_133 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_133
+DROP VIEW IF EXISTS view_3_tab3_133 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27893,13 +27893,13 @@ SELECT pk FROM tab4 WHERE col3 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab4_133
+DROP VIEW IF EXISTS view_1_tab4_133 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_133
+DROP VIEW IF EXISTS view_2_tab4_133 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_133
+DROP VIEW IF EXISTS view_3_tab4_133 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27990,13 +27990,13 @@ SELECT pk FROM tab0 WHERE (col3 > 574)
 48 values hashing to 152eb0d70273f5c70a9e5eaa4e52f3ee
 
 statement ok
-DROP VIEW view_1_tab0_134
+DROP VIEW IF EXISTS view_1_tab0_134 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_134
+DROP VIEW IF EXISTS view_2_tab0_134 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_134
+DROP VIEW IF EXISTS view_3_tab0_134 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28087,13 +28087,13 @@ SELECT pk FROM tab1 WHERE (col3 > 574)
 48 values hashing to 152eb0d70273f5c70a9e5eaa4e52f3ee
 
 statement ok
-DROP VIEW view_1_tab1_134
+DROP VIEW IF EXISTS view_1_tab1_134 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_134
+DROP VIEW IF EXISTS view_2_tab1_134 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_134
+DROP VIEW IF EXISTS view_3_tab1_134 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28184,13 +28184,13 @@ SELECT pk FROM tab2 WHERE (col3 > 574)
 48 values hashing to 152eb0d70273f5c70a9e5eaa4e52f3ee
 
 statement ok
-DROP VIEW view_1_tab2_134
+DROP VIEW IF EXISTS view_1_tab2_134 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_134
+DROP VIEW IF EXISTS view_2_tab2_134 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_134
+DROP VIEW IF EXISTS view_3_tab2_134 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28281,13 +28281,13 @@ SELECT pk FROM tab3 WHERE (col3 > 574)
 48 values hashing to 152eb0d70273f5c70a9e5eaa4e52f3ee
 
 statement ok
-DROP VIEW view_1_tab3_134
+DROP VIEW IF EXISTS view_1_tab3_134 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_134
+DROP VIEW IF EXISTS view_2_tab3_134 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_134
+DROP VIEW IF EXISTS view_3_tab3_134 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28378,13 +28378,13 @@ SELECT pk FROM tab4 WHERE (col3 > 574)
 48 values hashing to 152eb0d70273f5c70a9e5eaa4e52f3ee
 
 statement ok
-DROP VIEW view_1_tab4_134
+DROP VIEW IF EXISTS view_1_tab4_134 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_134
+DROP VIEW IF EXISTS view_2_tab4_134 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_134
+DROP VIEW IF EXISTS view_3_tab4_134 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28475,13 +28475,13 @@ SELECT pk FROM tab0 WHERE (col3 > 453)
 59 values hashing to 19d9d5b645ffe211c4985a187267dd59
 
 statement ok
-DROP VIEW view_1_tab0_135
+DROP VIEW IF EXISTS view_1_tab0_135 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_135
+DROP VIEW IF EXISTS view_2_tab0_135 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_135
+DROP VIEW IF EXISTS view_3_tab0_135 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28572,13 +28572,13 @@ SELECT pk FROM tab1 WHERE (col3 > 453)
 59 values hashing to 19d9d5b645ffe211c4985a187267dd59
 
 statement ok
-DROP VIEW view_1_tab1_135
+DROP VIEW IF EXISTS view_1_tab1_135 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_135
+DROP VIEW IF EXISTS view_2_tab1_135 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_135
+DROP VIEW IF EXISTS view_3_tab1_135 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28669,13 +28669,13 @@ SELECT pk FROM tab2 WHERE (col3 > 453)
 59 values hashing to 19d9d5b645ffe211c4985a187267dd59
 
 statement ok
-DROP VIEW view_1_tab2_135
+DROP VIEW IF EXISTS view_1_tab2_135 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_135
+DROP VIEW IF EXISTS view_2_tab2_135 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_135
+DROP VIEW IF EXISTS view_3_tab2_135 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28766,13 +28766,13 @@ SELECT pk FROM tab3 WHERE (col3 > 453)
 59 values hashing to 19d9d5b645ffe211c4985a187267dd59
 
 statement ok
-DROP VIEW view_1_tab3_135
+DROP VIEW IF EXISTS view_1_tab3_135 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_135
+DROP VIEW IF EXISTS view_2_tab3_135 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_135
+DROP VIEW IF EXISTS view_3_tab3_135 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28863,13 +28863,13 @@ SELECT pk FROM tab4 WHERE (col3 > 453)
 59 values hashing to 19d9d5b645ffe211c4985a187267dd59
 
 statement ok
-DROP VIEW view_1_tab4_135
+DROP VIEW IF EXISTS view_1_tab4_135 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_135
+DROP VIEW IF EXISTS view_2_tab4_135 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_135
+DROP VIEW IF EXISTS view_3_tab4_135 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28960,13 +28960,13 @@ SELECT pk FROM tab0 WHERE ((col0 <= 556))
 58 values hashing to 386da58aefba7186e06ef3b796020158
 
 statement ok
-DROP VIEW view_1_tab0_136
+DROP VIEW IF EXISTS view_1_tab0_136 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_136
+DROP VIEW IF EXISTS view_2_tab0_136 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_136
+DROP VIEW IF EXISTS view_3_tab0_136 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29057,13 +29057,13 @@ SELECT pk FROM tab1 WHERE ((col0 <= 556))
 58 values hashing to 386da58aefba7186e06ef3b796020158
 
 statement ok
-DROP VIEW view_1_tab1_136
+DROP VIEW IF EXISTS view_1_tab1_136 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_136
+DROP VIEW IF EXISTS view_2_tab1_136 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_136
+DROP VIEW IF EXISTS view_3_tab1_136 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29154,13 +29154,13 @@ SELECT pk FROM tab2 WHERE ((col0 <= 556))
 58 values hashing to 386da58aefba7186e06ef3b796020158
 
 statement ok
-DROP VIEW view_1_tab2_136
+DROP VIEW IF EXISTS view_1_tab2_136 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_136
+DROP VIEW IF EXISTS view_2_tab2_136 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_136
+DROP VIEW IF EXISTS view_3_tab2_136 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29251,13 +29251,13 @@ SELECT pk FROM tab3 WHERE ((col0 <= 556))
 58 values hashing to 386da58aefba7186e06ef3b796020158
 
 statement ok
-DROP VIEW view_1_tab3_136
+DROP VIEW IF EXISTS view_1_tab3_136 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_136
+DROP VIEW IF EXISTS view_2_tab3_136 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_136
+DROP VIEW IF EXISTS view_3_tab3_136 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29348,13 +29348,13 @@ SELECT pk FROM tab4 WHERE ((col0 <= 556))
 58 values hashing to 386da58aefba7186e06ef3b796020158
 
 statement ok
-DROP VIEW view_1_tab4_136
+DROP VIEW IF EXISTS view_1_tab4_136 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_136
+DROP VIEW IF EXISTS view_2_tab4_136 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_136
+DROP VIEW IF EXISTS view_3_tab4_136 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29440,13 +29440,13 @@ SELECT pk FROM tab0 WHERE ((((col0 < 272 OR col4 > 825.1 OR col0 < 851) OR ((col
 ----
 
 statement ok
-DROP VIEW view_1_tab0_137
+DROP VIEW IF EXISTS view_1_tab0_137 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_137
+DROP VIEW IF EXISTS view_2_tab0_137 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_137
+DROP VIEW IF EXISTS view_3_tab0_137 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29532,13 +29532,13 @@ SELECT pk FROM tab1 WHERE ((((col0 < 272 OR col4 > 825.1 OR col0 < 851) OR ((col
 ----
 
 statement ok
-DROP VIEW view_1_tab1_137
+DROP VIEW IF EXISTS view_1_tab1_137 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_137
+DROP VIEW IF EXISTS view_2_tab1_137 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_137
+DROP VIEW IF EXISTS view_3_tab1_137 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29624,13 +29624,13 @@ SELECT pk FROM tab2 WHERE ((((col0 < 272 OR col4 > 825.1 OR col0 < 851) OR ((col
 ----
 
 statement ok
-DROP VIEW view_1_tab2_137
+DROP VIEW IF EXISTS view_1_tab2_137 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_137
+DROP VIEW IF EXISTS view_2_tab2_137 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_137
+DROP VIEW IF EXISTS view_3_tab2_137 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29716,13 +29716,13 @@ SELECT pk FROM tab3 WHERE ((((col0 < 272 OR col4 > 825.1 OR col0 < 851) OR ((col
 ----
 
 statement ok
-DROP VIEW view_1_tab3_137
+DROP VIEW IF EXISTS view_1_tab3_137 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_137
+DROP VIEW IF EXISTS view_2_tab3_137 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_137
+DROP VIEW IF EXISTS view_3_tab3_137 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29808,13 +29808,13 @@ SELECT pk FROM tab4 WHERE ((((col0 < 272 OR col4 > 825.1 OR col0 < 851) OR ((col
 ----
 
 statement ok
-DROP VIEW view_1_tab4_137
+DROP VIEW IF EXISTS view_1_tab4_137 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_137
+DROP VIEW IF EXISTS view_2_tab4_137 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_137
+DROP VIEW IF EXISTS view_3_tab4_137 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29905,13 +29905,13 @@ SELECT pk FROM tab0 WHERE col0 > 669
 30 values hashing to 6ed341d1db018a7632d1f389e4c602fb
 
 statement ok
-DROP VIEW view_1_tab0_138
+DROP VIEW IF EXISTS view_1_tab0_138 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_138
+DROP VIEW IF EXISTS view_2_tab0_138 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_138
+DROP VIEW IF EXISTS view_3_tab0_138 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30002,13 +30002,13 @@ SELECT pk FROM tab1 WHERE col0 > 669
 30 values hashing to 6ed341d1db018a7632d1f389e4c602fb
 
 statement ok
-DROP VIEW view_1_tab1_138
+DROP VIEW IF EXISTS view_1_tab1_138 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_138
+DROP VIEW IF EXISTS view_2_tab1_138 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_138
+DROP VIEW IF EXISTS view_3_tab1_138 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30099,13 +30099,13 @@ SELECT pk FROM tab2 WHERE col0 > 669
 30 values hashing to 6ed341d1db018a7632d1f389e4c602fb
 
 statement ok
-DROP VIEW view_1_tab2_138
+DROP VIEW IF EXISTS view_1_tab2_138 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_138
+DROP VIEW IF EXISTS view_2_tab2_138 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_138
+DROP VIEW IF EXISTS view_3_tab2_138 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30196,13 +30196,13 @@ SELECT pk FROM tab3 WHERE col0 > 669
 30 values hashing to 6ed341d1db018a7632d1f389e4c602fb
 
 statement ok
-DROP VIEW view_1_tab3_138
+DROP VIEW IF EXISTS view_1_tab3_138 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_138
+DROP VIEW IF EXISTS view_2_tab3_138 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_138
+DROP VIEW IF EXISTS view_3_tab3_138 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30293,13 +30293,13 @@ SELECT pk FROM tab4 WHERE col0 > 669
 30 values hashing to 6ed341d1db018a7632d1f389e4c602fb
 
 statement ok
-DROP VIEW view_1_tab4_138
+DROP VIEW IF EXISTS view_1_tab4_138 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_138
+DROP VIEW IF EXISTS view_2_tab4_138 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_138
+DROP VIEW IF EXISTS view_3_tab4_138 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30385,13 +30385,13 @@ SELECT pk FROM tab0 WHERE (col3 >= 986 OR (((col0 > 434))) AND col1 <= 548.35 OR
 ----
 
 statement ok
-DROP VIEW view_1_tab0_139
+DROP VIEW IF EXISTS view_1_tab0_139 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_139
+DROP VIEW IF EXISTS view_2_tab0_139 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_139
+DROP VIEW IF EXISTS view_3_tab0_139 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30477,13 +30477,13 @@ SELECT pk FROM tab1 WHERE (col3 >= 986 OR (((col0 > 434))) AND col1 <= 548.35 OR
 ----
 
 statement ok
-DROP VIEW view_1_tab1_139
+DROP VIEW IF EXISTS view_1_tab1_139 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_139
+DROP VIEW IF EXISTS view_2_tab1_139 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_139
+DROP VIEW IF EXISTS view_3_tab1_139 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30569,13 +30569,13 @@ SELECT pk FROM tab2 WHERE (col3 >= 986 OR (((col0 > 434))) AND col1 <= 548.35 OR
 ----
 
 statement ok
-DROP VIEW view_1_tab2_139
+DROP VIEW IF EXISTS view_1_tab2_139 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_139
+DROP VIEW IF EXISTS view_2_tab2_139 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_139
+DROP VIEW IF EXISTS view_3_tab2_139 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30661,13 +30661,13 @@ SELECT pk FROM tab3 WHERE (col3 >= 986 OR (((col0 > 434))) AND col1 <= 548.35 OR
 ----
 
 statement ok
-DROP VIEW view_1_tab3_139
+DROP VIEW IF EXISTS view_1_tab3_139 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_139
+DROP VIEW IF EXISTS view_2_tab3_139 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_139
+DROP VIEW IF EXISTS view_3_tab3_139 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30753,13 +30753,13 @@ SELECT pk FROM tab4 WHERE (col3 >= 986 OR (((col0 > 434))) AND col1 <= 548.35 OR
 ----
 
 statement ok
-DROP VIEW view_1_tab4_139
+DROP VIEW IF EXISTS view_1_tab4_139 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_139
+DROP VIEW IF EXISTS view_2_tab4_139 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_139
+DROP VIEW IF EXISTS view_3_tab4_139 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30850,13 +30850,13 @@ SELECT pk FROM tab0 WHERE (col3 > 909)
 14 values hashing to 21a2f6f73a1a99dc21ca84769aee7aa3
 
 statement ok
-DROP VIEW view_1_tab0_140
+DROP VIEW IF EXISTS view_1_tab0_140 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_140
+DROP VIEW IF EXISTS view_2_tab0_140 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_140
+DROP VIEW IF EXISTS view_3_tab0_140 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30947,13 +30947,13 @@ SELECT pk FROM tab1 WHERE (col3 > 909)
 14 values hashing to 21a2f6f73a1a99dc21ca84769aee7aa3
 
 statement ok
-DROP VIEW view_1_tab1_140
+DROP VIEW IF EXISTS view_1_tab1_140 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_140
+DROP VIEW IF EXISTS view_2_tab1_140 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_140
+DROP VIEW IF EXISTS view_3_tab1_140 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31044,13 +31044,13 @@ SELECT pk FROM tab2 WHERE (col3 > 909)
 14 values hashing to 21a2f6f73a1a99dc21ca84769aee7aa3
 
 statement ok
-DROP VIEW view_1_tab2_140
+DROP VIEW IF EXISTS view_1_tab2_140 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_140
+DROP VIEW IF EXISTS view_2_tab2_140 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_140
+DROP VIEW IF EXISTS view_3_tab2_140 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31141,13 +31141,13 @@ SELECT pk FROM tab3 WHERE (col3 > 909)
 14 values hashing to 21a2f6f73a1a99dc21ca84769aee7aa3
 
 statement ok
-DROP VIEW view_1_tab3_140
+DROP VIEW IF EXISTS view_1_tab3_140 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_140
+DROP VIEW IF EXISTS view_2_tab3_140 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_140
+DROP VIEW IF EXISTS view_3_tab3_140 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31238,13 +31238,13 @@ SELECT pk FROM tab4 WHERE (col3 > 909)
 14 values hashing to 21a2f6f73a1a99dc21ca84769aee7aa3
 
 statement ok
-DROP VIEW view_1_tab4_140
+DROP VIEW IF EXISTS view_1_tab4_140 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_140
+DROP VIEW IF EXISTS view_2_tab4_140 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_140
+DROP VIEW IF EXISTS view_3_tab4_140 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31335,13 +31335,13 @@ SELECT pk FROM tab0 WHERE (col1 > 474.94)
 58 values hashing to fab1ee291e21e2bdc6868df65c9b8c99
 
 statement ok
-DROP VIEW view_1_tab0_141
+DROP VIEW IF EXISTS view_1_tab0_141 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_141
+DROP VIEW IF EXISTS view_2_tab0_141 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_141
+DROP VIEW IF EXISTS view_3_tab0_141 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31432,13 +31432,13 @@ SELECT pk FROM tab1 WHERE (col1 > 474.94)
 58 values hashing to fab1ee291e21e2bdc6868df65c9b8c99
 
 statement ok
-DROP VIEW view_1_tab1_141
+DROP VIEW IF EXISTS view_1_tab1_141 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_141
+DROP VIEW IF EXISTS view_2_tab1_141 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_141
+DROP VIEW IF EXISTS view_3_tab1_141 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31529,13 +31529,13 @@ SELECT pk FROM tab2 WHERE (col1 > 474.94)
 58 values hashing to fab1ee291e21e2bdc6868df65c9b8c99
 
 statement ok
-DROP VIEW view_1_tab2_141
+DROP VIEW IF EXISTS view_1_tab2_141 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_141
+DROP VIEW IF EXISTS view_2_tab2_141 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_141
+DROP VIEW IF EXISTS view_3_tab2_141 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31626,13 +31626,13 @@ SELECT pk FROM tab3 WHERE (col1 > 474.94)
 58 values hashing to fab1ee291e21e2bdc6868df65c9b8c99
 
 statement ok
-DROP VIEW view_1_tab3_141
+DROP VIEW IF EXISTS view_1_tab3_141 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_141
+DROP VIEW IF EXISTS view_2_tab3_141 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_141
+DROP VIEW IF EXISTS view_3_tab3_141 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31723,13 +31723,13 @@ SELECT pk FROM tab4 WHERE (col1 > 474.94)
 58 values hashing to fab1ee291e21e2bdc6868df65c9b8c99
 
 statement ok
-DROP VIEW view_1_tab4_141
+DROP VIEW IF EXISTS view_1_tab4_141 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_141
+DROP VIEW IF EXISTS view_2_tab4_141 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_141
+DROP VIEW IF EXISTS view_3_tab4_141 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31820,13 +31820,13 @@ SELECT pk FROM tab0 WHERE col1 >= 654.12
 36 values hashing to d36b9016a8453aa62f14a1553dcff970
 
 statement ok
-DROP VIEW view_1_tab0_142
+DROP VIEW IF EXISTS view_1_tab0_142 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_142
+DROP VIEW IF EXISTS view_2_tab0_142 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_142
+DROP VIEW IF EXISTS view_3_tab0_142 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31917,13 +31917,13 @@ SELECT pk FROM tab1 WHERE col1 >= 654.12
 36 values hashing to d36b9016a8453aa62f14a1553dcff970
 
 statement ok
-DROP VIEW view_1_tab1_142
+DROP VIEW IF EXISTS view_1_tab1_142 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_142
+DROP VIEW IF EXISTS view_2_tab1_142 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_142
+DROP VIEW IF EXISTS view_3_tab1_142 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32014,13 +32014,13 @@ SELECT pk FROM tab2 WHERE col1 >= 654.12
 36 values hashing to d36b9016a8453aa62f14a1553dcff970
 
 statement ok
-DROP VIEW view_1_tab2_142
+DROP VIEW IF EXISTS view_1_tab2_142 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_142
+DROP VIEW IF EXISTS view_2_tab2_142 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_142
+DROP VIEW IF EXISTS view_3_tab2_142 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32111,13 +32111,13 @@ SELECT pk FROM tab3 WHERE col1 >= 654.12
 36 values hashing to d36b9016a8453aa62f14a1553dcff970
 
 statement ok
-DROP VIEW view_1_tab3_142
+DROP VIEW IF EXISTS view_1_tab3_142 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_142
+DROP VIEW IF EXISTS view_2_tab3_142 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_142
+DROP VIEW IF EXISTS view_3_tab3_142 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32208,13 +32208,13 @@ SELECT pk FROM tab4 WHERE col1 >= 654.12
 36 values hashing to d36b9016a8453aa62f14a1553dcff970
 
 statement ok
-DROP VIEW view_1_tab4_142
+DROP VIEW IF EXISTS view_1_tab4_142 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_142
+DROP VIEW IF EXISTS view_2_tab4_142 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_142
+DROP VIEW IF EXISTS view_3_tab4_142 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32305,13 +32305,13 @@ SELECT pk FROM tab0 WHERE ((((col4 > 459.70))))
 54 values hashing to 50db0d074f0f2e707ad2a5afb9d21320
 
 statement ok
-DROP VIEW view_1_tab0_143
+DROP VIEW IF EXISTS view_1_tab0_143 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_143
+DROP VIEW IF EXISTS view_2_tab0_143 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_143
+DROP VIEW IF EXISTS view_3_tab0_143 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32402,13 +32402,13 @@ SELECT pk FROM tab1 WHERE ((((col4 > 459.70))))
 54 values hashing to 50db0d074f0f2e707ad2a5afb9d21320
 
 statement ok
-DROP VIEW view_1_tab1_143
+DROP VIEW IF EXISTS view_1_tab1_143 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_143
+DROP VIEW IF EXISTS view_2_tab1_143 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_143
+DROP VIEW IF EXISTS view_3_tab1_143 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32499,13 +32499,13 @@ SELECT pk FROM tab2 WHERE ((((col4 > 459.70))))
 54 values hashing to 50db0d074f0f2e707ad2a5afb9d21320
 
 statement ok
-DROP VIEW view_1_tab2_143
+DROP VIEW IF EXISTS view_1_tab2_143 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_143
+DROP VIEW IF EXISTS view_2_tab2_143 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_143
+DROP VIEW IF EXISTS view_3_tab2_143 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32596,13 +32596,13 @@ SELECT pk FROM tab3 WHERE ((((col4 > 459.70))))
 54 values hashing to 50db0d074f0f2e707ad2a5afb9d21320
 
 statement ok
-DROP VIEW view_1_tab3_143
+DROP VIEW IF EXISTS view_1_tab3_143 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_143
+DROP VIEW IF EXISTS view_2_tab3_143 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_143
+DROP VIEW IF EXISTS view_3_tab3_143 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32693,13 +32693,13 @@ SELECT pk FROM tab4 WHERE ((((col4 > 459.70))))
 54 values hashing to 50db0d074f0f2e707ad2a5afb9d21320
 
 statement ok
-DROP VIEW view_1_tab4_143
+DROP VIEW IF EXISTS view_1_tab4_143 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_143
+DROP VIEW IF EXISTS view_2_tab4_143 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_143
+DROP VIEW IF EXISTS view_3_tab4_143 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32790,13 +32790,13 @@ SELECT pk FROM tab0 WHERE col3 > 221
 84 values hashing to f87f36d231ad0571ef31c4b3b66aeaad
 
 statement ok
-DROP VIEW view_1_tab0_144
+DROP VIEW IF EXISTS view_1_tab0_144 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_144
+DROP VIEW IF EXISTS view_2_tab0_144 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_144
+DROP VIEW IF EXISTS view_3_tab0_144 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32887,13 +32887,13 @@ SELECT pk FROM tab1 WHERE col3 > 221
 84 values hashing to f87f36d231ad0571ef31c4b3b66aeaad
 
 statement ok
-DROP VIEW view_1_tab1_144
+DROP VIEW IF EXISTS view_1_tab1_144 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_144
+DROP VIEW IF EXISTS view_2_tab1_144 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_144
+DROP VIEW IF EXISTS view_3_tab1_144 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32984,13 +32984,13 @@ SELECT pk FROM tab2 WHERE col3 > 221
 84 values hashing to f87f36d231ad0571ef31c4b3b66aeaad
 
 statement ok
-DROP VIEW view_1_tab2_144
+DROP VIEW IF EXISTS view_1_tab2_144 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_144
+DROP VIEW IF EXISTS view_2_tab2_144 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_144
+DROP VIEW IF EXISTS view_3_tab2_144 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33081,13 +33081,13 @@ SELECT pk FROM tab3 WHERE col3 > 221
 84 values hashing to f87f36d231ad0571ef31c4b3b66aeaad
 
 statement ok
-DROP VIEW view_1_tab3_144
+DROP VIEW IF EXISTS view_1_tab3_144 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_144
+DROP VIEW IF EXISTS view_2_tab3_144 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_144
+DROP VIEW IF EXISTS view_3_tab3_144 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33178,13 +33178,13 @@ SELECT pk FROM tab4 WHERE col3 > 221
 84 values hashing to f87f36d231ad0571ef31c4b3b66aeaad
 
 statement ok
-DROP VIEW view_1_tab4_144
+DROP VIEW IF EXISTS view_1_tab4_144 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_144
+DROP VIEW IF EXISTS view_2_tab4_144 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_144
+DROP VIEW IF EXISTS view_3_tab4_144 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33270,13 +33270,13 @@ SELECT pk FROM tab0 WHERE col3 = 980 AND col4 > 70.95 AND ((col0 = 807))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_145
+DROP VIEW IF EXISTS view_1_tab0_145 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_145
+DROP VIEW IF EXISTS view_2_tab0_145 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_145
+DROP VIEW IF EXISTS view_3_tab0_145 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33362,13 +33362,13 @@ SELECT pk FROM tab1 WHERE col3 = 980 AND col4 > 70.95 AND ((col0 = 807))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_145
+DROP VIEW IF EXISTS view_1_tab1_145 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_145
+DROP VIEW IF EXISTS view_2_tab1_145 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_145
+DROP VIEW IF EXISTS view_3_tab1_145 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33454,13 +33454,13 @@ SELECT pk FROM tab2 WHERE col3 = 980 AND col4 > 70.95 AND ((col0 = 807))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_145
+DROP VIEW IF EXISTS view_1_tab2_145 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_145
+DROP VIEW IF EXISTS view_2_tab2_145 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_145
+DROP VIEW IF EXISTS view_3_tab2_145 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33546,13 +33546,13 @@ SELECT pk FROM tab3 WHERE col3 = 980 AND col4 > 70.95 AND ((col0 = 807))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_145
+DROP VIEW IF EXISTS view_1_tab3_145 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_145
+DROP VIEW IF EXISTS view_2_tab3_145 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_145
+DROP VIEW IF EXISTS view_3_tab3_145 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33638,13 +33638,13 @@ SELECT pk FROM tab4 WHERE col3 = 980 AND col4 > 70.95 AND ((col0 = 807))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_145
+DROP VIEW IF EXISTS view_1_tab4_145 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_145
+DROP VIEW IF EXISTS view_2_tab4_145 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_145
+DROP VIEW IF EXISTS view_3_tab4_145 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33735,13 +33735,13 @@ SELECT pk FROM tab0 WHERE col0 > 223
 78 values hashing to 6300afe8d9188a47a00f8a9773479c63
 
 statement ok
-DROP VIEW view_1_tab0_146
+DROP VIEW IF EXISTS view_1_tab0_146 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_146
+DROP VIEW IF EXISTS view_2_tab0_146 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_146
+DROP VIEW IF EXISTS view_3_tab0_146 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33832,13 +33832,13 @@ SELECT pk FROM tab1 WHERE col0 > 223
 78 values hashing to 6300afe8d9188a47a00f8a9773479c63
 
 statement ok
-DROP VIEW view_1_tab1_146
+DROP VIEW IF EXISTS view_1_tab1_146 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_146
+DROP VIEW IF EXISTS view_2_tab1_146 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_146
+DROP VIEW IF EXISTS view_3_tab1_146 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33929,13 +33929,13 @@ SELECT pk FROM tab2 WHERE col0 > 223
 78 values hashing to 6300afe8d9188a47a00f8a9773479c63
 
 statement ok
-DROP VIEW view_1_tab2_146
+DROP VIEW IF EXISTS view_1_tab2_146 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_146
+DROP VIEW IF EXISTS view_2_tab2_146 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_146
+DROP VIEW IF EXISTS view_3_tab2_146 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34026,13 +34026,13 @@ SELECT pk FROM tab3 WHERE col0 > 223
 78 values hashing to 6300afe8d9188a47a00f8a9773479c63
 
 statement ok
-DROP VIEW view_1_tab3_146
+DROP VIEW IF EXISTS view_1_tab3_146 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_146
+DROP VIEW IF EXISTS view_2_tab3_146 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_146
+DROP VIEW IF EXISTS view_3_tab3_146 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34123,13 +34123,13 @@ SELECT pk FROM tab4 WHERE col0 > 223
 78 values hashing to 6300afe8d9188a47a00f8a9773479c63
 
 statement ok
-DROP VIEW view_1_tab4_146
+DROP VIEW IF EXISTS view_1_tab4_146 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_146
+DROP VIEW IF EXISTS view_2_tab4_146 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_146
+DROP VIEW IF EXISTS view_3_tab4_146 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34220,13 +34220,13 @@ SELECT pk FROM tab0 WHERE (col1 > 684.6)
 33 values hashing to 39ad3a3d242135846ea7c0237e3902fe
 
 statement ok
-DROP VIEW view_1_tab0_147
+DROP VIEW IF EXISTS view_1_tab0_147 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_147
+DROP VIEW IF EXISTS view_2_tab0_147 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_147
+DROP VIEW IF EXISTS view_3_tab0_147 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34317,13 +34317,13 @@ SELECT pk FROM tab1 WHERE (col1 > 684.6)
 33 values hashing to 39ad3a3d242135846ea7c0237e3902fe
 
 statement ok
-DROP VIEW view_1_tab1_147
+DROP VIEW IF EXISTS view_1_tab1_147 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_147
+DROP VIEW IF EXISTS view_2_tab1_147 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_147
+DROP VIEW IF EXISTS view_3_tab1_147 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34414,13 +34414,13 @@ SELECT pk FROM tab2 WHERE (col1 > 684.6)
 33 values hashing to 39ad3a3d242135846ea7c0237e3902fe
 
 statement ok
-DROP VIEW view_1_tab2_147
+DROP VIEW IF EXISTS view_1_tab2_147 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_147
+DROP VIEW IF EXISTS view_2_tab2_147 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_147
+DROP VIEW IF EXISTS view_3_tab2_147 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34511,13 +34511,13 @@ SELECT pk FROM tab3 WHERE (col1 > 684.6)
 33 values hashing to 39ad3a3d242135846ea7c0237e3902fe
 
 statement ok
-DROP VIEW view_1_tab3_147
+DROP VIEW IF EXISTS view_1_tab3_147 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_147
+DROP VIEW IF EXISTS view_2_tab3_147 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_147
+DROP VIEW IF EXISTS view_3_tab3_147 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34608,13 +34608,13 @@ SELECT pk FROM tab4 WHERE (col1 > 684.6)
 33 values hashing to 39ad3a3d242135846ea7c0237e3902fe
 
 statement ok
-DROP VIEW view_1_tab4_147
+DROP VIEW IF EXISTS view_1_tab4_147 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_147
+DROP VIEW IF EXISTS view_2_tab4_147 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_147
+DROP VIEW IF EXISTS view_3_tab4_147 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34700,13 +34700,13 @@ SELECT pk FROM tab0 WHERE ((col3 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_148
+DROP VIEW IF EXISTS view_1_tab0_148 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_148
+DROP VIEW IF EXISTS view_2_tab0_148 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_148
+DROP VIEW IF EXISTS view_3_tab0_148 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34792,13 +34792,13 @@ SELECT pk FROM tab1 WHERE ((col3 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_148
+DROP VIEW IF EXISTS view_1_tab1_148 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_148
+DROP VIEW IF EXISTS view_2_tab1_148 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_148
+DROP VIEW IF EXISTS view_3_tab1_148 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34884,13 +34884,13 @@ SELECT pk FROM tab2 WHERE ((col3 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_148
+DROP VIEW IF EXISTS view_1_tab2_148 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_148
+DROP VIEW IF EXISTS view_2_tab2_148 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_148
+DROP VIEW IF EXISTS view_3_tab2_148 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34976,13 +34976,13 @@ SELECT pk FROM tab3 WHERE ((col3 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_148
+DROP VIEW IF EXISTS view_1_tab3_148 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_148
+DROP VIEW IF EXISTS view_2_tab3_148 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_148
+DROP VIEW IF EXISTS view_3_tab3_148 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35068,13 +35068,13 @@ SELECT pk FROM tab4 WHERE ((col3 IS NULL))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_148
+DROP VIEW IF EXISTS view_1_tab4_148 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_148
+DROP VIEW IF EXISTS view_2_tab4_148 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_148
+DROP VIEW IF EXISTS view_3_tab4_148 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35167,13 +35167,13 @@ SELECT pk FROM tab0 WHERE (col0 BETWEEN 831 AND 838)
 80
 
 statement ok
-DROP VIEW view_1_tab0_149
+DROP VIEW IF EXISTS view_1_tab0_149 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_149
+DROP VIEW IF EXISTS view_2_tab0_149 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_149
+DROP VIEW IF EXISTS view_3_tab0_149 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35266,13 +35266,13 @@ SELECT pk FROM tab1 WHERE (col0 BETWEEN 831 AND 838)
 80
 
 statement ok
-DROP VIEW view_1_tab1_149
+DROP VIEW IF EXISTS view_1_tab1_149 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_149
+DROP VIEW IF EXISTS view_2_tab1_149 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_149
+DROP VIEW IF EXISTS view_3_tab1_149 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35365,13 +35365,13 @@ SELECT pk FROM tab2 WHERE (col0 BETWEEN 831 AND 838)
 80
 
 statement ok
-DROP VIEW view_1_tab2_149
+DROP VIEW IF EXISTS view_1_tab2_149 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_149
+DROP VIEW IF EXISTS view_2_tab2_149 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_149
+DROP VIEW IF EXISTS view_3_tab2_149 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35464,13 +35464,13 @@ SELECT pk FROM tab3 WHERE (col0 BETWEEN 831 AND 838)
 80
 
 statement ok
-DROP VIEW view_1_tab3_149
+DROP VIEW IF EXISTS view_1_tab3_149 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_149
+DROP VIEW IF EXISTS view_2_tab3_149 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_149
+DROP VIEW IF EXISTS view_3_tab3_149 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35563,13 +35563,13 @@ SELECT pk FROM tab4 WHERE (col0 BETWEEN 831 AND 838)
 80
 
 statement ok
-DROP VIEW view_1_tab4_149
+DROP VIEW IF EXISTS view_1_tab4_149 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_149
+DROP VIEW IF EXISTS view_2_tab4_149 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_149
+DROP VIEW IF EXISTS view_3_tab4_149 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35655,13 +35655,13 @@ SELECT pk FROM tab0 WHERE col0 < 24
 ----
 
 statement ok
-DROP VIEW view_1_tab0_150
+DROP VIEW IF EXISTS view_1_tab0_150 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_150
+DROP VIEW IF EXISTS view_2_tab0_150 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_150
+DROP VIEW IF EXISTS view_3_tab0_150 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35747,13 +35747,13 @@ SELECT pk FROM tab1 WHERE col0 < 24
 ----
 
 statement ok
-DROP VIEW view_1_tab1_150
+DROP VIEW IF EXISTS view_1_tab1_150 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_150
+DROP VIEW IF EXISTS view_2_tab1_150 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_150
+DROP VIEW IF EXISTS view_3_tab1_150 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35839,13 +35839,13 @@ SELECT pk FROM tab2 WHERE col0 < 24
 ----
 
 statement ok
-DROP VIEW view_1_tab2_150
+DROP VIEW IF EXISTS view_1_tab2_150 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_150
+DROP VIEW IF EXISTS view_2_tab2_150 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_150
+DROP VIEW IF EXISTS view_3_tab2_150 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35931,13 +35931,13 @@ SELECT pk FROM tab3 WHERE col0 < 24
 ----
 
 statement ok
-DROP VIEW view_1_tab3_150
+DROP VIEW IF EXISTS view_1_tab3_150 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_150
+DROP VIEW IF EXISTS view_2_tab3_150 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_150
+DROP VIEW IF EXISTS view_3_tab3_150 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36023,13 +36023,13 @@ SELECT pk FROM tab4 WHERE col0 < 24
 ----
 
 statement ok
-DROP VIEW view_1_tab4_150
+DROP VIEW IF EXISTS view_1_tab4_150 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_150
+DROP VIEW IF EXISTS view_2_tab4_150 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_150
+DROP VIEW IF EXISTS view_3_tab4_150 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36120,13 +36120,13 @@ SELECT pk FROM tab0 WHERE col3 >= 733
 23 values hashing to 88401fe2315b3ac85a944436b5f43983
 
 statement ok
-DROP VIEW view_1_tab0_151
+DROP VIEW IF EXISTS view_1_tab0_151 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_151
+DROP VIEW IF EXISTS view_2_tab0_151 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_151
+DROP VIEW IF EXISTS view_3_tab0_151 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36217,13 +36217,13 @@ SELECT pk FROM tab1 WHERE col3 >= 733
 23 values hashing to 88401fe2315b3ac85a944436b5f43983
 
 statement ok
-DROP VIEW view_1_tab1_151
+DROP VIEW IF EXISTS view_1_tab1_151 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_151
+DROP VIEW IF EXISTS view_2_tab1_151 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_151
+DROP VIEW IF EXISTS view_3_tab1_151 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36314,13 +36314,13 @@ SELECT pk FROM tab2 WHERE col3 >= 733
 23 values hashing to 88401fe2315b3ac85a944436b5f43983
 
 statement ok
-DROP VIEW view_1_tab2_151
+DROP VIEW IF EXISTS view_1_tab2_151 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_151
+DROP VIEW IF EXISTS view_2_tab2_151 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_151
+DROP VIEW IF EXISTS view_3_tab2_151 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36411,13 +36411,13 @@ SELECT pk FROM tab3 WHERE col3 >= 733
 23 values hashing to 88401fe2315b3ac85a944436b5f43983
 
 statement ok
-DROP VIEW view_1_tab3_151
+DROP VIEW IF EXISTS view_1_tab3_151 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_151
+DROP VIEW IF EXISTS view_2_tab3_151 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_151
+DROP VIEW IF EXISTS view_3_tab3_151 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36508,13 +36508,13 @@ SELECT pk FROM tab4 WHERE col3 >= 733
 23 values hashing to 88401fe2315b3ac85a944436b5f43983
 
 statement ok
-DROP VIEW view_1_tab4_151
+DROP VIEW IF EXISTS view_1_tab4_151 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_151
+DROP VIEW IF EXISTS view_2_tab4_151 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_151
+DROP VIEW IF EXISTS view_3_tab4_151 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36605,13 +36605,13 @@ SELECT pk FROM tab0 WHERE col1 > 343.72
 68 values hashing to 7c7d4bc02f9480775307da2a5d8b3a49
 
 statement ok
-DROP VIEW view_1_tab0_152
+DROP VIEW IF EXISTS view_1_tab0_152 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_152
+DROP VIEW IF EXISTS view_2_tab0_152 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_152
+DROP VIEW IF EXISTS view_3_tab0_152 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36702,13 +36702,13 @@ SELECT pk FROM tab1 WHERE col1 > 343.72
 68 values hashing to 7c7d4bc02f9480775307da2a5d8b3a49
 
 statement ok
-DROP VIEW view_1_tab1_152
+DROP VIEW IF EXISTS view_1_tab1_152 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_152
+DROP VIEW IF EXISTS view_2_tab1_152 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_152
+DROP VIEW IF EXISTS view_3_tab1_152 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36799,13 +36799,13 @@ SELECT pk FROM tab2 WHERE col1 > 343.72
 68 values hashing to 7c7d4bc02f9480775307da2a5d8b3a49
 
 statement ok
-DROP VIEW view_1_tab2_152
+DROP VIEW IF EXISTS view_1_tab2_152 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_152
+DROP VIEW IF EXISTS view_2_tab2_152 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_152
+DROP VIEW IF EXISTS view_3_tab2_152 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36896,13 +36896,13 @@ SELECT pk FROM tab3 WHERE col1 > 343.72
 68 values hashing to 7c7d4bc02f9480775307da2a5d8b3a49
 
 statement ok
-DROP VIEW view_1_tab3_152
+DROP VIEW IF EXISTS view_1_tab3_152 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_152
+DROP VIEW IF EXISTS view_2_tab3_152 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_152
+DROP VIEW IF EXISTS view_3_tab3_152 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -36993,11 +36993,11 @@ SELECT pk FROM tab4 WHERE col1 > 343.72
 68 values hashing to 7c7d4bc02f9480775307da2a5d8b3a49
 
 statement ok
-DROP VIEW view_1_tab4_152
+DROP VIEW IF EXISTS view_1_tab4_152 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_152
+DROP VIEW IF EXISTS view_2_tab4_152 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_152
+DROP VIEW IF EXISTS view_3_tab4_152 CASCADE
 

--- a/test/index/view/100/slt_good_1.test
+++ b/test/index/view/100/slt_good_1.test
@@ -458,13 +458,13 @@ SELECT pk FROM tab0 WHERE col3 >= 543
 44 values hashing to ecb6cd388cbae3cc1bc36453db868c49
 
 statement ok
-DROP VIEW view_1_tab0_226
+DROP VIEW IF EXISTS view_1_tab0_226 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_226
+DROP VIEW IF EXISTS view_2_tab0_226 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_226
+DROP VIEW IF EXISTS view_3_tab0_226 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -555,13 +555,13 @@ SELECT pk FROM tab1 WHERE col3 >= 543
 44 values hashing to ecb6cd388cbae3cc1bc36453db868c49
 
 statement ok
-DROP VIEW view_1_tab1_226
+DROP VIEW IF EXISTS view_1_tab1_226 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_226
+DROP VIEW IF EXISTS view_2_tab1_226 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_226
+DROP VIEW IF EXISTS view_3_tab1_226 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -652,13 +652,13 @@ SELECT pk FROM tab2 WHERE col3 >= 543
 44 values hashing to ecb6cd388cbae3cc1bc36453db868c49
 
 statement ok
-DROP VIEW view_1_tab2_226
+DROP VIEW IF EXISTS view_1_tab2_226 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_226
+DROP VIEW IF EXISTS view_2_tab2_226 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_226
+DROP VIEW IF EXISTS view_3_tab2_226 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -749,13 +749,13 @@ SELECT pk FROM tab3 WHERE col3 >= 543
 44 values hashing to ecb6cd388cbae3cc1bc36453db868c49
 
 statement ok
-DROP VIEW view_1_tab3_226
+DROP VIEW IF EXISTS view_1_tab3_226 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_226
+DROP VIEW IF EXISTS view_2_tab3_226 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_226
+DROP VIEW IF EXISTS view_3_tab3_226 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -846,13 +846,13 @@ SELECT pk FROM tab4 WHERE col3 >= 543
 44 values hashing to ecb6cd388cbae3cc1bc36453db868c49
 
 statement ok
-DROP VIEW view_1_tab4_226
+DROP VIEW IF EXISTS view_1_tab4_226 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_226
+DROP VIEW IF EXISTS view_2_tab4_226 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_226
+DROP VIEW IF EXISTS view_3_tab4_226 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -943,13 +943,13 @@ SELECT pk FROM tab0 WHERE (col0 > 340)
 69 values hashing to af786110acd754dac0ba7c543f7fd08f
 
 statement ok
-DROP VIEW view_1_tab0_227
+DROP VIEW IF EXISTS view_1_tab0_227 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_227
+DROP VIEW IF EXISTS view_2_tab0_227 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_227
+DROP VIEW IF EXISTS view_3_tab0_227 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1040,13 +1040,13 @@ SELECT pk FROM tab1 WHERE (col0 > 340)
 69 values hashing to af786110acd754dac0ba7c543f7fd08f
 
 statement ok
-DROP VIEW view_1_tab1_227
+DROP VIEW IF EXISTS view_1_tab1_227 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_227
+DROP VIEW IF EXISTS view_2_tab1_227 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_227
+DROP VIEW IF EXISTS view_3_tab1_227 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1137,13 +1137,13 @@ SELECT pk FROM tab2 WHERE (col0 > 340)
 69 values hashing to af786110acd754dac0ba7c543f7fd08f
 
 statement ok
-DROP VIEW view_1_tab2_227
+DROP VIEW IF EXISTS view_1_tab2_227 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_227
+DROP VIEW IF EXISTS view_2_tab2_227 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_227
+DROP VIEW IF EXISTS view_3_tab2_227 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1234,13 +1234,13 @@ SELECT pk FROM tab3 WHERE (col0 > 340)
 69 values hashing to af786110acd754dac0ba7c543f7fd08f
 
 statement ok
-DROP VIEW view_1_tab3_227
+DROP VIEW IF EXISTS view_1_tab3_227 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_227
+DROP VIEW IF EXISTS view_2_tab3_227 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_227
+DROP VIEW IF EXISTS view_3_tab3_227 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1331,13 +1331,13 @@ SELECT pk FROM tab4 WHERE (col0 > 340)
 69 values hashing to af786110acd754dac0ba7c543f7fd08f
 
 statement ok
-DROP VIEW view_1_tab4_227
+DROP VIEW IF EXISTS view_1_tab4_227 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_227
+DROP VIEW IF EXISTS view_2_tab4_227 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_227
+DROP VIEW IF EXISTS view_3_tab4_227 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1428,13 +1428,13 @@ SELECT pk FROM tab0 WHERE ((((col4 IN (962.87,413.75,599.80))) AND col0 IN (165,
 29 values hashing to 2dc70d6a908574e3e9c0a53f0b1934b4
 
 statement ok
-DROP VIEW view_1_tab0_228
+DROP VIEW IF EXISTS view_1_tab0_228 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_228
+DROP VIEW IF EXISTS view_2_tab0_228 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_228
+DROP VIEW IF EXISTS view_3_tab0_228 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1525,13 +1525,13 @@ SELECT pk FROM tab1 WHERE ((((col4 IN (962.87,413.75,599.80))) AND col0 IN (165,
 29 values hashing to 2dc70d6a908574e3e9c0a53f0b1934b4
 
 statement ok
-DROP VIEW view_1_tab1_228
+DROP VIEW IF EXISTS view_1_tab1_228 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_228
+DROP VIEW IF EXISTS view_2_tab1_228 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_228
+DROP VIEW IF EXISTS view_3_tab1_228 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1622,13 +1622,13 @@ SELECT pk FROM tab2 WHERE ((((col4 IN (962.87,413.75,599.80))) AND col0 IN (165,
 29 values hashing to 2dc70d6a908574e3e9c0a53f0b1934b4
 
 statement ok
-DROP VIEW view_1_tab2_228
+DROP VIEW IF EXISTS view_1_tab2_228 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_228
+DROP VIEW IF EXISTS view_2_tab2_228 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_228
+DROP VIEW IF EXISTS view_3_tab2_228 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1719,13 +1719,13 @@ SELECT pk FROM tab3 WHERE ((((col4 IN (962.87,413.75,599.80))) AND col0 IN (165,
 29 values hashing to 2dc70d6a908574e3e9c0a53f0b1934b4
 
 statement ok
-DROP VIEW view_1_tab3_228
+DROP VIEW IF EXISTS view_1_tab3_228 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_228
+DROP VIEW IF EXISTS view_2_tab3_228 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_228
+DROP VIEW IF EXISTS view_3_tab3_228 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1816,13 +1816,13 @@ SELECT pk FROM tab4 WHERE ((((col4 IN (962.87,413.75,599.80))) AND col0 IN (165,
 29 values hashing to 2dc70d6a908574e3e9c0a53f0b1934b4
 
 statement ok
-DROP VIEW view_1_tab4_228
+DROP VIEW IF EXISTS view_1_tab4_228 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_228
+DROP VIEW IF EXISTS view_2_tab4_228 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_228
+DROP VIEW IF EXISTS view_3_tab4_228 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1919,13 +1919,13 @@ SELECT pk FROM tab0 WHERE col1 >= 58.87 OR col0 > 203 OR (col3 IS NULL)
 98 values hashing to d89e31820a5a0d4130ee76a78dea1398
 
 statement ok
-DROP VIEW view_1_tab0_229
+DROP VIEW IF EXISTS view_1_tab0_229 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_229
+DROP VIEW IF EXISTS view_2_tab0_229 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_229
+DROP VIEW IF EXISTS view_3_tab0_229 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2022,13 +2022,13 @@ SELECT pk FROM tab1 WHERE col1 >= 58.87 OR col0 > 203 OR (col3 IS NULL)
 98 values hashing to d89e31820a5a0d4130ee76a78dea1398
 
 statement ok
-DROP VIEW view_1_tab1_229
+DROP VIEW IF EXISTS view_1_tab1_229 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_229
+DROP VIEW IF EXISTS view_2_tab1_229 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_229
+DROP VIEW IF EXISTS view_3_tab1_229 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2125,13 +2125,13 @@ SELECT pk FROM tab2 WHERE col1 >= 58.87 OR col0 > 203 OR (col3 IS NULL)
 98 values hashing to d89e31820a5a0d4130ee76a78dea1398
 
 statement ok
-DROP VIEW view_1_tab2_229
+DROP VIEW IF EXISTS view_1_tab2_229 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_229
+DROP VIEW IF EXISTS view_2_tab2_229 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_229
+DROP VIEW IF EXISTS view_3_tab2_229 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2228,13 +2228,13 @@ SELECT pk FROM tab3 WHERE col1 >= 58.87 OR col0 > 203 OR (col3 IS NULL)
 98 values hashing to d89e31820a5a0d4130ee76a78dea1398
 
 statement ok
-DROP VIEW view_1_tab3_229
+DROP VIEW IF EXISTS view_1_tab3_229 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_229
+DROP VIEW IF EXISTS view_2_tab3_229 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_229
+DROP VIEW IF EXISTS view_3_tab3_229 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2331,13 +2331,13 @@ SELECT pk FROM tab4 WHERE col1 >= 58.87 OR col0 > 203 OR (col3 IS NULL)
 98 values hashing to d89e31820a5a0d4130ee76a78dea1398
 
 statement ok
-DROP VIEW view_1_tab4_229
+DROP VIEW IF EXISTS view_1_tab4_229 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_229
+DROP VIEW IF EXISTS view_2_tab4_229 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_229
+DROP VIEW IF EXISTS view_3_tab4_229 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2428,13 +2428,13 @@ SELECT pk FROM tab0 WHERE col1 <= 731.67
 68 values hashing to 70303cedfaac8eb3a35a0988de63236e
 
 statement ok
-DROP VIEW view_1_tab0_230
+DROP VIEW IF EXISTS view_1_tab0_230 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_230
+DROP VIEW IF EXISTS view_2_tab0_230 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_230
+DROP VIEW IF EXISTS view_3_tab0_230 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2525,13 +2525,13 @@ SELECT pk FROM tab1 WHERE col1 <= 731.67
 68 values hashing to 70303cedfaac8eb3a35a0988de63236e
 
 statement ok
-DROP VIEW view_1_tab1_230
+DROP VIEW IF EXISTS view_1_tab1_230 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_230
+DROP VIEW IF EXISTS view_2_tab1_230 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_230
+DROP VIEW IF EXISTS view_3_tab1_230 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2622,13 +2622,13 @@ SELECT pk FROM tab2 WHERE col1 <= 731.67
 68 values hashing to 70303cedfaac8eb3a35a0988de63236e
 
 statement ok
-DROP VIEW view_1_tab2_230
+DROP VIEW IF EXISTS view_1_tab2_230 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_230
+DROP VIEW IF EXISTS view_2_tab2_230 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_230
+DROP VIEW IF EXISTS view_3_tab2_230 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2719,13 +2719,13 @@ SELECT pk FROM tab3 WHERE col1 <= 731.67
 68 values hashing to 70303cedfaac8eb3a35a0988de63236e
 
 statement ok
-DROP VIEW view_1_tab3_230
+DROP VIEW IF EXISTS view_1_tab3_230 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_230
+DROP VIEW IF EXISTS view_2_tab3_230 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_230
+DROP VIEW IF EXISTS view_3_tab3_230 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2816,13 +2816,13 @@ SELECT pk FROM tab4 WHERE col1 <= 731.67
 68 values hashing to 70303cedfaac8eb3a35a0988de63236e
 
 statement ok
-DROP VIEW view_1_tab4_230
+DROP VIEW IF EXISTS view_1_tab4_230 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_230
+DROP VIEW IF EXISTS view_2_tab4_230 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_230
+DROP VIEW IF EXISTS view_3_tab4_230 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2913,13 +2913,13 @@ SELECT pk FROM tab0 WHERE col4 <= 503.11
 44 values hashing to 53aead8468651de48ae7ee99ac9d4914
 
 statement ok
-DROP VIEW view_1_tab0_231
+DROP VIEW IF EXISTS view_1_tab0_231 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_231
+DROP VIEW IF EXISTS view_2_tab0_231 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_231
+DROP VIEW IF EXISTS view_3_tab0_231 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3010,13 +3010,13 @@ SELECT pk FROM tab1 WHERE col4 <= 503.11
 44 values hashing to 53aead8468651de48ae7ee99ac9d4914
 
 statement ok
-DROP VIEW view_1_tab1_231
+DROP VIEW IF EXISTS view_1_tab1_231 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_231
+DROP VIEW IF EXISTS view_2_tab1_231 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_231
+DROP VIEW IF EXISTS view_3_tab1_231 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3107,13 +3107,13 @@ SELECT pk FROM tab2 WHERE col4 <= 503.11
 44 values hashing to 53aead8468651de48ae7ee99ac9d4914
 
 statement ok
-DROP VIEW view_1_tab2_231
+DROP VIEW IF EXISTS view_1_tab2_231 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_231
+DROP VIEW IF EXISTS view_2_tab2_231 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_231
+DROP VIEW IF EXISTS view_3_tab2_231 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3204,13 +3204,13 @@ SELECT pk FROM tab3 WHERE col4 <= 503.11
 44 values hashing to 53aead8468651de48ae7ee99ac9d4914
 
 statement ok
-DROP VIEW view_1_tab3_231
+DROP VIEW IF EXISTS view_1_tab3_231 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_231
+DROP VIEW IF EXISTS view_2_tab3_231 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_231
+DROP VIEW IF EXISTS view_3_tab3_231 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3301,13 +3301,13 @@ SELECT pk FROM tab4 WHERE col4 <= 503.11
 44 values hashing to 53aead8468651de48ae7ee99ac9d4914
 
 statement ok
-DROP VIEW view_1_tab4_231
+DROP VIEW IF EXISTS view_1_tab4_231 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_231
+DROP VIEW IF EXISTS view_2_tab4_231 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_231
+DROP VIEW IF EXISTS view_3_tab4_231 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3414,13 +3414,13 @@ SELECT pk FROM tab0 WHERE (((col1 <= 384.28))) AND (col3 >= 446 AND (((col0 = 75
 83
 
 statement ok
-DROP VIEW view_1_tab0_232
+DROP VIEW IF EXISTS view_1_tab0_232 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_232
+DROP VIEW IF EXISTS view_2_tab0_232 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_232
+DROP VIEW IF EXISTS view_3_tab0_232 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3527,13 +3527,13 @@ SELECT pk FROM tab1 WHERE (((col1 <= 384.28))) AND (col3 >= 446 AND (((col0 = 75
 83
 
 statement ok
-DROP VIEW view_1_tab1_232
+DROP VIEW IF EXISTS view_1_tab1_232 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_232
+DROP VIEW IF EXISTS view_2_tab1_232 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_232
+DROP VIEW IF EXISTS view_3_tab1_232 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3640,13 +3640,13 @@ SELECT pk FROM tab2 WHERE (((col1 <= 384.28))) AND (col3 >= 446 AND (((col0 = 75
 83
 
 statement ok
-DROP VIEW view_1_tab2_232
+DROP VIEW IF EXISTS view_1_tab2_232 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_232
+DROP VIEW IF EXISTS view_2_tab2_232 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_232
+DROP VIEW IF EXISTS view_3_tab2_232 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3753,13 +3753,13 @@ SELECT pk FROM tab3 WHERE (((col1 <= 384.28))) AND (col3 >= 446 AND (((col0 = 75
 83
 
 statement ok
-DROP VIEW view_1_tab3_232
+DROP VIEW IF EXISTS view_1_tab3_232 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_232
+DROP VIEW IF EXISTS view_2_tab3_232 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_232
+DROP VIEW IF EXISTS view_3_tab3_232 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3866,13 +3866,13 @@ SELECT pk FROM tab4 WHERE (((col1 <= 384.28))) AND (col3 >= 446 AND (((col0 = 75
 83
 
 statement ok
-DROP VIEW view_1_tab4_232
+DROP VIEW IF EXISTS view_1_tab4_232 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_232
+DROP VIEW IF EXISTS view_2_tab4_232 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_232
+DROP VIEW IF EXISTS view_3_tab4_232 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3963,13 +3963,13 @@ SELECT pk FROM tab0 WHERE ((col3 = 751) AND ((((col3 > 506)))) AND ((((((col3 < 
 80 values hashing to 3e885bf601ff8cc09542b40f9aaea973
 
 statement ok
-DROP VIEW view_1_tab0_233
+DROP VIEW IF EXISTS view_1_tab0_233 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_233
+DROP VIEW IF EXISTS view_2_tab0_233 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_233
+DROP VIEW IF EXISTS view_3_tab0_233 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4060,13 +4060,13 @@ SELECT pk FROM tab1 WHERE ((col3 = 751) AND ((((col3 > 506)))) AND ((((((col3 < 
 80 values hashing to 3e885bf601ff8cc09542b40f9aaea973
 
 statement ok
-DROP VIEW view_1_tab1_233
+DROP VIEW IF EXISTS view_1_tab1_233 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_233
+DROP VIEW IF EXISTS view_2_tab1_233 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_233
+DROP VIEW IF EXISTS view_3_tab1_233 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4157,13 +4157,13 @@ SELECT pk FROM tab2 WHERE ((col3 = 751) AND ((((col3 > 506)))) AND ((((((col3 < 
 80 values hashing to 3e885bf601ff8cc09542b40f9aaea973
 
 statement ok
-DROP VIEW view_1_tab2_233
+DROP VIEW IF EXISTS view_1_tab2_233 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_233
+DROP VIEW IF EXISTS view_2_tab2_233 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_233
+DROP VIEW IF EXISTS view_3_tab2_233 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4254,13 +4254,13 @@ SELECT pk FROM tab3 WHERE ((col3 = 751) AND ((((col3 > 506)))) AND ((((((col3 < 
 80 values hashing to 3e885bf601ff8cc09542b40f9aaea973
 
 statement ok
-DROP VIEW view_1_tab3_233
+DROP VIEW IF EXISTS view_1_tab3_233 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_233
+DROP VIEW IF EXISTS view_2_tab3_233 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_233
+DROP VIEW IF EXISTS view_3_tab3_233 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4351,13 +4351,13 @@ SELECT pk FROM tab4 WHERE ((col3 = 751) AND ((((col3 > 506)))) AND ((((((col3 < 
 80 values hashing to 3e885bf601ff8cc09542b40f9aaea973
 
 statement ok
-DROP VIEW view_1_tab4_233
+DROP VIEW IF EXISTS view_1_tab4_233 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_233
+DROP VIEW IF EXISTS view_2_tab4_233 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_233
+DROP VIEW IF EXISTS view_3_tab4_233 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4448,13 +4448,13 @@ SELECT pk FROM tab0 WHERE ((((((col0 <= 79 OR col1 < 413.47 AND col4 < 748.94)))
 39 values hashing to db04c80b635ebb1b693eedee48ff7b39
 
 statement ok
-DROP VIEW view_1_tab0_234
+DROP VIEW IF EXISTS view_1_tab0_234 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_234
+DROP VIEW IF EXISTS view_2_tab0_234 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_234
+DROP VIEW IF EXISTS view_3_tab0_234 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4545,13 +4545,13 @@ SELECT pk FROM tab1 WHERE ((((((col0 <= 79 OR col1 < 413.47 AND col4 < 748.94)))
 39 values hashing to db04c80b635ebb1b693eedee48ff7b39
 
 statement ok
-DROP VIEW view_1_tab1_234
+DROP VIEW IF EXISTS view_1_tab1_234 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_234
+DROP VIEW IF EXISTS view_2_tab1_234 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_234
+DROP VIEW IF EXISTS view_3_tab1_234 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4642,13 +4642,13 @@ SELECT pk FROM tab2 WHERE ((((((col0 <= 79 OR col1 < 413.47 AND col4 < 748.94)))
 39 values hashing to db04c80b635ebb1b693eedee48ff7b39
 
 statement ok
-DROP VIEW view_1_tab2_234
+DROP VIEW IF EXISTS view_1_tab2_234 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_234
+DROP VIEW IF EXISTS view_2_tab2_234 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_234
+DROP VIEW IF EXISTS view_3_tab2_234 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4739,13 +4739,13 @@ SELECT pk FROM tab3 WHERE ((((((col0 <= 79 OR col1 < 413.47 AND col4 < 748.94)))
 39 values hashing to db04c80b635ebb1b693eedee48ff7b39
 
 statement ok
-DROP VIEW view_1_tab3_234
+DROP VIEW IF EXISTS view_1_tab3_234 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_234
+DROP VIEW IF EXISTS view_2_tab3_234 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_234
+DROP VIEW IF EXISTS view_3_tab3_234 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4836,13 +4836,13 @@ SELECT pk FROM tab4 WHERE ((((((col0 <= 79 OR col1 < 413.47 AND col4 < 748.94)))
 39 values hashing to db04c80b635ebb1b693eedee48ff7b39
 
 statement ok
-DROP VIEW view_1_tab4_234
+DROP VIEW IF EXISTS view_1_tab4_234 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_234
+DROP VIEW IF EXISTS view_2_tab4_234 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_234
+DROP VIEW IF EXISTS view_3_tab4_234 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4933,13 +4933,13 @@ SELECT pk FROM tab0 WHERE col1 < 454.34
 46 values hashing to 6697fc4feac35532a5948307e7ca3e80
 
 statement ok
-DROP VIEW view_1_tab0_235
+DROP VIEW IF EXISTS view_1_tab0_235 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_235
+DROP VIEW IF EXISTS view_2_tab0_235 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_235
+DROP VIEW IF EXISTS view_3_tab0_235 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5030,13 +5030,13 @@ SELECT pk FROM tab1 WHERE col1 < 454.34
 46 values hashing to 6697fc4feac35532a5948307e7ca3e80
 
 statement ok
-DROP VIEW view_1_tab1_235
+DROP VIEW IF EXISTS view_1_tab1_235 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_235
+DROP VIEW IF EXISTS view_2_tab1_235 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_235
+DROP VIEW IF EXISTS view_3_tab1_235 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5127,13 +5127,13 @@ SELECT pk FROM tab2 WHERE col1 < 454.34
 46 values hashing to 6697fc4feac35532a5948307e7ca3e80
 
 statement ok
-DROP VIEW view_1_tab2_235
+DROP VIEW IF EXISTS view_1_tab2_235 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_235
+DROP VIEW IF EXISTS view_2_tab2_235 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_235
+DROP VIEW IF EXISTS view_3_tab2_235 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5224,13 +5224,13 @@ SELECT pk FROM tab3 WHERE col1 < 454.34
 46 values hashing to 6697fc4feac35532a5948307e7ca3e80
 
 statement ok
-DROP VIEW view_1_tab3_235
+DROP VIEW IF EXISTS view_1_tab3_235 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_235
+DROP VIEW IF EXISTS view_2_tab3_235 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_235
+DROP VIEW IF EXISTS view_3_tab3_235 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5321,13 +5321,13 @@ SELECT pk FROM tab4 WHERE col1 < 454.34
 46 values hashing to 6697fc4feac35532a5948307e7ca3e80
 
 statement ok
-DROP VIEW view_1_tab4_235
+DROP VIEW IF EXISTS view_1_tab4_235 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_235
+DROP VIEW IF EXISTS view_2_tab4_235 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_235
+DROP VIEW IF EXISTS view_3_tab4_235 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5418,13 +5418,13 @@ SELECT pk FROM tab0 WHERE col3 IS NULL OR col3 > 246
 74 values hashing to 5ad20fe152e830337d40d9d608a17eee
 
 statement ok
-DROP VIEW view_1_tab0_236
+DROP VIEW IF EXISTS view_1_tab0_236 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_236
+DROP VIEW IF EXISTS view_2_tab0_236 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_236
+DROP VIEW IF EXISTS view_3_tab0_236 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5515,13 +5515,13 @@ SELECT pk FROM tab1 WHERE col3 IS NULL OR col3 > 246
 74 values hashing to 5ad20fe152e830337d40d9d608a17eee
 
 statement ok
-DROP VIEW view_1_tab1_236
+DROP VIEW IF EXISTS view_1_tab1_236 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_236
+DROP VIEW IF EXISTS view_2_tab1_236 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_236
+DROP VIEW IF EXISTS view_3_tab1_236 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5612,13 +5612,13 @@ SELECT pk FROM tab2 WHERE col3 IS NULL OR col3 > 246
 74 values hashing to 5ad20fe152e830337d40d9d608a17eee
 
 statement ok
-DROP VIEW view_1_tab2_236
+DROP VIEW IF EXISTS view_1_tab2_236 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_236
+DROP VIEW IF EXISTS view_2_tab2_236 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_236
+DROP VIEW IF EXISTS view_3_tab2_236 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5709,13 +5709,13 @@ SELECT pk FROM tab3 WHERE col3 IS NULL OR col3 > 246
 74 values hashing to 5ad20fe152e830337d40d9d608a17eee
 
 statement ok
-DROP VIEW view_1_tab3_236
+DROP VIEW IF EXISTS view_1_tab3_236 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_236
+DROP VIEW IF EXISTS view_2_tab3_236 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_236
+DROP VIEW IF EXISTS view_3_tab3_236 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5806,13 +5806,13 @@ SELECT pk FROM tab4 WHERE col3 IS NULL OR col3 > 246
 74 values hashing to 5ad20fe152e830337d40d9d608a17eee
 
 statement ok
-DROP VIEW view_1_tab4_236
+DROP VIEW IF EXISTS view_1_tab4_236 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_236
+DROP VIEW IF EXISTS view_2_tab4_236 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_236
+DROP VIEW IF EXISTS view_3_tab4_236 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5903,13 +5903,13 @@ SELECT pk FROM tab0 WHERE col4 < 750.37 OR ((col0 > 876 AND col0 > 638 AND (col0
 82 values hashing to cb20d7602297ed852bf66f6d469216b2
 
 statement ok
-DROP VIEW view_1_tab0_237
+DROP VIEW IF EXISTS view_1_tab0_237 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_237
+DROP VIEW IF EXISTS view_2_tab0_237 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_237
+DROP VIEW IF EXISTS view_3_tab0_237 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6000,13 +6000,13 @@ SELECT pk FROM tab1 WHERE col4 < 750.37 OR ((col0 > 876 AND col0 > 638 AND (col0
 82 values hashing to cb20d7602297ed852bf66f6d469216b2
 
 statement ok
-DROP VIEW view_1_tab1_237
+DROP VIEW IF EXISTS view_1_tab1_237 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_237
+DROP VIEW IF EXISTS view_2_tab1_237 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_237
+DROP VIEW IF EXISTS view_3_tab1_237 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6097,13 +6097,13 @@ SELECT pk FROM tab2 WHERE col4 < 750.37 OR ((col0 > 876 AND col0 > 638 AND (col0
 82 values hashing to cb20d7602297ed852bf66f6d469216b2
 
 statement ok
-DROP VIEW view_1_tab2_237
+DROP VIEW IF EXISTS view_1_tab2_237 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_237
+DROP VIEW IF EXISTS view_2_tab2_237 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_237
+DROP VIEW IF EXISTS view_3_tab2_237 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6194,13 +6194,13 @@ SELECT pk FROM tab3 WHERE col4 < 750.37 OR ((col0 > 876 AND col0 > 638 AND (col0
 82 values hashing to cb20d7602297ed852bf66f6d469216b2
 
 statement ok
-DROP VIEW view_1_tab3_237
+DROP VIEW IF EXISTS view_1_tab3_237 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_237
+DROP VIEW IF EXISTS view_2_tab3_237 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_237
+DROP VIEW IF EXISTS view_3_tab3_237 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6291,13 +6291,13 @@ SELECT pk FROM tab4 WHERE col4 < 750.37 OR ((col0 > 876 AND col0 > 638 AND (col0
 82 values hashing to cb20d7602297ed852bf66f6d469216b2
 
 statement ok
-DROP VIEW view_1_tab4_237
+DROP VIEW IF EXISTS view_1_tab4_237 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_237
+DROP VIEW IF EXISTS view_2_tab4_237 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_237
+DROP VIEW IF EXISTS view_3_tab4_237 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6388,13 +6388,13 @@ SELECT pk FROM tab0 WHERE (col0 >= 659 OR col1 < 607.82 OR col3 > 93 AND (col0 >
 90 values hashing to f0d01d2a464f68494498153035674949
 
 statement ok
-DROP VIEW view_1_tab0_239
+DROP VIEW IF EXISTS view_1_tab0_239 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_239
+DROP VIEW IF EXISTS view_2_tab0_239 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_239
+DROP VIEW IF EXISTS view_3_tab0_239 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6485,13 +6485,13 @@ SELECT pk FROM tab1 WHERE (col0 >= 659 OR col1 < 607.82 OR col3 > 93 AND (col0 >
 90 values hashing to f0d01d2a464f68494498153035674949
 
 statement ok
-DROP VIEW view_1_tab1_239
+DROP VIEW IF EXISTS view_1_tab1_239 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_239
+DROP VIEW IF EXISTS view_2_tab1_239 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_239
+DROP VIEW IF EXISTS view_3_tab1_239 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6582,13 +6582,13 @@ SELECT pk FROM tab2 WHERE (col0 >= 659 OR col1 < 607.82 OR col3 > 93 AND (col0 >
 90 values hashing to f0d01d2a464f68494498153035674949
 
 statement ok
-DROP VIEW view_1_tab2_239
+DROP VIEW IF EXISTS view_1_tab2_239 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_239
+DROP VIEW IF EXISTS view_2_tab2_239 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_239
+DROP VIEW IF EXISTS view_3_tab2_239 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6679,13 +6679,13 @@ SELECT pk FROM tab3 WHERE (col0 >= 659 OR col1 < 607.82 OR col3 > 93 AND (col0 >
 90 values hashing to f0d01d2a464f68494498153035674949
 
 statement ok
-DROP VIEW view_1_tab3_239
+DROP VIEW IF EXISTS view_1_tab3_239 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_239
+DROP VIEW IF EXISTS view_2_tab3_239 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_239
+DROP VIEW IF EXISTS view_3_tab3_239 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6776,13 +6776,13 @@ SELECT pk FROM tab4 WHERE (col0 >= 659 OR col1 < 607.82 OR col3 > 93 AND (col0 >
 90 values hashing to f0d01d2a464f68494498153035674949
 
 statement ok
-DROP VIEW view_1_tab4_239
+DROP VIEW IF EXISTS view_1_tab4_239 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_239
+DROP VIEW IF EXISTS view_2_tab4_239 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_239
+DROP VIEW IF EXISTS view_3_tab4_239 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6868,13 +6868,13 @@ SELECT pk FROM tab0 WHERE col0 <= 191 AND ((col4 IS NULL)) AND col4 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab0_240
+DROP VIEW IF EXISTS view_1_tab0_240 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_240
+DROP VIEW IF EXISTS view_2_tab0_240 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_240
+DROP VIEW IF EXISTS view_3_tab0_240 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6960,13 +6960,13 @@ SELECT pk FROM tab1 WHERE col0 <= 191 AND ((col4 IS NULL)) AND col4 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab1_240
+DROP VIEW IF EXISTS view_1_tab1_240 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_240
+DROP VIEW IF EXISTS view_2_tab1_240 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_240
+DROP VIEW IF EXISTS view_3_tab1_240 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7052,13 +7052,13 @@ SELECT pk FROM tab2 WHERE col0 <= 191 AND ((col4 IS NULL)) AND col4 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab2_240
+DROP VIEW IF EXISTS view_1_tab2_240 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_240
+DROP VIEW IF EXISTS view_2_tab2_240 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_240
+DROP VIEW IF EXISTS view_3_tab2_240 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7144,13 +7144,13 @@ SELECT pk FROM tab3 WHERE col0 <= 191 AND ((col4 IS NULL)) AND col4 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab3_240
+DROP VIEW IF EXISTS view_1_tab3_240 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_240
+DROP VIEW IF EXISTS view_2_tab3_240 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_240
+DROP VIEW IF EXISTS view_3_tab3_240 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7236,13 +7236,13 @@ SELECT pk FROM tab4 WHERE col0 <= 191 AND ((col4 IS NULL)) AND col4 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab4_240
+DROP VIEW IF EXISTS view_1_tab4_240 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_240
+DROP VIEW IF EXISTS view_2_tab4_240 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_240
+DROP VIEW IF EXISTS view_3_tab4_240 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7333,13 +7333,13 @@ SELECT pk FROM tab0 WHERE (col3 < 776)
 81 values hashing to 82afb06f03aa8d5e3e20ceae31803911
 
 statement ok
-DROP VIEW view_1_tab0_242
+DROP VIEW IF EXISTS view_1_tab0_242 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_242
+DROP VIEW IF EXISTS view_2_tab0_242 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_242
+DROP VIEW IF EXISTS view_3_tab0_242 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7430,13 +7430,13 @@ SELECT pk FROM tab1 WHERE (col3 < 776)
 81 values hashing to 82afb06f03aa8d5e3e20ceae31803911
 
 statement ok
-DROP VIEW view_1_tab1_242
+DROP VIEW IF EXISTS view_1_tab1_242 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_242
+DROP VIEW IF EXISTS view_2_tab1_242 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_242
+DROP VIEW IF EXISTS view_3_tab1_242 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7527,13 +7527,13 @@ SELECT pk FROM tab2 WHERE (col3 < 776)
 81 values hashing to 82afb06f03aa8d5e3e20ceae31803911
 
 statement ok
-DROP VIEW view_1_tab2_242
+DROP VIEW IF EXISTS view_1_tab2_242 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_242
+DROP VIEW IF EXISTS view_2_tab2_242 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_242
+DROP VIEW IF EXISTS view_3_tab2_242 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7624,13 +7624,13 @@ SELECT pk FROM tab3 WHERE (col3 < 776)
 81 values hashing to 82afb06f03aa8d5e3e20ceae31803911
 
 statement ok
-DROP VIEW view_1_tab3_242
+DROP VIEW IF EXISTS view_1_tab3_242 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_242
+DROP VIEW IF EXISTS view_2_tab3_242 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_242
+DROP VIEW IF EXISTS view_3_tab3_242 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7721,13 +7721,13 @@ SELECT pk FROM tab4 WHERE (col3 < 776)
 81 values hashing to 82afb06f03aa8d5e3e20ceae31803911
 
 statement ok
-DROP VIEW view_1_tab4_242
+DROP VIEW IF EXISTS view_1_tab4_242 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_242
+DROP VIEW IF EXISTS view_2_tab4_242 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_242
+DROP VIEW IF EXISTS view_3_tab4_242 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7818,13 +7818,13 @@ SELECT pk FROM tab0 WHERE col0 > 416 AND col0 >= 916
 10 values hashing to eb5a73b6cf4e036f1c61966a84dd2671
 
 statement ok
-DROP VIEW view_1_tab0_243
+DROP VIEW IF EXISTS view_1_tab0_243 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_243
+DROP VIEW IF EXISTS view_2_tab0_243 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_243
+DROP VIEW IF EXISTS view_3_tab0_243 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7915,13 +7915,13 @@ SELECT pk FROM tab1 WHERE col0 > 416 AND col0 >= 916
 10 values hashing to eb5a73b6cf4e036f1c61966a84dd2671
 
 statement ok
-DROP VIEW view_1_tab1_243
+DROP VIEW IF EXISTS view_1_tab1_243 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_243
+DROP VIEW IF EXISTS view_2_tab1_243 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_243
+DROP VIEW IF EXISTS view_3_tab1_243 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8012,13 +8012,13 @@ SELECT pk FROM tab2 WHERE col0 > 416 AND col0 >= 916
 10 values hashing to eb5a73b6cf4e036f1c61966a84dd2671
 
 statement ok
-DROP VIEW view_1_tab2_243
+DROP VIEW IF EXISTS view_1_tab2_243 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_243
+DROP VIEW IF EXISTS view_2_tab2_243 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_243
+DROP VIEW IF EXISTS view_3_tab2_243 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8109,13 +8109,13 @@ SELECT pk FROM tab3 WHERE col0 > 416 AND col0 >= 916
 10 values hashing to eb5a73b6cf4e036f1c61966a84dd2671
 
 statement ok
-DROP VIEW view_1_tab3_243
+DROP VIEW IF EXISTS view_1_tab3_243 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_243
+DROP VIEW IF EXISTS view_2_tab3_243 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_243
+DROP VIEW IF EXISTS view_3_tab3_243 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8206,13 +8206,13 @@ SELECT pk FROM tab4 WHERE col0 > 416 AND col0 >= 916
 10 values hashing to eb5a73b6cf4e036f1c61966a84dd2671
 
 statement ok
-DROP VIEW view_1_tab4_243
+DROP VIEW IF EXISTS view_1_tab4_243 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_243
+DROP VIEW IF EXISTS view_2_tab4_243 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_243
+DROP VIEW IF EXISTS view_3_tab4_243 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8303,13 +8303,13 @@ SELECT pk FROM tab0 WHERE col3 < 371 OR col1 >= 956.47 OR ((col0 <= 276 OR ((col
 74 values hashing to 79b9791cfa6373f244e7e0d9f81f300d
 
 statement ok
-DROP VIEW view_1_tab0_245
+DROP VIEW IF EXISTS view_1_tab0_245 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_245
+DROP VIEW IF EXISTS view_2_tab0_245 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_245
+DROP VIEW IF EXISTS view_3_tab0_245 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8400,13 +8400,13 @@ SELECT pk FROM tab1 WHERE col3 < 371 OR col1 >= 956.47 OR ((col0 <= 276 OR ((col
 74 values hashing to 79b9791cfa6373f244e7e0d9f81f300d
 
 statement ok
-DROP VIEW view_1_tab1_245
+DROP VIEW IF EXISTS view_1_tab1_245 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_245
+DROP VIEW IF EXISTS view_2_tab1_245 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_245
+DROP VIEW IF EXISTS view_3_tab1_245 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8497,13 +8497,13 @@ SELECT pk FROM tab2 WHERE col3 < 371 OR col1 >= 956.47 OR ((col0 <= 276 OR ((col
 74 values hashing to 79b9791cfa6373f244e7e0d9f81f300d
 
 statement ok
-DROP VIEW view_1_tab2_245
+DROP VIEW IF EXISTS view_1_tab2_245 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_245
+DROP VIEW IF EXISTS view_2_tab2_245 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_245
+DROP VIEW IF EXISTS view_3_tab2_245 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8594,13 +8594,13 @@ SELECT pk FROM tab3 WHERE col3 < 371 OR col1 >= 956.47 OR ((col0 <= 276 OR ((col
 74 values hashing to 79b9791cfa6373f244e7e0d9f81f300d
 
 statement ok
-DROP VIEW view_1_tab3_245
+DROP VIEW IF EXISTS view_1_tab3_245 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_245
+DROP VIEW IF EXISTS view_2_tab3_245 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_245
+DROP VIEW IF EXISTS view_3_tab3_245 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8691,13 +8691,13 @@ SELECT pk FROM tab4 WHERE col3 < 371 OR col1 >= 956.47 OR ((col0 <= 276 OR ((col
 74 values hashing to 79b9791cfa6373f244e7e0d9f81f300d
 
 statement ok
-DROP VIEW view_1_tab4_245
+DROP VIEW IF EXISTS view_1_tab4_245 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_245
+DROP VIEW IF EXISTS view_2_tab4_245 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_245
+DROP VIEW IF EXISTS view_3_tab4_245 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8783,13 +8783,13 @@ SELECT pk FROM tab0 WHERE (col4 = 413.88)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_246
+DROP VIEW IF EXISTS view_1_tab0_246 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_246
+DROP VIEW IF EXISTS view_2_tab0_246 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_246
+DROP VIEW IF EXISTS view_3_tab0_246 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8875,13 +8875,13 @@ SELECT pk FROM tab1 WHERE (col4 = 413.88)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_246
+DROP VIEW IF EXISTS view_1_tab1_246 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_246
+DROP VIEW IF EXISTS view_2_tab1_246 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_246
+DROP VIEW IF EXISTS view_3_tab1_246 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8967,13 +8967,13 @@ SELECT pk FROM tab2 WHERE (col4 = 413.88)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_246
+DROP VIEW IF EXISTS view_1_tab2_246 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_246
+DROP VIEW IF EXISTS view_2_tab2_246 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_246
+DROP VIEW IF EXISTS view_3_tab2_246 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9059,13 +9059,13 @@ SELECT pk FROM tab3 WHERE (col4 = 413.88)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_246
+DROP VIEW IF EXISTS view_1_tab3_246 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_246
+DROP VIEW IF EXISTS view_2_tab3_246 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_246
+DROP VIEW IF EXISTS view_3_tab3_246 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9151,13 +9151,13 @@ SELECT pk FROM tab4 WHERE (col4 = 413.88)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_246
+DROP VIEW IF EXISTS view_1_tab4_246 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_246
+DROP VIEW IF EXISTS view_2_tab4_246 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_246
+DROP VIEW IF EXISTS view_3_tab4_246 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9248,13 +9248,13 @@ SELECT pk FROM tab0 WHERE col0 <= 422
 37 values hashing to de1fb9ce3bb7fc1f06e044b5713c5cdd
 
 statement ok
-DROP VIEW view_1_tab0_247
+DROP VIEW IF EXISTS view_1_tab0_247 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_247
+DROP VIEW IF EXISTS view_2_tab0_247 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_247
+DROP VIEW IF EXISTS view_3_tab0_247 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9345,13 +9345,13 @@ SELECT pk FROM tab1 WHERE col0 <= 422
 37 values hashing to de1fb9ce3bb7fc1f06e044b5713c5cdd
 
 statement ok
-DROP VIEW view_1_tab1_247
+DROP VIEW IF EXISTS view_1_tab1_247 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_247
+DROP VIEW IF EXISTS view_2_tab1_247 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_247
+DROP VIEW IF EXISTS view_3_tab1_247 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9442,13 +9442,13 @@ SELECT pk FROM tab2 WHERE col0 <= 422
 37 values hashing to de1fb9ce3bb7fc1f06e044b5713c5cdd
 
 statement ok
-DROP VIEW view_1_tab2_247
+DROP VIEW IF EXISTS view_1_tab2_247 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_247
+DROP VIEW IF EXISTS view_2_tab2_247 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_247
+DROP VIEW IF EXISTS view_3_tab2_247 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9539,13 +9539,13 @@ SELECT pk FROM tab3 WHERE col0 <= 422
 37 values hashing to de1fb9ce3bb7fc1f06e044b5713c5cdd
 
 statement ok
-DROP VIEW view_1_tab3_247
+DROP VIEW IF EXISTS view_1_tab3_247 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_247
+DROP VIEW IF EXISTS view_2_tab3_247 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_247
+DROP VIEW IF EXISTS view_3_tab3_247 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9636,13 +9636,13 @@ SELECT pk FROM tab4 WHERE col0 <= 422
 37 values hashing to de1fb9ce3bb7fc1f06e044b5713c5cdd
 
 statement ok
-DROP VIEW view_1_tab4_247
+DROP VIEW IF EXISTS view_1_tab4_247 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_247
+DROP VIEW IF EXISTS view_2_tab4_247 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_247
+DROP VIEW IF EXISTS view_3_tab4_247 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9733,13 +9733,13 @@ SELECT pk FROM tab0 WHERE (col1 >= 41.89)
 94 values hashing to 3f929a361abed420accfd7121b4f0f76
 
 statement ok
-DROP VIEW view_1_tab0_248
+DROP VIEW IF EXISTS view_1_tab0_248 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_248
+DROP VIEW IF EXISTS view_2_tab0_248 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_248
+DROP VIEW IF EXISTS view_3_tab0_248 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9830,13 +9830,13 @@ SELECT pk FROM tab1 WHERE (col1 >= 41.89)
 94 values hashing to 3f929a361abed420accfd7121b4f0f76
 
 statement ok
-DROP VIEW view_1_tab1_248
+DROP VIEW IF EXISTS view_1_tab1_248 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_248
+DROP VIEW IF EXISTS view_2_tab1_248 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_248
+DROP VIEW IF EXISTS view_3_tab1_248 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9927,13 +9927,13 @@ SELECT pk FROM tab2 WHERE (col1 >= 41.89)
 94 values hashing to 3f929a361abed420accfd7121b4f0f76
 
 statement ok
-DROP VIEW view_1_tab2_248
+DROP VIEW IF EXISTS view_1_tab2_248 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_248
+DROP VIEW IF EXISTS view_2_tab2_248 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_248
+DROP VIEW IF EXISTS view_3_tab2_248 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10024,13 +10024,13 @@ SELECT pk FROM tab3 WHERE (col1 >= 41.89)
 94 values hashing to 3f929a361abed420accfd7121b4f0f76
 
 statement ok
-DROP VIEW view_1_tab3_248
+DROP VIEW IF EXISTS view_1_tab3_248 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_248
+DROP VIEW IF EXISTS view_2_tab3_248 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_248
+DROP VIEW IF EXISTS view_3_tab3_248 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10121,13 +10121,13 @@ SELECT pk FROM tab4 WHERE (col1 >= 41.89)
 94 values hashing to 3f929a361abed420accfd7121b4f0f76
 
 statement ok
-DROP VIEW view_1_tab4_248
+DROP VIEW IF EXISTS view_1_tab4_248 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_248
+DROP VIEW IF EXISTS view_2_tab4_248 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_248
+DROP VIEW IF EXISTS view_3_tab4_248 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10218,13 +10218,13 @@ SELECT pk FROM tab0 WHERE col3 >= 272
 71 values hashing to 4c8e878831bdd848c2a9c02ba0a4c9fe
 
 statement ok
-DROP VIEW view_1_tab0_249
+DROP VIEW IF EXISTS view_1_tab0_249 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_249
+DROP VIEW IF EXISTS view_2_tab0_249 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_249
+DROP VIEW IF EXISTS view_3_tab0_249 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10315,13 +10315,13 @@ SELECT pk FROM tab1 WHERE col3 >= 272
 71 values hashing to 4c8e878831bdd848c2a9c02ba0a4c9fe
 
 statement ok
-DROP VIEW view_1_tab1_249
+DROP VIEW IF EXISTS view_1_tab1_249 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_249
+DROP VIEW IF EXISTS view_2_tab1_249 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_249
+DROP VIEW IF EXISTS view_3_tab1_249 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10412,13 +10412,13 @@ SELECT pk FROM tab2 WHERE col3 >= 272
 71 values hashing to 4c8e878831bdd848c2a9c02ba0a4c9fe
 
 statement ok
-DROP VIEW view_1_tab2_249
+DROP VIEW IF EXISTS view_1_tab2_249 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_249
+DROP VIEW IF EXISTS view_2_tab2_249 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_249
+DROP VIEW IF EXISTS view_3_tab2_249 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10509,13 +10509,13 @@ SELECT pk FROM tab3 WHERE col3 >= 272
 71 values hashing to 4c8e878831bdd848c2a9c02ba0a4c9fe
 
 statement ok
-DROP VIEW view_1_tab3_249
+DROP VIEW IF EXISTS view_1_tab3_249 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_249
+DROP VIEW IF EXISTS view_2_tab3_249 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_249
+DROP VIEW IF EXISTS view_3_tab3_249 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10606,13 +10606,13 @@ SELECT pk FROM tab4 WHERE col3 >= 272
 71 values hashing to 4c8e878831bdd848c2a9c02ba0a4c9fe
 
 statement ok
-DROP VIEW view_1_tab4_249
+DROP VIEW IF EXISTS view_1_tab4_249 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_249
+DROP VIEW IF EXISTS view_2_tab4_249 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_249
+DROP VIEW IF EXISTS view_3_tab4_249 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10712,13 +10712,13 @@ SELECT pk FROM tab0 WHERE col4 < 83.51
 24
 
 statement ok
-DROP VIEW view_1_tab0_250
+DROP VIEW IF EXISTS view_1_tab0_250 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_250
+DROP VIEW IF EXISTS view_2_tab0_250 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_250
+DROP VIEW IF EXISTS view_3_tab0_250 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10818,13 +10818,13 @@ SELECT pk FROM tab1 WHERE col4 < 83.51
 24
 
 statement ok
-DROP VIEW view_1_tab1_250
+DROP VIEW IF EXISTS view_1_tab1_250 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_250
+DROP VIEW IF EXISTS view_2_tab1_250 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_250
+DROP VIEW IF EXISTS view_3_tab1_250 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10924,13 +10924,13 @@ SELECT pk FROM tab2 WHERE col4 < 83.51
 24
 
 statement ok
-DROP VIEW view_1_tab2_250
+DROP VIEW IF EXISTS view_1_tab2_250 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_250
+DROP VIEW IF EXISTS view_2_tab2_250 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_250
+DROP VIEW IF EXISTS view_3_tab2_250 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11030,13 +11030,13 @@ SELECT pk FROM tab3 WHERE col4 < 83.51
 24
 
 statement ok
-DROP VIEW view_1_tab3_250
+DROP VIEW IF EXISTS view_1_tab3_250 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_250
+DROP VIEW IF EXISTS view_2_tab3_250 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_250
+DROP VIEW IF EXISTS view_3_tab3_250 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11136,13 +11136,13 @@ SELECT pk FROM tab4 WHERE col4 < 83.51
 24
 
 statement ok
-DROP VIEW view_1_tab4_250
+DROP VIEW IF EXISTS view_1_tab4_250 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_250
+DROP VIEW IF EXISTS view_2_tab4_250 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_250
+DROP VIEW IF EXISTS view_3_tab4_250 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11228,13 +11228,13 @@ SELECT pk FROM tab0 WHERE col3 IN (199)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_251
+DROP VIEW IF EXISTS view_1_tab0_251 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_251
+DROP VIEW IF EXISTS view_2_tab0_251 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_251
+DROP VIEW IF EXISTS view_3_tab0_251 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11320,13 +11320,13 @@ SELECT pk FROM tab1 WHERE col3 IN (199)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_251
+DROP VIEW IF EXISTS view_1_tab1_251 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_251
+DROP VIEW IF EXISTS view_2_tab1_251 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_251
+DROP VIEW IF EXISTS view_3_tab1_251 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11412,13 +11412,13 @@ SELECT pk FROM tab2 WHERE col3 IN (199)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_251
+DROP VIEW IF EXISTS view_1_tab2_251 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_251
+DROP VIEW IF EXISTS view_2_tab2_251 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_251
+DROP VIEW IF EXISTS view_3_tab2_251 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11504,13 +11504,13 @@ SELECT pk FROM tab3 WHERE col3 IN (199)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_251
+DROP VIEW IF EXISTS view_1_tab3_251 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_251
+DROP VIEW IF EXISTS view_2_tab3_251 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_251
+DROP VIEW IF EXISTS view_3_tab3_251 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11596,13 +11596,13 @@ SELECT pk FROM tab4 WHERE col3 IN (199)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_251
+DROP VIEW IF EXISTS view_1_tab4_251 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_251
+DROP VIEW IF EXISTS view_2_tab4_251 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_251
+DROP VIEW IF EXISTS view_3_tab4_251 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11693,13 +11693,13 @@ SELECT pk FROM tab0 WHERE ((((((col3 < 599)) OR col1 < 415.26))))
 74 values hashing to c297f9980e0a5781c277e2908ee10de2
 
 statement ok
-DROP VIEW view_1_tab0_252
+DROP VIEW IF EXISTS view_1_tab0_252 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_252
+DROP VIEW IF EXISTS view_2_tab0_252 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_252
+DROP VIEW IF EXISTS view_3_tab0_252 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11790,13 +11790,13 @@ SELECT pk FROM tab1 WHERE ((((((col3 < 599)) OR col1 < 415.26))))
 74 values hashing to c297f9980e0a5781c277e2908ee10de2
 
 statement ok
-DROP VIEW view_1_tab1_252
+DROP VIEW IF EXISTS view_1_tab1_252 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_252
+DROP VIEW IF EXISTS view_2_tab1_252 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_252
+DROP VIEW IF EXISTS view_3_tab1_252 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11887,13 +11887,13 @@ SELECT pk FROM tab2 WHERE ((((((col3 < 599)) OR col1 < 415.26))))
 74 values hashing to c297f9980e0a5781c277e2908ee10de2
 
 statement ok
-DROP VIEW view_1_tab2_252
+DROP VIEW IF EXISTS view_1_tab2_252 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_252
+DROP VIEW IF EXISTS view_2_tab2_252 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_252
+DROP VIEW IF EXISTS view_3_tab2_252 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11984,13 +11984,13 @@ SELECT pk FROM tab3 WHERE ((((((col3 < 599)) OR col1 < 415.26))))
 74 values hashing to c297f9980e0a5781c277e2908ee10de2
 
 statement ok
-DROP VIEW view_1_tab3_252
+DROP VIEW IF EXISTS view_1_tab3_252 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_252
+DROP VIEW IF EXISTS view_2_tab3_252 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_252
+DROP VIEW IF EXISTS view_3_tab3_252 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12081,13 +12081,13 @@ SELECT pk FROM tab4 WHERE ((((((col3 < 599)) OR col1 < 415.26))))
 74 values hashing to c297f9980e0a5781c277e2908ee10de2
 
 statement ok
-DROP VIEW view_1_tab4_252
+DROP VIEW IF EXISTS view_1_tab4_252 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_252
+DROP VIEW IF EXISTS view_2_tab4_252 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_252
+DROP VIEW IF EXISTS view_3_tab4_252 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12178,13 +12178,13 @@ SELECT pk FROM tab0 WHERE col3 > 371
 59 values hashing to d65972592b1595702d7980f9e135cb3e
 
 statement ok
-DROP VIEW view_1_tab0_253
+DROP VIEW IF EXISTS view_1_tab0_253 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_253
+DROP VIEW IF EXISTS view_2_tab0_253 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_253
+DROP VIEW IF EXISTS view_3_tab0_253 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12275,13 +12275,13 @@ SELECT pk FROM tab1 WHERE col3 > 371
 59 values hashing to d65972592b1595702d7980f9e135cb3e
 
 statement ok
-DROP VIEW view_1_tab1_253
+DROP VIEW IF EXISTS view_1_tab1_253 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_253
+DROP VIEW IF EXISTS view_2_tab1_253 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_253
+DROP VIEW IF EXISTS view_3_tab1_253 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12372,13 +12372,13 @@ SELECT pk FROM tab2 WHERE col3 > 371
 59 values hashing to d65972592b1595702d7980f9e135cb3e
 
 statement ok
-DROP VIEW view_1_tab2_253
+DROP VIEW IF EXISTS view_1_tab2_253 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_253
+DROP VIEW IF EXISTS view_2_tab2_253 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_253
+DROP VIEW IF EXISTS view_3_tab2_253 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12469,13 +12469,13 @@ SELECT pk FROM tab3 WHERE col3 > 371
 59 values hashing to d65972592b1595702d7980f9e135cb3e
 
 statement ok
-DROP VIEW view_1_tab3_253
+DROP VIEW IF EXISTS view_1_tab3_253 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_253
+DROP VIEW IF EXISTS view_2_tab3_253 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_253
+DROP VIEW IF EXISTS view_3_tab3_253 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12566,13 +12566,13 @@ SELECT pk FROM tab4 WHERE col3 > 371
 59 values hashing to d65972592b1595702d7980f9e135cb3e
 
 statement ok
-DROP VIEW view_1_tab4_253
+DROP VIEW IF EXISTS view_1_tab4_253 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_253
+DROP VIEW IF EXISTS view_2_tab4_253 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_253
+DROP VIEW IF EXISTS view_3_tab4_253 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12663,13 +12663,13 @@ SELECT pk FROM tab0 WHERE ((col3 <= 633 OR col4 = 257.91))
 68 values hashing to 812c0af0b0d8a6c1ada3366b5b985a9f
 
 statement ok
-DROP VIEW view_1_tab0_254
+DROP VIEW IF EXISTS view_1_tab0_254 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_254
+DROP VIEW IF EXISTS view_2_tab0_254 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_254
+DROP VIEW IF EXISTS view_3_tab0_254 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12760,13 +12760,13 @@ SELECT pk FROM tab1 WHERE ((col3 <= 633 OR col4 = 257.91))
 68 values hashing to 812c0af0b0d8a6c1ada3366b5b985a9f
 
 statement ok
-DROP VIEW view_1_tab1_254
+DROP VIEW IF EXISTS view_1_tab1_254 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_254
+DROP VIEW IF EXISTS view_2_tab1_254 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_254
+DROP VIEW IF EXISTS view_3_tab1_254 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12857,13 +12857,13 @@ SELECT pk FROM tab2 WHERE ((col3 <= 633 OR col4 = 257.91))
 68 values hashing to 812c0af0b0d8a6c1ada3366b5b985a9f
 
 statement ok
-DROP VIEW view_1_tab2_254
+DROP VIEW IF EXISTS view_1_tab2_254 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_254
+DROP VIEW IF EXISTS view_2_tab2_254 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_254
+DROP VIEW IF EXISTS view_3_tab2_254 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12954,13 +12954,13 @@ SELECT pk FROM tab3 WHERE ((col3 <= 633 OR col4 = 257.91))
 68 values hashing to 812c0af0b0d8a6c1ada3366b5b985a9f
 
 statement ok
-DROP VIEW view_1_tab3_254
+DROP VIEW IF EXISTS view_1_tab3_254 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_254
+DROP VIEW IF EXISTS view_2_tab3_254 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_254
+DROP VIEW IF EXISTS view_3_tab3_254 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13051,13 +13051,13 @@ SELECT pk FROM tab4 WHERE ((col3 <= 633 OR col4 = 257.91))
 68 values hashing to 812c0af0b0d8a6c1ada3366b5b985a9f
 
 statement ok
-DROP VIEW view_1_tab4_254
+DROP VIEW IF EXISTS view_1_tab4_254 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_254
+DROP VIEW IF EXISTS view_2_tab4_254 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_254
+DROP VIEW IF EXISTS view_3_tab4_254 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13143,13 +13143,13 @@ SELECT pk FROM tab0 WHERE col3 = 72 AND (col0 IN (34,203) AND col1 < 655.0)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_255
+DROP VIEW IF EXISTS view_1_tab0_255 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_255
+DROP VIEW IF EXISTS view_2_tab0_255 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_255
+DROP VIEW IF EXISTS view_3_tab0_255 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13235,13 +13235,13 @@ SELECT pk FROM tab1 WHERE col3 = 72 AND (col0 IN (34,203) AND col1 < 655.0)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_255
+DROP VIEW IF EXISTS view_1_tab1_255 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_255
+DROP VIEW IF EXISTS view_2_tab1_255 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_255
+DROP VIEW IF EXISTS view_3_tab1_255 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13327,13 +13327,13 @@ SELECT pk FROM tab2 WHERE col3 = 72 AND (col0 IN (34,203) AND col1 < 655.0)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_255
+DROP VIEW IF EXISTS view_1_tab2_255 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_255
+DROP VIEW IF EXISTS view_2_tab2_255 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_255
+DROP VIEW IF EXISTS view_3_tab2_255 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13419,13 +13419,13 @@ SELECT pk FROM tab3 WHERE col3 = 72 AND (col0 IN (34,203) AND col1 < 655.0)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_255
+DROP VIEW IF EXISTS view_1_tab3_255 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_255
+DROP VIEW IF EXISTS view_2_tab3_255 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_255
+DROP VIEW IF EXISTS view_3_tab3_255 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13511,13 +13511,13 @@ SELECT pk FROM tab4 WHERE col3 = 72 AND (col0 IN (34,203) AND col1 < 655.0)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_255
+DROP VIEW IF EXISTS view_1_tab4_255 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_255
+DROP VIEW IF EXISTS view_2_tab4_255 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_255
+DROP VIEW IF EXISTS view_3_tab4_255 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13608,13 +13608,13 @@ SELECT pk FROM tab0 WHERE (col3 <= 457) OR col0 < 688
 85 values hashing to f7bad25ed9f136f83bfada23c3f028fc
 
 statement ok
-DROP VIEW view_1_tab0_256
+DROP VIEW IF EXISTS view_1_tab0_256 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_256
+DROP VIEW IF EXISTS view_2_tab0_256 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_256
+DROP VIEW IF EXISTS view_3_tab0_256 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13705,13 +13705,13 @@ SELECT pk FROM tab1 WHERE (col3 <= 457) OR col0 < 688
 85 values hashing to f7bad25ed9f136f83bfada23c3f028fc
 
 statement ok
-DROP VIEW view_1_tab1_256
+DROP VIEW IF EXISTS view_1_tab1_256 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_256
+DROP VIEW IF EXISTS view_2_tab1_256 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_256
+DROP VIEW IF EXISTS view_3_tab1_256 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13802,13 +13802,13 @@ SELECT pk FROM tab2 WHERE (col3 <= 457) OR col0 < 688
 85 values hashing to f7bad25ed9f136f83bfada23c3f028fc
 
 statement ok
-DROP VIEW view_1_tab2_256
+DROP VIEW IF EXISTS view_1_tab2_256 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_256
+DROP VIEW IF EXISTS view_2_tab2_256 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_256
+DROP VIEW IF EXISTS view_3_tab2_256 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13899,13 +13899,13 @@ SELECT pk FROM tab3 WHERE (col3 <= 457) OR col0 < 688
 85 values hashing to f7bad25ed9f136f83bfada23c3f028fc
 
 statement ok
-DROP VIEW view_1_tab3_256
+DROP VIEW IF EXISTS view_1_tab3_256 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_256
+DROP VIEW IF EXISTS view_2_tab3_256 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_256
+DROP VIEW IF EXISTS view_3_tab3_256 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13996,13 +13996,13 @@ SELECT pk FROM tab4 WHERE (col3 <= 457) OR col0 < 688
 85 values hashing to f7bad25ed9f136f83bfada23c3f028fc
 
 statement ok
-DROP VIEW view_1_tab4_256
+DROP VIEW IF EXISTS view_1_tab4_256 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_256
+DROP VIEW IF EXISTS view_2_tab4_256 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_256
+DROP VIEW IF EXISTS view_3_tab4_256 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14093,13 +14093,13 @@ SELECT pk FROM tab0 WHERE ((col4 < 313.64) OR col0 < 499)
 59 values hashing to 4a66c2bcdfb5fd7f975921e90479652c
 
 statement ok
-DROP VIEW view_1_tab0_257
+DROP VIEW IF EXISTS view_1_tab0_257 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_257
+DROP VIEW IF EXISTS view_2_tab0_257 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_257
+DROP VIEW IF EXISTS view_3_tab0_257 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14190,13 +14190,13 @@ SELECT pk FROM tab1 WHERE ((col4 < 313.64) OR col0 < 499)
 59 values hashing to 4a66c2bcdfb5fd7f975921e90479652c
 
 statement ok
-DROP VIEW view_1_tab1_257
+DROP VIEW IF EXISTS view_1_tab1_257 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_257
+DROP VIEW IF EXISTS view_2_tab1_257 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_257
+DROP VIEW IF EXISTS view_3_tab1_257 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14287,13 +14287,13 @@ SELECT pk FROM tab2 WHERE ((col4 < 313.64) OR col0 < 499)
 59 values hashing to 4a66c2bcdfb5fd7f975921e90479652c
 
 statement ok
-DROP VIEW view_1_tab2_257
+DROP VIEW IF EXISTS view_1_tab2_257 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_257
+DROP VIEW IF EXISTS view_2_tab2_257 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_257
+DROP VIEW IF EXISTS view_3_tab2_257 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14384,13 +14384,13 @@ SELECT pk FROM tab3 WHERE ((col4 < 313.64) OR col0 < 499)
 59 values hashing to 4a66c2bcdfb5fd7f975921e90479652c
 
 statement ok
-DROP VIEW view_1_tab3_257
+DROP VIEW IF EXISTS view_1_tab3_257 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_257
+DROP VIEW IF EXISTS view_2_tab3_257 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_257
+DROP VIEW IF EXISTS view_3_tab3_257 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14481,13 +14481,13 @@ SELECT pk FROM tab4 WHERE ((col4 < 313.64) OR col0 < 499)
 59 values hashing to 4a66c2bcdfb5fd7f975921e90479652c
 
 statement ok
-DROP VIEW view_1_tab4_257
+DROP VIEW IF EXISTS view_1_tab4_257 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_257
+DROP VIEW IF EXISTS view_2_tab4_257 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_257
+DROP VIEW IF EXISTS view_3_tab4_257 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14580,13 +14580,13 @@ SELECT pk FROM tab0 WHERE ((col0 >= 11))
 99 values hashing to 5af1bf83923df5a62a2fa6dc6298cdf4
 
 statement ok
-DROP VIEW view_1_tab0_258
+DROP VIEW IF EXISTS view_1_tab0_258 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_258
+DROP VIEW IF EXISTS view_2_tab0_258 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_258
+DROP VIEW IF EXISTS view_3_tab0_258 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14679,13 +14679,13 @@ SELECT pk FROM tab1 WHERE ((col0 >= 11))
 99 values hashing to 5af1bf83923df5a62a2fa6dc6298cdf4
 
 statement ok
-DROP VIEW view_1_tab1_258
+DROP VIEW IF EXISTS view_1_tab1_258 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_258
+DROP VIEW IF EXISTS view_2_tab1_258 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_258
+DROP VIEW IF EXISTS view_3_tab1_258 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14778,13 +14778,13 @@ SELECT pk FROM tab2 WHERE ((col0 >= 11))
 99 values hashing to 5af1bf83923df5a62a2fa6dc6298cdf4
 
 statement ok
-DROP VIEW view_1_tab2_258
+DROP VIEW IF EXISTS view_1_tab2_258 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_258
+DROP VIEW IF EXISTS view_2_tab2_258 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_258
+DROP VIEW IF EXISTS view_3_tab2_258 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14877,13 +14877,13 @@ SELECT pk FROM tab3 WHERE ((col0 >= 11))
 99 values hashing to 5af1bf83923df5a62a2fa6dc6298cdf4
 
 statement ok
-DROP VIEW view_1_tab3_258
+DROP VIEW IF EXISTS view_1_tab3_258 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_258
+DROP VIEW IF EXISTS view_2_tab3_258 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_258
+DROP VIEW IF EXISTS view_3_tab3_258 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14976,13 +14976,13 @@ SELECT pk FROM tab4 WHERE ((col0 >= 11))
 99 values hashing to 5af1bf83923df5a62a2fa6dc6298cdf4
 
 statement ok
-DROP VIEW view_1_tab4_258
+DROP VIEW IF EXISTS view_1_tab4_258 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_258
+DROP VIEW IF EXISTS view_2_tab4_258 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_258
+DROP VIEW IF EXISTS view_3_tab4_258 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15073,13 +15073,13 @@ SELECT pk FROM tab0 WHERE col3 < 770 OR col4 > 981.53 OR (col4 >= 634.21) OR (((
 86 values hashing to de561888761e809ec6f307ba37ae4aa3
 
 statement ok
-DROP VIEW view_1_tab0_260
+DROP VIEW IF EXISTS view_1_tab0_260 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_260
+DROP VIEW IF EXISTS view_2_tab0_260 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_260
+DROP VIEW IF EXISTS view_3_tab0_260 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15170,13 +15170,13 @@ SELECT pk FROM tab1 WHERE col3 < 770 OR col4 > 981.53 OR (col4 >= 634.21) OR (((
 86 values hashing to de561888761e809ec6f307ba37ae4aa3
 
 statement ok
-DROP VIEW view_1_tab1_260
+DROP VIEW IF EXISTS view_1_tab1_260 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_260
+DROP VIEW IF EXISTS view_2_tab1_260 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_260
+DROP VIEW IF EXISTS view_3_tab1_260 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15267,13 +15267,13 @@ SELECT pk FROM tab2 WHERE col3 < 770 OR col4 > 981.53 OR (col4 >= 634.21) OR (((
 86 values hashing to de561888761e809ec6f307ba37ae4aa3
 
 statement ok
-DROP VIEW view_1_tab2_260
+DROP VIEW IF EXISTS view_1_tab2_260 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_260
+DROP VIEW IF EXISTS view_2_tab2_260 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_260
+DROP VIEW IF EXISTS view_3_tab2_260 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15364,13 +15364,13 @@ SELECT pk FROM tab3 WHERE col3 < 770 OR col4 > 981.53 OR (col4 >= 634.21) OR (((
 86 values hashing to de561888761e809ec6f307ba37ae4aa3
 
 statement ok
-DROP VIEW view_1_tab3_260
+DROP VIEW IF EXISTS view_1_tab3_260 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_260
+DROP VIEW IF EXISTS view_2_tab3_260 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_260
+DROP VIEW IF EXISTS view_3_tab3_260 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15461,13 +15461,13 @@ SELECT pk FROM tab4 WHERE col3 < 770 OR col4 > 981.53 OR (col4 >= 634.21) OR (((
 86 values hashing to de561888761e809ec6f307ba37ae4aa3
 
 statement ok
-DROP VIEW view_1_tab4_260
+DROP VIEW IF EXISTS view_1_tab4_260 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_260
+DROP VIEW IF EXISTS view_2_tab4_260 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_260
+DROP VIEW IF EXISTS view_3_tab4_260 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15553,13 +15553,13 @@ SELECT pk FROM tab0 WHERE (col1 IN (344.84,326.40,509.8,263.0))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_261
+DROP VIEW IF EXISTS view_1_tab0_261 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_261
+DROP VIEW IF EXISTS view_2_tab0_261 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_261
+DROP VIEW IF EXISTS view_3_tab0_261 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15645,13 +15645,13 @@ SELECT pk FROM tab1 WHERE (col1 IN (344.84,326.40,509.8,263.0))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_261
+DROP VIEW IF EXISTS view_1_tab1_261 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_261
+DROP VIEW IF EXISTS view_2_tab1_261 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_261
+DROP VIEW IF EXISTS view_3_tab1_261 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15737,13 +15737,13 @@ SELECT pk FROM tab2 WHERE (col1 IN (344.84,326.40,509.8,263.0))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_261
+DROP VIEW IF EXISTS view_1_tab2_261 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_261
+DROP VIEW IF EXISTS view_2_tab2_261 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_261
+DROP VIEW IF EXISTS view_3_tab2_261 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15829,13 +15829,13 @@ SELECT pk FROM tab3 WHERE (col1 IN (344.84,326.40,509.8,263.0))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_261
+DROP VIEW IF EXISTS view_1_tab3_261 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_261
+DROP VIEW IF EXISTS view_2_tab3_261 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_261
+DROP VIEW IF EXISTS view_3_tab3_261 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15921,13 +15921,13 @@ SELECT pk FROM tab4 WHERE (col1 IN (344.84,326.40,509.8,263.0))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_261
+DROP VIEW IF EXISTS view_1_tab4_261 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_261
+DROP VIEW IF EXISTS view_2_tab4_261 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_261
+DROP VIEW IF EXISTS view_3_tab4_261 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16018,13 +16018,13 @@ SELECT pk FROM tab0 WHERE ((col4 > 839.10) AND col4 <= 637.72 AND col3 >= 790 OR
 43 values hashing to 99471a9383c79b6f9698fe9496698fda
 
 statement ok
-DROP VIEW view_1_tab0_262
+DROP VIEW IF EXISTS view_1_tab0_262 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_262
+DROP VIEW IF EXISTS view_2_tab0_262 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_262
+DROP VIEW IF EXISTS view_3_tab0_262 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16115,13 +16115,13 @@ SELECT pk FROM tab1 WHERE ((col4 > 839.10) AND col4 <= 637.72 AND col3 >= 790 OR
 43 values hashing to 99471a9383c79b6f9698fe9496698fda
 
 statement ok
-DROP VIEW view_1_tab1_262
+DROP VIEW IF EXISTS view_1_tab1_262 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_262
+DROP VIEW IF EXISTS view_2_tab1_262 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_262
+DROP VIEW IF EXISTS view_3_tab1_262 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16212,13 +16212,13 @@ SELECT pk FROM tab2 WHERE ((col4 > 839.10) AND col4 <= 637.72 AND col3 >= 790 OR
 43 values hashing to 99471a9383c79b6f9698fe9496698fda
 
 statement ok
-DROP VIEW view_1_tab2_262
+DROP VIEW IF EXISTS view_1_tab2_262 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_262
+DROP VIEW IF EXISTS view_2_tab2_262 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_262
+DROP VIEW IF EXISTS view_3_tab2_262 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16309,13 +16309,13 @@ SELECT pk FROM tab3 WHERE ((col4 > 839.10) AND col4 <= 637.72 AND col3 >= 790 OR
 43 values hashing to 99471a9383c79b6f9698fe9496698fda
 
 statement ok
-DROP VIEW view_1_tab3_262
+DROP VIEW IF EXISTS view_1_tab3_262 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_262
+DROP VIEW IF EXISTS view_2_tab3_262 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_262
+DROP VIEW IF EXISTS view_3_tab3_262 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16406,13 +16406,13 @@ SELECT pk FROM tab4 WHERE ((col4 > 839.10) AND col4 <= 637.72 AND col3 >= 790 OR
 43 values hashing to 99471a9383c79b6f9698fe9496698fda
 
 statement ok
-DROP VIEW view_1_tab4_262
+DROP VIEW IF EXISTS view_1_tab4_262 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_262
+DROP VIEW IF EXISTS view_2_tab4_262 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_262
+DROP VIEW IF EXISTS view_3_tab4_262 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16503,13 +16503,13 @@ SELECT pk FROM tab0 WHERE (((col3 <= 275) AND (col3 > 343) OR col3 <= 418) OR co
 46 values hashing to 9db1ecd96a41c7ec2ce72e3dc018a2cf
 
 statement ok
-DROP VIEW view_1_tab0_263
+DROP VIEW IF EXISTS view_1_tab0_263 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_263
+DROP VIEW IF EXISTS view_2_tab0_263 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_263
+DROP VIEW IF EXISTS view_3_tab0_263 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16600,13 +16600,13 @@ SELECT pk FROM tab1 WHERE (((col3 <= 275) AND (col3 > 343) OR col3 <= 418) OR co
 46 values hashing to 9db1ecd96a41c7ec2ce72e3dc018a2cf
 
 statement ok
-DROP VIEW view_1_tab1_263
+DROP VIEW IF EXISTS view_1_tab1_263 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_263
+DROP VIEW IF EXISTS view_2_tab1_263 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_263
+DROP VIEW IF EXISTS view_3_tab1_263 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16697,13 +16697,13 @@ SELECT pk FROM tab2 WHERE (((col3 <= 275) AND (col3 > 343) OR col3 <= 418) OR co
 46 values hashing to 9db1ecd96a41c7ec2ce72e3dc018a2cf
 
 statement ok
-DROP VIEW view_1_tab2_263
+DROP VIEW IF EXISTS view_1_tab2_263 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_263
+DROP VIEW IF EXISTS view_2_tab2_263 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_263
+DROP VIEW IF EXISTS view_3_tab2_263 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16794,13 +16794,13 @@ SELECT pk FROM tab3 WHERE (((col3 <= 275) AND (col3 > 343) OR col3 <= 418) OR co
 46 values hashing to 9db1ecd96a41c7ec2ce72e3dc018a2cf
 
 statement ok
-DROP VIEW view_1_tab3_263
+DROP VIEW IF EXISTS view_1_tab3_263 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_263
+DROP VIEW IF EXISTS view_2_tab3_263 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_263
+DROP VIEW IF EXISTS view_3_tab3_263 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16891,13 +16891,13 @@ SELECT pk FROM tab4 WHERE (((col3 <= 275) AND (col3 > 343) OR col3 <= 418) OR co
 46 values hashing to 9db1ecd96a41c7ec2ce72e3dc018a2cf
 
 statement ok
-DROP VIEW view_1_tab4_263
+DROP VIEW IF EXISTS view_1_tab4_263 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_263
+DROP VIEW IF EXISTS view_2_tab4_263 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_263
+DROP VIEW IF EXISTS view_3_tab4_263 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16983,13 +16983,13 @@ SELECT pk FROM tab0 WHERE col0 = 161
 ----
 
 statement ok
-DROP VIEW view_1_tab0_264
+DROP VIEW IF EXISTS view_1_tab0_264 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_264
+DROP VIEW IF EXISTS view_2_tab0_264 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_264
+DROP VIEW IF EXISTS view_3_tab0_264 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17075,13 +17075,13 @@ SELECT pk FROM tab1 WHERE col0 = 161
 ----
 
 statement ok
-DROP VIEW view_1_tab1_264
+DROP VIEW IF EXISTS view_1_tab1_264 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_264
+DROP VIEW IF EXISTS view_2_tab1_264 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_264
+DROP VIEW IF EXISTS view_3_tab1_264 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17167,13 +17167,13 @@ SELECT pk FROM tab2 WHERE col0 = 161
 ----
 
 statement ok
-DROP VIEW view_1_tab2_264
+DROP VIEW IF EXISTS view_1_tab2_264 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_264
+DROP VIEW IF EXISTS view_2_tab2_264 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_264
+DROP VIEW IF EXISTS view_3_tab2_264 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17259,13 +17259,13 @@ SELECT pk FROM tab3 WHERE col0 = 161
 ----
 
 statement ok
-DROP VIEW view_1_tab3_264
+DROP VIEW IF EXISTS view_1_tab3_264 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_264
+DROP VIEW IF EXISTS view_2_tab3_264 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_264
+DROP VIEW IF EXISTS view_3_tab3_264 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17351,13 +17351,13 @@ SELECT pk FROM tab4 WHERE col0 = 161
 ----
 
 statement ok
-DROP VIEW view_1_tab4_264
+DROP VIEW IF EXISTS view_1_tab4_264 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_264
+DROP VIEW IF EXISTS view_2_tab4_264 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_264
+DROP VIEW IF EXISTS view_3_tab4_264 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17448,13 +17448,13 @@ SELECT pk FROM tab0 WHERE (col0 > 694)
 30 values hashing to b0970e5645b012ec9ea992f416c2ecba
 
 statement ok
-DROP VIEW view_1_tab0_265
+DROP VIEW IF EXISTS view_1_tab0_265 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_265
+DROP VIEW IF EXISTS view_2_tab0_265 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_265
+DROP VIEW IF EXISTS view_3_tab0_265 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17545,13 +17545,13 @@ SELECT pk FROM tab1 WHERE (col0 > 694)
 30 values hashing to b0970e5645b012ec9ea992f416c2ecba
 
 statement ok
-DROP VIEW view_1_tab1_265
+DROP VIEW IF EXISTS view_1_tab1_265 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_265
+DROP VIEW IF EXISTS view_2_tab1_265 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_265
+DROP VIEW IF EXISTS view_3_tab1_265 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17642,13 +17642,13 @@ SELECT pk FROM tab2 WHERE (col0 > 694)
 30 values hashing to b0970e5645b012ec9ea992f416c2ecba
 
 statement ok
-DROP VIEW view_1_tab2_265
+DROP VIEW IF EXISTS view_1_tab2_265 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_265
+DROP VIEW IF EXISTS view_2_tab2_265 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_265
+DROP VIEW IF EXISTS view_3_tab2_265 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17739,13 +17739,13 @@ SELECT pk FROM tab3 WHERE (col0 > 694)
 30 values hashing to b0970e5645b012ec9ea992f416c2ecba
 
 statement ok
-DROP VIEW view_1_tab3_265
+DROP VIEW IF EXISTS view_1_tab3_265 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_265
+DROP VIEW IF EXISTS view_2_tab3_265 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_265
+DROP VIEW IF EXISTS view_3_tab3_265 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17836,13 +17836,13 @@ SELECT pk FROM tab4 WHERE (col0 > 694)
 30 values hashing to b0970e5645b012ec9ea992f416c2ecba
 
 statement ok
-DROP VIEW view_1_tab4_265
+DROP VIEW IF EXISTS view_1_tab4_265 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_265
+DROP VIEW IF EXISTS view_2_tab4_265 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_265
+DROP VIEW IF EXISTS view_3_tab4_265 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17928,13 +17928,13 @@ SELECT pk FROM tab0 WHERE (col3 IS NULL OR col4 < 723.74 AND col3 <= 182 AND col
 ----
 
 statement ok
-DROP VIEW view_1_tab0_266
+DROP VIEW IF EXISTS view_1_tab0_266 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_266
+DROP VIEW IF EXISTS view_2_tab0_266 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_266
+DROP VIEW IF EXISTS view_3_tab0_266 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18020,13 +18020,13 @@ SELECT pk FROM tab1 WHERE (col3 IS NULL OR col4 < 723.74 AND col3 <= 182 AND col
 ----
 
 statement ok
-DROP VIEW view_1_tab1_266
+DROP VIEW IF EXISTS view_1_tab1_266 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_266
+DROP VIEW IF EXISTS view_2_tab1_266 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_266
+DROP VIEW IF EXISTS view_3_tab1_266 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18112,13 +18112,13 @@ SELECT pk FROM tab2 WHERE (col3 IS NULL OR col4 < 723.74 AND col3 <= 182 AND col
 ----
 
 statement ok
-DROP VIEW view_1_tab2_266
+DROP VIEW IF EXISTS view_1_tab2_266 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_266
+DROP VIEW IF EXISTS view_2_tab2_266 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_266
+DROP VIEW IF EXISTS view_3_tab2_266 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18204,13 +18204,13 @@ SELECT pk FROM tab3 WHERE (col3 IS NULL OR col4 < 723.74 AND col3 <= 182 AND col
 ----
 
 statement ok
-DROP VIEW view_1_tab3_266
+DROP VIEW IF EXISTS view_1_tab3_266 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_266
+DROP VIEW IF EXISTS view_2_tab3_266 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_266
+DROP VIEW IF EXISTS view_3_tab3_266 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18296,13 +18296,13 @@ SELECT pk FROM tab4 WHERE (col3 IS NULL OR col4 < 723.74 AND col3 <= 182 AND col
 ----
 
 statement ok
-DROP VIEW view_1_tab4_266
+DROP VIEW IF EXISTS view_1_tab4_266 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_266
+DROP VIEW IF EXISTS view_2_tab4_266 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_266
+DROP VIEW IF EXISTS view_3_tab4_266 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18393,13 +18393,13 @@ SELECT pk FROM tab0 WHERE (col3 IN (163,887,124,808,198) OR col4 > 490.27 OR col
 75 values hashing to 1abe2ff8fa7178a9cb1ffe4b6b52f9a6
 
 statement ok
-DROP VIEW view_1_tab0_267
+DROP VIEW IF EXISTS view_1_tab0_267 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_267
+DROP VIEW IF EXISTS view_2_tab0_267 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_267
+DROP VIEW IF EXISTS view_3_tab0_267 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18490,13 +18490,13 @@ SELECT pk FROM tab1 WHERE (col3 IN (163,887,124,808,198) OR col4 > 490.27 OR col
 75 values hashing to 1abe2ff8fa7178a9cb1ffe4b6b52f9a6
 
 statement ok
-DROP VIEW view_1_tab1_267
+DROP VIEW IF EXISTS view_1_tab1_267 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_267
+DROP VIEW IF EXISTS view_2_tab1_267 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_267
+DROP VIEW IF EXISTS view_3_tab1_267 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18587,13 +18587,13 @@ SELECT pk FROM tab2 WHERE (col3 IN (163,887,124,808,198) OR col4 > 490.27 OR col
 75 values hashing to 1abe2ff8fa7178a9cb1ffe4b6b52f9a6
 
 statement ok
-DROP VIEW view_1_tab2_267
+DROP VIEW IF EXISTS view_1_tab2_267 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_267
+DROP VIEW IF EXISTS view_2_tab2_267 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_267
+DROP VIEW IF EXISTS view_3_tab2_267 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18684,13 +18684,13 @@ SELECT pk FROM tab3 WHERE (col3 IN (163,887,124,808,198) OR col4 > 490.27 OR col
 75 values hashing to 1abe2ff8fa7178a9cb1ffe4b6b52f9a6
 
 statement ok
-DROP VIEW view_1_tab3_267
+DROP VIEW IF EXISTS view_1_tab3_267 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_267
+DROP VIEW IF EXISTS view_2_tab3_267 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_267
+DROP VIEW IF EXISTS view_3_tab3_267 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18781,13 +18781,13 @@ SELECT pk FROM tab4 WHERE (col3 IN (163,887,124,808,198) OR col4 > 490.27 OR col
 75 values hashing to 1abe2ff8fa7178a9cb1ffe4b6b52f9a6
 
 statement ok
-DROP VIEW view_1_tab4_267
+DROP VIEW IF EXISTS view_1_tab4_267 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_267
+DROP VIEW IF EXISTS view_2_tab4_267 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_267
+DROP VIEW IF EXISTS view_3_tab4_267 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18878,13 +18878,13 @@ SELECT pk FROM tab0 WHERE col4 >= 212.36
 82 values hashing to 8ce39bb5ab608448d50f86ffe921119e
 
 statement ok
-DROP VIEW view_1_tab0_268
+DROP VIEW IF EXISTS view_1_tab0_268 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_268
+DROP VIEW IF EXISTS view_2_tab0_268 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_268
+DROP VIEW IF EXISTS view_3_tab0_268 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18975,13 +18975,13 @@ SELECT pk FROM tab1 WHERE col4 >= 212.36
 82 values hashing to 8ce39bb5ab608448d50f86ffe921119e
 
 statement ok
-DROP VIEW view_1_tab1_268
+DROP VIEW IF EXISTS view_1_tab1_268 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_268
+DROP VIEW IF EXISTS view_2_tab1_268 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_268
+DROP VIEW IF EXISTS view_3_tab1_268 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19072,13 +19072,13 @@ SELECT pk FROM tab2 WHERE col4 >= 212.36
 82 values hashing to 8ce39bb5ab608448d50f86ffe921119e
 
 statement ok
-DROP VIEW view_1_tab2_268
+DROP VIEW IF EXISTS view_1_tab2_268 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_268
+DROP VIEW IF EXISTS view_2_tab2_268 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_268
+DROP VIEW IF EXISTS view_3_tab2_268 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19169,13 +19169,13 @@ SELECT pk FROM tab3 WHERE col4 >= 212.36
 82 values hashing to 8ce39bb5ab608448d50f86ffe921119e
 
 statement ok
-DROP VIEW view_1_tab3_268
+DROP VIEW IF EXISTS view_1_tab3_268 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_268
+DROP VIEW IF EXISTS view_2_tab3_268 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_268
+DROP VIEW IF EXISTS view_3_tab3_268 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19266,13 +19266,13 @@ SELECT pk FROM tab4 WHERE col4 >= 212.36
 82 values hashing to 8ce39bb5ab608448d50f86ffe921119e
 
 statement ok
-DROP VIEW view_1_tab4_268
+DROP VIEW IF EXISTS view_1_tab4_268 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_268
+DROP VIEW IF EXISTS view_2_tab4_268 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_268
+DROP VIEW IF EXISTS view_3_tab4_268 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19363,13 +19363,13 @@ SELECT pk FROM tab0 WHERE col1 < 641.78
 64 values hashing to 3011f18386b3cce75db43426423ebf9f
 
 statement ok
-DROP VIEW view_1_tab0_269
+DROP VIEW IF EXISTS view_1_tab0_269 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_269
+DROP VIEW IF EXISTS view_2_tab0_269 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_269
+DROP VIEW IF EXISTS view_3_tab0_269 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19460,13 +19460,13 @@ SELECT pk FROM tab1 WHERE col1 < 641.78
 64 values hashing to 3011f18386b3cce75db43426423ebf9f
 
 statement ok
-DROP VIEW view_1_tab1_269
+DROP VIEW IF EXISTS view_1_tab1_269 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_269
+DROP VIEW IF EXISTS view_2_tab1_269 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_269
+DROP VIEW IF EXISTS view_3_tab1_269 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19557,13 +19557,13 @@ SELECT pk FROM tab2 WHERE col1 < 641.78
 64 values hashing to 3011f18386b3cce75db43426423ebf9f
 
 statement ok
-DROP VIEW view_1_tab2_269
+DROP VIEW IF EXISTS view_1_tab2_269 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_269
+DROP VIEW IF EXISTS view_2_tab2_269 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_269
+DROP VIEW IF EXISTS view_3_tab2_269 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19654,13 +19654,13 @@ SELECT pk FROM tab3 WHERE col1 < 641.78
 64 values hashing to 3011f18386b3cce75db43426423ebf9f
 
 statement ok
-DROP VIEW view_1_tab3_269
+DROP VIEW IF EXISTS view_1_tab3_269 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_269
+DROP VIEW IF EXISTS view_2_tab3_269 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_269
+DROP VIEW IF EXISTS view_3_tab3_269 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19751,13 +19751,13 @@ SELECT pk FROM tab4 WHERE col1 < 641.78
 64 values hashing to 3011f18386b3cce75db43426423ebf9f
 
 statement ok
-DROP VIEW view_1_tab4_269
+DROP VIEW IF EXISTS view_1_tab4_269 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_269
+DROP VIEW IF EXISTS view_2_tab4_269 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_269
+DROP VIEW IF EXISTS view_3_tab4_269 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19843,13 +19843,13 @@ SELECT pk FROM tab0 WHERE (col0 = 779)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_270
+DROP VIEW IF EXISTS view_1_tab0_270 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_270
+DROP VIEW IF EXISTS view_2_tab0_270 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_270
+DROP VIEW IF EXISTS view_3_tab0_270 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19935,13 +19935,13 @@ SELECT pk FROM tab1 WHERE (col0 = 779)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_270
+DROP VIEW IF EXISTS view_1_tab1_270 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_270
+DROP VIEW IF EXISTS view_2_tab1_270 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_270
+DROP VIEW IF EXISTS view_3_tab1_270 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20027,13 +20027,13 @@ SELECT pk FROM tab2 WHERE (col0 = 779)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_270
+DROP VIEW IF EXISTS view_1_tab2_270 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_270
+DROP VIEW IF EXISTS view_2_tab2_270 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_270
+DROP VIEW IF EXISTS view_3_tab2_270 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20119,13 +20119,13 @@ SELECT pk FROM tab3 WHERE (col0 = 779)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_270
+DROP VIEW IF EXISTS view_1_tab3_270 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_270
+DROP VIEW IF EXISTS view_2_tab3_270 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_270
+DROP VIEW IF EXISTS view_3_tab3_270 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20211,13 +20211,13 @@ SELECT pk FROM tab4 WHERE (col0 = 779)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_270
+DROP VIEW IF EXISTS view_1_tab4_270 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_270
+DROP VIEW IF EXISTS view_2_tab4_270 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_270
+DROP VIEW IF EXISTS view_3_tab4_270 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20310,13 +20310,13 @@ SELECT pk FROM tab0 WHERE (col0 = 850 OR col3 = 474)
 93
 
 statement ok
-DROP VIEW view_1_tab0_271
+DROP VIEW IF EXISTS view_1_tab0_271 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_271
+DROP VIEW IF EXISTS view_2_tab0_271 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_271
+DROP VIEW IF EXISTS view_3_tab0_271 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20409,13 +20409,13 @@ SELECT pk FROM tab1 WHERE (col0 = 850 OR col3 = 474)
 93
 
 statement ok
-DROP VIEW view_1_tab1_271
+DROP VIEW IF EXISTS view_1_tab1_271 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_271
+DROP VIEW IF EXISTS view_2_tab1_271 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_271
+DROP VIEW IF EXISTS view_3_tab1_271 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20508,13 +20508,13 @@ SELECT pk FROM tab2 WHERE (col0 = 850 OR col3 = 474)
 93
 
 statement ok
-DROP VIEW view_1_tab2_271
+DROP VIEW IF EXISTS view_1_tab2_271 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_271
+DROP VIEW IF EXISTS view_2_tab2_271 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_271
+DROP VIEW IF EXISTS view_3_tab2_271 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20607,13 +20607,13 @@ SELECT pk FROM tab3 WHERE (col0 = 850 OR col3 = 474)
 93
 
 statement ok
-DROP VIEW view_1_tab3_271
+DROP VIEW IF EXISTS view_1_tab3_271 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_271
+DROP VIEW IF EXISTS view_2_tab3_271 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_271
+DROP VIEW IF EXISTS view_3_tab3_271 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20706,13 +20706,13 @@ SELECT pk FROM tab4 WHERE (col0 = 850 OR col3 = 474)
 93
 
 statement ok
-DROP VIEW view_1_tab4_271
+DROP VIEW IF EXISTS view_1_tab4_271 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_271
+DROP VIEW IF EXISTS view_2_tab4_271 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_271
+DROP VIEW IF EXISTS view_3_tab4_271 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20803,13 +20803,13 @@ SELECT pk FROM tab0 WHERE col1 <= 795.0
 79 values hashing to a22e278d5dbb3478b94f474fe095aa45
 
 statement ok
-DROP VIEW view_1_tab0_272
+DROP VIEW IF EXISTS view_1_tab0_272 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_272
+DROP VIEW IF EXISTS view_2_tab0_272 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_272
+DROP VIEW IF EXISTS view_3_tab0_272 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20900,13 +20900,13 @@ SELECT pk FROM tab1 WHERE col1 <= 795.0
 79 values hashing to a22e278d5dbb3478b94f474fe095aa45
 
 statement ok
-DROP VIEW view_1_tab1_272
+DROP VIEW IF EXISTS view_1_tab1_272 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_272
+DROP VIEW IF EXISTS view_2_tab1_272 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_272
+DROP VIEW IF EXISTS view_3_tab1_272 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20997,13 +20997,13 @@ SELECT pk FROM tab2 WHERE col1 <= 795.0
 79 values hashing to a22e278d5dbb3478b94f474fe095aa45
 
 statement ok
-DROP VIEW view_1_tab2_272
+DROP VIEW IF EXISTS view_1_tab2_272 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_272
+DROP VIEW IF EXISTS view_2_tab2_272 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_272
+DROP VIEW IF EXISTS view_3_tab2_272 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21094,13 +21094,13 @@ SELECT pk FROM tab3 WHERE col1 <= 795.0
 79 values hashing to a22e278d5dbb3478b94f474fe095aa45
 
 statement ok
-DROP VIEW view_1_tab3_272
+DROP VIEW IF EXISTS view_1_tab3_272 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_272
+DROP VIEW IF EXISTS view_2_tab3_272 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_272
+DROP VIEW IF EXISTS view_3_tab3_272 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21191,13 +21191,13 @@ SELECT pk FROM tab4 WHERE col1 <= 795.0
 79 values hashing to a22e278d5dbb3478b94f474fe095aa45
 
 statement ok
-DROP VIEW view_1_tab4_272
+DROP VIEW IF EXISTS view_1_tab4_272 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_272
+DROP VIEW IF EXISTS view_2_tab4_272 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_272
+DROP VIEW IF EXISTS view_3_tab4_272 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21288,13 +21288,13 @@ SELECT pk FROM tab0 WHERE col4 > 513.77
 54 values hashing to a70b7120009c9b248a4eb9a0a87c370c
 
 statement ok
-DROP VIEW view_1_tab0_273
+DROP VIEW IF EXISTS view_1_tab0_273 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_273
+DROP VIEW IF EXISTS view_2_tab0_273 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_273
+DROP VIEW IF EXISTS view_3_tab0_273 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21385,13 +21385,13 @@ SELECT pk FROM tab1 WHERE col4 > 513.77
 54 values hashing to a70b7120009c9b248a4eb9a0a87c370c
 
 statement ok
-DROP VIEW view_1_tab1_273
+DROP VIEW IF EXISTS view_1_tab1_273 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_273
+DROP VIEW IF EXISTS view_2_tab1_273 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_273
+DROP VIEW IF EXISTS view_3_tab1_273 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21482,13 +21482,13 @@ SELECT pk FROM tab2 WHERE col4 > 513.77
 54 values hashing to a70b7120009c9b248a4eb9a0a87c370c
 
 statement ok
-DROP VIEW view_1_tab2_273
+DROP VIEW IF EXISTS view_1_tab2_273 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_273
+DROP VIEW IF EXISTS view_2_tab2_273 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_273
+DROP VIEW IF EXISTS view_3_tab2_273 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21579,13 +21579,13 @@ SELECT pk FROM tab3 WHERE col4 > 513.77
 54 values hashing to a70b7120009c9b248a4eb9a0a87c370c
 
 statement ok
-DROP VIEW view_1_tab3_273
+DROP VIEW IF EXISTS view_1_tab3_273 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_273
+DROP VIEW IF EXISTS view_2_tab3_273 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_273
+DROP VIEW IF EXISTS view_3_tab3_273 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21676,13 +21676,13 @@ SELECT pk FROM tab4 WHERE col4 > 513.77
 54 values hashing to a70b7120009c9b248a4eb9a0a87c370c
 
 statement ok
-DROP VIEW view_1_tab4_273
+DROP VIEW IF EXISTS view_1_tab4_273 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_273
+DROP VIEW IF EXISTS view_2_tab4_273 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_273
+DROP VIEW IF EXISTS view_3_tab4_273 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21768,13 +21768,13 @@ SELECT pk FROM tab0 WHERE ((col3 = 961))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_274
+DROP VIEW IF EXISTS view_1_tab0_274 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_274
+DROP VIEW IF EXISTS view_2_tab0_274 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_274
+DROP VIEW IF EXISTS view_3_tab0_274 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21860,13 +21860,13 @@ SELECT pk FROM tab1 WHERE ((col3 = 961))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_274
+DROP VIEW IF EXISTS view_1_tab1_274 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_274
+DROP VIEW IF EXISTS view_2_tab1_274 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_274
+DROP VIEW IF EXISTS view_3_tab1_274 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21952,13 +21952,13 @@ SELECT pk FROM tab2 WHERE ((col3 = 961))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_274
+DROP VIEW IF EXISTS view_1_tab2_274 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_274
+DROP VIEW IF EXISTS view_2_tab2_274 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_274
+DROP VIEW IF EXISTS view_3_tab2_274 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22044,13 +22044,13 @@ SELECT pk FROM tab3 WHERE ((col3 = 961))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_274
+DROP VIEW IF EXISTS view_1_tab3_274 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_274
+DROP VIEW IF EXISTS view_2_tab3_274 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_274
+DROP VIEW IF EXISTS view_3_tab3_274 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22136,13 +22136,13 @@ SELECT pk FROM tab4 WHERE ((col3 = 961))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_274
+DROP VIEW IF EXISTS view_1_tab4_274 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_274
+DROP VIEW IF EXISTS view_2_tab4_274 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_274
+DROP VIEW IF EXISTS view_3_tab4_274 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22233,13 +22233,13 @@ SELECT pk FROM tab0 WHERE (((col0 < 932 OR ((col0 = 506) AND (col4 < 845.42)) OR
 25 values hashing to daab5a56422fe3795f4f9ed8c21fd002
 
 statement ok
-DROP VIEW view_1_tab0_275
+DROP VIEW IF EXISTS view_1_tab0_275 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_275
+DROP VIEW IF EXISTS view_2_tab0_275 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_275
+DROP VIEW IF EXISTS view_3_tab0_275 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22330,13 +22330,13 @@ SELECT pk FROM tab1 WHERE (((col0 < 932 OR ((col0 = 506) AND (col4 < 845.42)) OR
 25 values hashing to daab5a56422fe3795f4f9ed8c21fd002
 
 statement ok
-DROP VIEW view_1_tab1_275
+DROP VIEW IF EXISTS view_1_tab1_275 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_275
+DROP VIEW IF EXISTS view_2_tab1_275 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_275
+DROP VIEW IF EXISTS view_3_tab1_275 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22427,13 +22427,13 @@ SELECT pk FROM tab2 WHERE (((col0 < 932 OR ((col0 = 506) AND (col4 < 845.42)) OR
 25 values hashing to daab5a56422fe3795f4f9ed8c21fd002
 
 statement ok
-DROP VIEW view_1_tab2_275
+DROP VIEW IF EXISTS view_1_tab2_275 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_275
+DROP VIEW IF EXISTS view_2_tab2_275 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_275
+DROP VIEW IF EXISTS view_3_tab2_275 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22524,13 +22524,13 @@ SELECT pk FROM tab3 WHERE (((col0 < 932 OR ((col0 = 506) AND (col4 < 845.42)) OR
 25 values hashing to daab5a56422fe3795f4f9ed8c21fd002
 
 statement ok
-DROP VIEW view_1_tab3_275
+DROP VIEW IF EXISTS view_1_tab3_275 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_275
+DROP VIEW IF EXISTS view_2_tab3_275 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_275
+DROP VIEW IF EXISTS view_3_tab3_275 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22621,13 +22621,13 @@ SELECT pk FROM tab4 WHERE (((col0 < 932 OR ((col0 = 506) AND (col4 < 845.42)) OR
 25 values hashing to daab5a56422fe3795f4f9ed8c21fd002
 
 statement ok
-DROP VIEW view_1_tab4_275
+DROP VIEW IF EXISTS view_1_tab4_275 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_275
+DROP VIEW IF EXISTS view_2_tab4_275 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_275
+DROP VIEW IF EXISTS view_3_tab4_275 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22713,13 +22713,13 @@ SELECT pk FROM tab0 WHERE col3 IN (395,213)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_276
+DROP VIEW IF EXISTS view_1_tab0_276 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_276
+DROP VIEW IF EXISTS view_2_tab0_276 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_276
+DROP VIEW IF EXISTS view_3_tab0_276 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22805,13 +22805,13 @@ SELECT pk FROM tab1 WHERE col3 IN (395,213)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_276
+DROP VIEW IF EXISTS view_1_tab1_276 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_276
+DROP VIEW IF EXISTS view_2_tab1_276 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_276
+DROP VIEW IF EXISTS view_3_tab1_276 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22897,13 +22897,13 @@ SELECT pk FROM tab2 WHERE col3 IN (395,213)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_276
+DROP VIEW IF EXISTS view_1_tab2_276 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_276
+DROP VIEW IF EXISTS view_2_tab2_276 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_276
+DROP VIEW IF EXISTS view_3_tab2_276 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22989,13 +22989,13 @@ SELECT pk FROM tab3 WHERE col3 IN (395,213)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_276
+DROP VIEW IF EXISTS view_1_tab3_276 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_276
+DROP VIEW IF EXISTS view_2_tab3_276 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_276
+DROP VIEW IF EXISTS view_3_tab3_276 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23081,13 +23081,13 @@ SELECT pk FROM tab4 WHERE col3 IN (395,213)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_276
+DROP VIEW IF EXISTS view_1_tab4_276 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_276
+DROP VIEW IF EXISTS view_2_tab4_276 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_276
+DROP VIEW IF EXISTS view_3_tab4_276 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23178,13 +23178,13 @@ SELECT pk FROM tab0 WHERE ((col3 < 387))
 41 values hashing to 6c25c3ab37aaea35892735f40e824582
 
 statement ok
-DROP VIEW view_1_tab0_277
+DROP VIEW IF EXISTS view_1_tab0_277 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_277
+DROP VIEW IF EXISTS view_2_tab0_277 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_277
+DROP VIEW IF EXISTS view_3_tab0_277 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23275,13 +23275,13 @@ SELECT pk FROM tab1 WHERE ((col3 < 387))
 41 values hashing to 6c25c3ab37aaea35892735f40e824582
 
 statement ok
-DROP VIEW view_1_tab1_277
+DROP VIEW IF EXISTS view_1_tab1_277 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_277
+DROP VIEW IF EXISTS view_2_tab1_277 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_277
+DROP VIEW IF EXISTS view_3_tab1_277 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23372,13 +23372,13 @@ SELECT pk FROM tab2 WHERE ((col3 < 387))
 41 values hashing to 6c25c3ab37aaea35892735f40e824582
 
 statement ok
-DROP VIEW view_1_tab2_277
+DROP VIEW IF EXISTS view_1_tab2_277 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_277
+DROP VIEW IF EXISTS view_2_tab2_277 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_277
+DROP VIEW IF EXISTS view_3_tab2_277 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23469,13 +23469,13 @@ SELECT pk FROM tab3 WHERE ((col3 < 387))
 41 values hashing to 6c25c3ab37aaea35892735f40e824582
 
 statement ok
-DROP VIEW view_1_tab3_277
+DROP VIEW IF EXISTS view_1_tab3_277 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_277
+DROP VIEW IF EXISTS view_2_tab3_277 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_277
+DROP VIEW IF EXISTS view_3_tab3_277 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23566,13 +23566,13 @@ SELECT pk FROM tab4 WHERE ((col3 < 387))
 41 values hashing to 6c25c3ab37aaea35892735f40e824582
 
 statement ok
-DROP VIEW view_1_tab4_277
+DROP VIEW IF EXISTS view_1_tab4_277 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_277
+DROP VIEW IF EXISTS view_2_tab4_277 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_277
+DROP VIEW IF EXISTS view_3_tab4_277 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23663,13 +23663,13 @@ SELECT pk FROM tab0 WHERE (col3 >= 549)
 43 values hashing to 1239463f5e7ad0b7eec0ceedbce195cd
 
 statement ok
-DROP VIEW view_1_tab0_278
+DROP VIEW IF EXISTS view_1_tab0_278 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_278
+DROP VIEW IF EXISTS view_2_tab0_278 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_278
+DROP VIEW IF EXISTS view_3_tab0_278 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23760,13 +23760,13 @@ SELECT pk FROM tab1 WHERE (col3 >= 549)
 43 values hashing to 1239463f5e7ad0b7eec0ceedbce195cd
 
 statement ok
-DROP VIEW view_1_tab1_278
+DROP VIEW IF EXISTS view_1_tab1_278 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_278
+DROP VIEW IF EXISTS view_2_tab1_278 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_278
+DROP VIEW IF EXISTS view_3_tab1_278 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23857,13 +23857,13 @@ SELECT pk FROM tab2 WHERE (col3 >= 549)
 43 values hashing to 1239463f5e7ad0b7eec0ceedbce195cd
 
 statement ok
-DROP VIEW view_1_tab2_278
+DROP VIEW IF EXISTS view_1_tab2_278 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_278
+DROP VIEW IF EXISTS view_2_tab2_278 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_278
+DROP VIEW IF EXISTS view_3_tab2_278 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23954,13 +23954,13 @@ SELECT pk FROM tab3 WHERE (col3 >= 549)
 43 values hashing to 1239463f5e7ad0b7eec0ceedbce195cd
 
 statement ok
-DROP VIEW view_1_tab3_278
+DROP VIEW IF EXISTS view_1_tab3_278 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_278
+DROP VIEW IF EXISTS view_2_tab3_278 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_278
+DROP VIEW IF EXISTS view_3_tab3_278 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24051,13 +24051,13 @@ SELECT pk FROM tab4 WHERE (col3 >= 549)
 43 values hashing to 1239463f5e7ad0b7eec0ceedbce195cd
 
 statement ok
-DROP VIEW view_1_tab4_278
+DROP VIEW IF EXISTS view_1_tab4_278 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_278
+DROP VIEW IF EXISTS view_2_tab4_278 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_278
+DROP VIEW IF EXISTS view_3_tab4_278 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24148,13 +24148,13 @@ SELECT pk FROM tab0 WHERE (col4 > 48.26 AND col1 > 575.40)
 44 values hashing to 9aec7282e06ecfc4a058238d6290079b
 
 statement ok
-DROP VIEW view_1_tab0_279
+DROP VIEW IF EXISTS view_1_tab0_279 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_279
+DROP VIEW IF EXISTS view_2_tab0_279 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_279
+DROP VIEW IF EXISTS view_3_tab0_279 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24245,13 +24245,13 @@ SELECT pk FROM tab1 WHERE (col4 > 48.26 AND col1 > 575.40)
 44 values hashing to 9aec7282e06ecfc4a058238d6290079b
 
 statement ok
-DROP VIEW view_1_tab1_279
+DROP VIEW IF EXISTS view_1_tab1_279 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_279
+DROP VIEW IF EXISTS view_2_tab1_279 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_279
+DROP VIEW IF EXISTS view_3_tab1_279 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24342,13 +24342,13 @@ SELECT pk FROM tab2 WHERE (col4 > 48.26 AND col1 > 575.40)
 44 values hashing to 9aec7282e06ecfc4a058238d6290079b
 
 statement ok
-DROP VIEW view_1_tab2_279
+DROP VIEW IF EXISTS view_1_tab2_279 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_279
+DROP VIEW IF EXISTS view_2_tab2_279 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_279
+DROP VIEW IF EXISTS view_3_tab2_279 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24439,13 +24439,13 @@ SELECT pk FROM tab3 WHERE (col4 > 48.26 AND col1 > 575.40)
 44 values hashing to 9aec7282e06ecfc4a058238d6290079b
 
 statement ok
-DROP VIEW view_1_tab3_279
+DROP VIEW IF EXISTS view_1_tab3_279 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_279
+DROP VIEW IF EXISTS view_2_tab3_279 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_279
+DROP VIEW IF EXISTS view_3_tab3_279 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24536,13 +24536,13 @@ SELECT pk FROM tab4 WHERE (col4 > 48.26 AND col1 > 575.40)
 44 values hashing to 9aec7282e06ecfc4a058238d6290079b
 
 statement ok
-DROP VIEW view_1_tab4_279
+DROP VIEW IF EXISTS view_1_tab4_279 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_279
+DROP VIEW IF EXISTS view_2_tab4_279 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_279
+DROP VIEW IF EXISTS view_3_tab4_279 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24633,13 +24633,13 @@ SELECT pk FROM tab0 WHERE (col1 < 966.10)
 93 values hashing to 83618884a27f5c13e71c50d7b3329eb8
 
 statement ok
-DROP VIEW view_1_tab0_280
+DROP VIEW IF EXISTS view_1_tab0_280 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_280
+DROP VIEW IF EXISTS view_2_tab0_280 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_280
+DROP VIEW IF EXISTS view_3_tab0_280 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24730,13 +24730,13 @@ SELECT pk FROM tab1 WHERE (col1 < 966.10)
 93 values hashing to 83618884a27f5c13e71c50d7b3329eb8
 
 statement ok
-DROP VIEW view_1_tab1_280
+DROP VIEW IF EXISTS view_1_tab1_280 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_280
+DROP VIEW IF EXISTS view_2_tab1_280 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_280
+DROP VIEW IF EXISTS view_3_tab1_280 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24827,13 +24827,13 @@ SELECT pk FROM tab2 WHERE (col1 < 966.10)
 93 values hashing to 83618884a27f5c13e71c50d7b3329eb8
 
 statement ok
-DROP VIEW view_1_tab2_280
+DROP VIEW IF EXISTS view_1_tab2_280 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_280
+DROP VIEW IF EXISTS view_2_tab2_280 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_280
+DROP VIEW IF EXISTS view_3_tab2_280 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24924,13 +24924,13 @@ SELECT pk FROM tab3 WHERE (col1 < 966.10)
 93 values hashing to 83618884a27f5c13e71c50d7b3329eb8
 
 statement ok
-DROP VIEW view_1_tab3_280
+DROP VIEW IF EXISTS view_1_tab3_280 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_280
+DROP VIEW IF EXISTS view_2_tab3_280 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_280
+DROP VIEW IF EXISTS view_3_tab3_280 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25021,13 +25021,13 @@ SELECT pk FROM tab4 WHERE (col1 < 966.10)
 93 values hashing to 83618884a27f5c13e71c50d7b3329eb8
 
 statement ok
-DROP VIEW view_1_tab4_280
+DROP VIEW IF EXISTS view_1_tab4_280 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_280
+DROP VIEW IF EXISTS view_2_tab4_280 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_280
+DROP VIEW IF EXISTS view_3_tab4_280 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25118,13 +25118,13 @@ SELECT pk FROM tab0 WHERE col3 < 679
 73 values hashing to 302aa1540155a6f7993e9241e0116771
 
 statement ok
-DROP VIEW view_1_tab0_282
+DROP VIEW IF EXISTS view_1_tab0_282 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_282
+DROP VIEW IF EXISTS view_2_tab0_282 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_282
+DROP VIEW IF EXISTS view_3_tab0_282 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25215,13 +25215,13 @@ SELECT pk FROM tab1 WHERE col3 < 679
 73 values hashing to 302aa1540155a6f7993e9241e0116771
 
 statement ok
-DROP VIEW view_1_tab1_282
+DROP VIEW IF EXISTS view_1_tab1_282 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_282
+DROP VIEW IF EXISTS view_2_tab1_282 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_282
+DROP VIEW IF EXISTS view_3_tab1_282 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25312,13 +25312,13 @@ SELECT pk FROM tab2 WHERE col3 < 679
 73 values hashing to 302aa1540155a6f7993e9241e0116771
 
 statement ok
-DROP VIEW view_1_tab2_282
+DROP VIEW IF EXISTS view_1_tab2_282 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_282
+DROP VIEW IF EXISTS view_2_tab2_282 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_282
+DROP VIEW IF EXISTS view_3_tab2_282 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25409,13 +25409,13 @@ SELECT pk FROM tab3 WHERE col3 < 679
 73 values hashing to 302aa1540155a6f7993e9241e0116771
 
 statement ok
-DROP VIEW view_1_tab3_282
+DROP VIEW IF EXISTS view_1_tab3_282 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_282
+DROP VIEW IF EXISTS view_2_tab3_282 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_282
+DROP VIEW IF EXISTS view_3_tab3_282 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25506,13 +25506,13 @@ SELECT pk FROM tab4 WHERE col3 < 679
 73 values hashing to 302aa1540155a6f7993e9241e0116771
 
 statement ok
-DROP VIEW view_1_tab4_282
+DROP VIEW IF EXISTS view_1_tab4_282 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_282
+DROP VIEW IF EXISTS view_2_tab4_282 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_282
+DROP VIEW IF EXISTS view_3_tab4_282 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25598,13 +25598,13 @@ SELECT pk FROM tab0 WHERE col3 = 999 AND col0 > 745 OR (((col3 = 824)))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_283
+DROP VIEW IF EXISTS view_1_tab0_283 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_283
+DROP VIEW IF EXISTS view_2_tab0_283 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_283
+DROP VIEW IF EXISTS view_3_tab0_283 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25690,13 +25690,13 @@ SELECT pk FROM tab1 WHERE col3 = 999 AND col0 > 745 OR (((col3 = 824)))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_283
+DROP VIEW IF EXISTS view_1_tab1_283 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_283
+DROP VIEW IF EXISTS view_2_tab1_283 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_283
+DROP VIEW IF EXISTS view_3_tab1_283 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25782,13 +25782,13 @@ SELECT pk FROM tab2 WHERE col3 = 999 AND col0 > 745 OR (((col3 = 824)))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_283
+DROP VIEW IF EXISTS view_1_tab2_283 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_283
+DROP VIEW IF EXISTS view_2_tab2_283 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_283
+DROP VIEW IF EXISTS view_3_tab2_283 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25874,13 +25874,13 @@ SELECT pk FROM tab3 WHERE col3 = 999 AND col0 > 745 OR (((col3 = 824)))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_283
+DROP VIEW IF EXISTS view_1_tab3_283 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_283
+DROP VIEW IF EXISTS view_2_tab3_283 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_283
+DROP VIEW IF EXISTS view_3_tab3_283 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25966,13 +25966,13 @@ SELECT pk FROM tab4 WHERE col3 = 999 AND col0 > 745 OR (((col3 = 824)))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_283
+DROP VIEW IF EXISTS view_1_tab4_283 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_283
+DROP VIEW IF EXISTS view_2_tab4_283 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_283
+DROP VIEW IF EXISTS view_3_tab4_283 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26058,13 +26058,13 @@ SELECT pk FROM tab0 WHERE ((col0 BETWEEN 534 AND 52)) AND (((col1 > 960.52)) AND
 ----
 
 statement ok
-DROP VIEW view_1_tab0_285
+DROP VIEW IF EXISTS view_1_tab0_285 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_285
+DROP VIEW IF EXISTS view_2_tab0_285 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_285
+DROP VIEW IF EXISTS view_3_tab0_285 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26150,13 +26150,13 @@ SELECT pk FROM tab1 WHERE ((col0 BETWEEN 534 AND 52)) AND (((col1 > 960.52)) AND
 ----
 
 statement ok
-DROP VIEW view_1_tab1_285
+DROP VIEW IF EXISTS view_1_tab1_285 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_285
+DROP VIEW IF EXISTS view_2_tab1_285 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_285
+DROP VIEW IF EXISTS view_3_tab1_285 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26242,13 +26242,13 @@ SELECT pk FROM tab2 WHERE ((col0 BETWEEN 534 AND 52)) AND (((col1 > 960.52)) AND
 ----
 
 statement ok
-DROP VIEW view_1_tab2_285
+DROP VIEW IF EXISTS view_1_tab2_285 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_285
+DROP VIEW IF EXISTS view_2_tab2_285 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_285
+DROP VIEW IF EXISTS view_3_tab2_285 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26334,13 +26334,13 @@ SELECT pk FROM tab3 WHERE ((col0 BETWEEN 534 AND 52)) AND (((col1 > 960.52)) AND
 ----
 
 statement ok
-DROP VIEW view_1_tab3_285
+DROP VIEW IF EXISTS view_1_tab3_285 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_285
+DROP VIEW IF EXISTS view_2_tab3_285 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_285
+DROP VIEW IF EXISTS view_3_tab3_285 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26426,13 +26426,13 @@ SELECT pk FROM tab4 WHERE ((col0 BETWEEN 534 AND 52)) AND (((col1 > 960.52)) AND
 ----
 
 statement ok
-DROP VIEW view_1_tab4_285
+DROP VIEW IF EXISTS view_1_tab4_285 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_285
+DROP VIEW IF EXISTS view_2_tab4_285 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_285
+DROP VIEW IF EXISTS view_3_tab4_285 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26518,13 +26518,13 @@ SELECT pk FROM tab0 WHERE (col1 = 664.28 AND col0 = 338 AND (col3 = 35 AND ((col
 ----
 
 statement ok
-DROP VIEW view_1_tab0_286
+DROP VIEW IF EXISTS view_1_tab0_286 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_286
+DROP VIEW IF EXISTS view_2_tab0_286 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_286
+DROP VIEW IF EXISTS view_3_tab0_286 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26610,13 +26610,13 @@ SELECT pk FROM tab1 WHERE (col1 = 664.28 AND col0 = 338 AND (col3 = 35 AND ((col
 ----
 
 statement ok
-DROP VIEW view_1_tab1_286
+DROP VIEW IF EXISTS view_1_tab1_286 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_286
+DROP VIEW IF EXISTS view_2_tab1_286 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_286
+DROP VIEW IF EXISTS view_3_tab1_286 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26702,13 +26702,13 @@ SELECT pk FROM tab2 WHERE (col1 = 664.28 AND col0 = 338 AND (col3 = 35 AND ((col
 ----
 
 statement ok
-DROP VIEW view_1_tab2_286
+DROP VIEW IF EXISTS view_1_tab2_286 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_286
+DROP VIEW IF EXISTS view_2_tab2_286 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_286
+DROP VIEW IF EXISTS view_3_tab2_286 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26794,13 +26794,13 @@ SELECT pk FROM tab3 WHERE (col1 = 664.28 AND col0 = 338 AND (col3 = 35 AND ((col
 ----
 
 statement ok
-DROP VIEW view_1_tab3_286
+DROP VIEW IF EXISTS view_1_tab3_286 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_286
+DROP VIEW IF EXISTS view_2_tab3_286 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_286
+DROP VIEW IF EXISTS view_3_tab3_286 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26886,13 +26886,13 @@ SELECT pk FROM tab4 WHERE (col1 = 664.28 AND col0 = 338 AND (col3 = 35 AND ((col
 ----
 
 statement ok
-DROP VIEW view_1_tab4_286
+DROP VIEW IF EXISTS view_1_tab4_286 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_286
+DROP VIEW IF EXISTS view_2_tab4_286 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_286
+DROP VIEW IF EXISTS view_3_tab4_286 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26983,13 +26983,13 @@ SELECT pk FROM tab0 WHERE col0 > 722
 27 values hashing to 7b9fa0a7c0f9200ba37d39881c88ef96
 
 statement ok
-DROP VIEW view_1_tab0_287
+DROP VIEW IF EXISTS view_1_tab0_287 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_287
+DROP VIEW IF EXISTS view_2_tab0_287 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_287
+DROP VIEW IF EXISTS view_3_tab0_287 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27080,13 +27080,13 @@ SELECT pk FROM tab1 WHERE col0 > 722
 27 values hashing to 7b9fa0a7c0f9200ba37d39881c88ef96
 
 statement ok
-DROP VIEW view_1_tab1_287
+DROP VIEW IF EXISTS view_1_tab1_287 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_287
+DROP VIEW IF EXISTS view_2_tab1_287 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_287
+DROP VIEW IF EXISTS view_3_tab1_287 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27177,13 +27177,13 @@ SELECT pk FROM tab2 WHERE col0 > 722
 27 values hashing to 7b9fa0a7c0f9200ba37d39881c88ef96
 
 statement ok
-DROP VIEW view_1_tab2_287
+DROP VIEW IF EXISTS view_1_tab2_287 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_287
+DROP VIEW IF EXISTS view_2_tab2_287 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_287
+DROP VIEW IF EXISTS view_3_tab2_287 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27274,13 +27274,13 @@ SELECT pk FROM tab3 WHERE col0 > 722
 27 values hashing to 7b9fa0a7c0f9200ba37d39881c88ef96
 
 statement ok
-DROP VIEW view_1_tab3_287
+DROP VIEW IF EXISTS view_1_tab3_287 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_287
+DROP VIEW IF EXISTS view_2_tab3_287 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_287
+DROP VIEW IF EXISTS view_3_tab3_287 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27371,13 +27371,13 @@ SELECT pk FROM tab4 WHERE col0 > 722
 27 values hashing to 7b9fa0a7c0f9200ba37d39881c88ef96
 
 statement ok
-DROP VIEW view_1_tab4_287
+DROP VIEW IF EXISTS view_1_tab4_287 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_287
+DROP VIEW IF EXISTS view_2_tab4_287 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_287
+DROP VIEW IF EXISTS view_3_tab4_287 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27470,13 +27470,13 @@ SELECT pk FROM tab0 WHERE (col0 < 985 OR col0 < 304 AND col1 < 525.45)
 99 values hashing to 95cfb44363c1cb762ec04a82427ef49d
 
 statement ok
-DROP VIEW view_1_tab0_288
+DROP VIEW IF EXISTS view_1_tab0_288 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_288
+DROP VIEW IF EXISTS view_2_tab0_288 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_288
+DROP VIEW IF EXISTS view_3_tab0_288 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27569,13 +27569,13 @@ SELECT pk FROM tab1 WHERE (col0 < 985 OR col0 < 304 AND col1 < 525.45)
 99 values hashing to 95cfb44363c1cb762ec04a82427ef49d
 
 statement ok
-DROP VIEW view_1_tab1_288
+DROP VIEW IF EXISTS view_1_tab1_288 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_288
+DROP VIEW IF EXISTS view_2_tab1_288 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_288
+DROP VIEW IF EXISTS view_3_tab1_288 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27668,13 +27668,13 @@ SELECT pk FROM tab2 WHERE (col0 < 985 OR col0 < 304 AND col1 < 525.45)
 99 values hashing to 95cfb44363c1cb762ec04a82427ef49d
 
 statement ok
-DROP VIEW view_1_tab2_288
+DROP VIEW IF EXISTS view_1_tab2_288 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_288
+DROP VIEW IF EXISTS view_2_tab2_288 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_288
+DROP VIEW IF EXISTS view_3_tab2_288 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27767,13 +27767,13 @@ SELECT pk FROM tab3 WHERE (col0 < 985 OR col0 < 304 AND col1 < 525.45)
 99 values hashing to 95cfb44363c1cb762ec04a82427ef49d
 
 statement ok
-DROP VIEW view_1_tab3_288
+DROP VIEW IF EXISTS view_1_tab3_288 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_288
+DROP VIEW IF EXISTS view_2_tab3_288 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_288
+DROP VIEW IF EXISTS view_3_tab3_288 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27866,13 +27866,13 @@ SELECT pk FROM tab4 WHERE (col0 < 985 OR col0 < 304 AND col1 < 525.45)
 99 values hashing to 95cfb44363c1cb762ec04a82427ef49d
 
 statement ok
-DROP VIEW view_1_tab4_288
+DROP VIEW IF EXISTS view_1_tab4_288 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_288
+DROP VIEW IF EXISTS view_2_tab4_288 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_288
+DROP VIEW IF EXISTS view_3_tab4_288 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27963,13 +27963,13 @@ SELECT pk FROM tab0 WHERE col0 <= 642 AND col3 > 287 OR col1 <= 864.75 OR ((col0
 93 values hashing to 99c99a56d2c39a0275b0b1f7c6348235
 
 statement ok
-DROP VIEW view_1_tab0_289
+DROP VIEW IF EXISTS view_1_tab0_289 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_289
+DROP VIEW IF EXISTS view_2_tab0_289 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_289
+DROP VIEW IF EXISTS view_3_tab0_289 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28060,13 +28060,13 @@ SELECT pk FROM tab1 WHERE col0 <= 642 AND col3 > 287 OR col1 <= 864.75 OR ((col0
 93 values hashing to 99c99a56d2c39a0275b0b1f7c6348235
 
 statement ok
-DROP VIEW view_1_tab1_289
+DROP VIEW IF EXISTS view_1_tab1_289 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_289
+DROP VIEW IF EXISTS view_2_tab1_289 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_289
+DROP VIEW IF EXISTS view_3_tab1_289 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28157,13 +28157,13 @@ SELECT pk FROM tab2 WHERE col0 <= 642 AND col3 > 287 OR col1 <= 864.75 OR ((col0
 93 values hashing to 99c99a56d2c39a0275b0b1f7c6348235
 
 statement ok
-DROP VIEW view_1_tab2_289
+DROP VIEW IF EXISTS view_1_tab2_289 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_289
+DROP VIEW IF EXISTS view_2_tab2_289 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_289
+DROP VIEW IF EXISTS view_3_tab2_289 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28254,13 +28254,13 @@ SELECT pk FROM tab3 WHERE col0 <= 642 AND col3 > 287 OR col1 <= 864.75 OR ((col0
 93 values hashing to 99c99a56d2c39a0275b0b1f7c6348235
 
 statement ok
-DROP VIEW view_1_tab3_289
+DROP VIEW IF EXISTS view_1_tab3_289 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_289
+DROP VIEW IF EXISTS view_2_tab3_289 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_289
+DROP VIEW IF EXISTS view_3_tab3_289 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28351,13 +28351,13 @@ SELECT pk FROM tab4 WHERE col0 <= 642 AND col3 > 287 OR col1 <= 864.75 OR ((col0
 93 values hashing to 99c99a56d2c39a0275b0b1f7c6348235
 
 statement ok
-DROP VIEW view_1_tab4_289
+DROP VIEW IF EXISTS view_1_tab4_289 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_289
+DROP VIEW IF EXISTS view_2_tab4_289 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_289
+DROP VIEW IF EXISTS view_3_tab4_289 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28446,13 +28446,13 @@ SELECT pk FROM tab0 WHERE (((col3 <= 612) OR (((col3 IS NULL)) OR col0 >= 43) AN
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab0_290
+DROP VIEW IF EXISTS view_1_tab0_290 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_290
+DROP VIEW IF EXISTS view_2_tab0_290 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_290
+DROP VIEW IF EXISTS view_3_tab0_290 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28541,13 +28541,13 @@ SELECT pk FROM tab1 WHERE (((col3 <= 612) OR (((col3 IS NULL)) OR col0 >= 43) AN
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab1_290
+DROP VIEW IF EXISTS view_1_tab1_290 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_290
+DROP VIEW IF EXISTS view_2_tab1_290 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_290
+DROP VIEW IF EXISTS view_3_tab1_290 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28636,13 +28636,13 @@ SELECT pk FROM tab2 WHERE (((col3 <= 612) OR (((col3 IS NULL)) OR col0 >= 43) AN
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab2_290
+DROP VIEW IF EXISTS view_1_tab2_290 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_290
+DROP VIEW IF EXISTS view_2_tab2_290 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_290
+DROP VIEW IF EXISTS view_3_tab2_290 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28731,13 +28731,13 @@ SELECT pk FROM tab3 WHERE (((col3 <= 612) OR (((col3 IS NULL)) OR col0 >= 43) AN
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab3_290
+DROP VIEW IF EXISTS view_1_tab3_290 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_290
+DROP VIEW IF EXISTS view_2_tab3_290 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_290
+DROP VIEW IF EXISTS view_3_tab3_290 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28826,13 +28826,13 @@ SELECT pk FROM tab4 WHERE (((col3 <= 612) OR (((col3 IS NULL)) OR col0 >= 43) AN
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab4_290
+DROP VIEW IF EXISTS view_1_tab4_290 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_290
+DROP VIEW IF EXISTS view_2_tab4_290 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_290
+DROP VIEW IF EXISTS view_3_tab4_290 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28923,13 +28923,13 @@ SELECT pk FROM tab0 WHERE (col3 >= 584 OR col3 <= 85)
 47 values hashing to 50b5dc04cbfeb74a0a833ccec72cfe75
 
 statement ok
-DROP VIEW view_1_tab0_291
+DROP VIEW IF EXISTS view_1_tab0_291 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_291
+DROP VIEW IF EXISTS view_2_tab0_291 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_291
+DROP VIEW IF EXISTS view_3_tab0_291 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29020,13 +29020,13 @@ SELECT pk FROM tab1 WHERE (col3 >= 584 OR col3 <= 85)
 47 values hashing to 50b5dc04cbfeb74a0a833ccec72cfe75
 
 statement ok
-DROP VIEW view_1_tab1_291
+DROP VIEW IF EXISTS view_1_tab1_291 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_291
+DROP VIEW IF EXISTS view_2_tab1_291 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_291
+DROP VIEW IF EXISTS view_3_tab1_291 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29117,13 +29117,13 @@ SELECT pk FROM tab2 WHERE (col3 >= 584 OR col3 <= 85)
 47 values hashing to 50b5dc04cbfeb74a0a833ccec72cfe75
 
 statement ok
-DROP VIEW view_1_tab2_291
+DROP VIEW IF EXISTS view_1_tab2_291 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_291
+DROP VIEW IF EXISTS view_2_tab2_291 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_291
+DROP VIEW IF EXISTS view_3_tab2_291 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29214,13 +29214,13 @@ SELECT pk FROM tab3 WHERE (col3 >= 584 OR col3 <= 85)
 47 values hashing to 50b5dc04cbfeb74a0a833ccec72cfe75
 
 statement ok
-DROP VIEW view_1_tab3_291
+DROP VIEW IF EXISTS view_1_tab3_291 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_291
+DROP VIEW IF EXISTS view_2_tab3_291 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_291
+DROP VIEW IF EXISTS view_3_tab3_291 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29311,13 +29311,13 @@ SELECT pk FROM tab4 WHERE (col3 >= 584 OR col3 <= 85)
 47 values hashing to 50b5dc04cbfeb74a0a833ccec72cfe75
 
 statement ok
-DROP VIEW view_1_tab4_291
+DROP VIEW IF EXISTS view_1_tab4_291 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_291
+DROP VIEW IF EXISTS view_2_tab4_291 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_291
+DROP VIEW IF EXISTS view_3_tab4_291 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29408,13 +29408,13 @@ SELECT pk FROM tab0 WHERE (col3 >= 808 AND col0 < 749 AND col1 > 203.77 OR ((col
 49 values hashing to b4c3b711218c3dbcb058f6c694e28d20
 
 statement ok
-DROP VIEW view_1_tab0_292
+DROP VIEW IF EXISTS view_1_tab0_292 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_292
+DROP VIEW IF EXISTS view_2_tab0_292 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_292
+DROP VIEW IF EXISTS view_3_tab0_292 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29505,13 +29505,13 @@ SELECT pk FROM tab1 WHERE (col3 >= 808 AND col0 < 749 AND col1 > 203.77 OR ((col
 49 values hashing to b4c3b711218c3dbcb058f6c694e28d20
 
 statement ok
-DROP VIEW view_1_tab1_292
+DROP VIEW IF EXISTS view_1_tab1_292 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_292
+DROP VIEW IF EXISTS view_2_tab1_292 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_292
+DROP VIEW IF EXISTS view_3_tab1_292 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29602,13 +29602,13 @@ SELECT pk FROM tab2 WHERE (col3 >= 808 AND col0 < 749 AND col1 > 203.77 OR ((col
 49 values hashing to b4c3b711218c3dbcb058f6c694e28d20
 
 statement ok
-DROP VIEW view_1_tab2_292
+DROP VIEW IF EXISTS view_1_tab2_292 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_292
+DROP VIEW IF EXISTS view_2_tab2_292 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_292
+DROP VIEW IF EXISTS view_3_tab2_292 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29699,13 +29699,13 @@ SELECT pk FROM tab3 WHERE (col3 >= 808 AND col0 < 749 AND col1 > 203.77 OR ((col
 49 values hashing to b4c3b711218c3dbcb058f6c694e28d20
 
 statement ok
-DROP VIEW view_1_tab3_292
+DROP VIEW IF EXISTS view_1_tab3_292 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_292
+DROP VIEW IF EXISTS view_2_tab3_292 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_292
+DROP VIEW IF EXISTS view_3_tab3_292 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29796,13 +29796,13 @@ SELECT pk FROM tab4 WHERE (col3 >= 808 AND col0 < 749 AND col1 > 203.77 OR ((col
 49 values hashing to b4c3b711218c3dbcb058f6c694e28d20
 
 statement ok
-DROP VIEW view_1_tab4_292
+DROP VIEW IF EXISTS view_1_tab4_292 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_292
+DROP VIEW IF EXISTS view_2_tab4_292 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_292
+DROP VIEW IF EXISTS view_3_tab4_292 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29893,13 +29893,13 @@ SELECT pk FROM tab0 WHERE col3 >= 328
 65 values hashing to 21ed37aacd4a5bd30d78762f3faff5e3
 
 statement ok
-DROP VIEW view_1_tab0_293
+DROP VIEW IF EXISTS view_1_tab0_293 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_293
+DROP VIEW IF EXISTS view_2_tab0_293 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_293
+DROP VIEW IF EXISTS view_3_tab0_293 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29990,13 +29990,13 @@ SELECT pk FROM tab1 WHERE col3 >= 328
 65 values hashing to 21ed37aacd4a5bd30d78762f3faff5e3
 
 statement ok
-DROP VIEW view_1_tab1_293
+DROP VIEW IF EXISTS view_1_tab1_293 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_293
+DROP VIEW IF EXISTS view_2_tab1_293 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_293
+DROP VIEW IF EXISTS view_3_tab1_293 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30087,13 +30087,13 @@ SELECT pk FROM tab2 WHERE col3 >= 328
 65 values hashing to 21ed37aacd4a5bd30d78762f3faff5e3
 
 statement ok
-DROP VIEW view_1_tab2_293
+DROP VIEW IF EXISTS view_1_tab2_293 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_293
+DROP VIEW IF EXISTS view_2_tab2_293 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_293
+DROP VIEW IF EXISTS view_3_tab2_293 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30184,13 +30184,13 @@ SELECT pk FROM tab3 WHERE col3 >= 328
 65 values hashing to 21ed37aacd4a5bd30d78762f3faff5e3
 
 statement ok
-DROP VIEW view_1_tab3_293
+DROP VIEW IF EXISTS view_1_tab3_293 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_293
+DROP VIEW IF EXISTS view_2_tab3_293 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_293
+DROP VIEW IF EXISTS view_3_tab3_293 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30281,13 +30281,13 @@ SELECT pk FROM tab4 WHERE col3 >= 328
 65 values hashing to 21ed37aacd4a5bd30d78762f3faff5e3
 
 statement ok
-DROP VIEW view_1_tab4_293
+DROP VIEW IF EXISTS view_1_tab4_293 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_293
+DROP VIEW IF EXISTS view_2_tab4_293 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_293
+DROP VIEW IF EXISTS view_3_tab4_293 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30378,13 +30378,13 @@ SELECT pk FROM tab0 WHERE col3 <= 687 AND col3 >= 393 OR col1 = 192.1
 33 values hashing to 762e7098997b7d2cb04de7a17d92a260
 
 statement ok
-DROP VIEW view_1_tab0_294
+DROP VIEW IF EXISTS view_1_tab0_294 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_294
+DROP VIEW IF EXISTS view_2_tab0_294 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_294
+DROP VIEW IF EXISTS view_3_tab0_294 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30475,13 +30475,13 @@ SELECT pk FROM tab1 WHERE col3 <= 687 AND col3 >= 393 OR col1 = 192.1
 33 values hashing to 762e7098997b7d2cb04de7a17d92a260
 
 statement ok
-DROP VIEW view_1_tab1_294
+DROP VIEW IF EXISTS view_1_tab1_294 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_294
+DROP VIEW IF EXISTS view_2_tab1_294 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_294
+DROP VIEW IF EXISTS view_3_tab1_294 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30572,13 +30572,13 @@ SELECT pk FROM tab2 WHERE col3 <= 687 AND col3 >= 393 OR col1 = 192.1
 33 values hashing to 762e7098997b7d2cb04de7a17d92a260
 
 statement ok
-DROP VIEW view_1_tab2_294
+DROP VIEW IF EXISTS view_1_tab2_294 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_294
+DROP VIEW IF EXISTS view_2_tab2_294 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_294
+DROP VIEW IF EXISTS view_3_tab2_294 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30669,13 +30669,13 @@ SELECT pk FROM tab3 WHERE col3 <= 687 AND col3 >= 393 OR col1 = 192.1
 33 values hashing to 762e7098997b7d2cb04de7a17d92a260
 
 statement ok
-DROP VIEW view_1_tab3_294
+DROP VIEW IF EXISTS view_1_tab3_294 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_294
+DROP VIEW IF EXISTS view_2_tab3_294 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_294
+DROP VIEW IF EXISTS view_3_tab3_294 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30766,13 +30766,13 @@ SELECT pk FROM tab4 WHERE col3 <= 687 AND col3 >= 393 OR col1 = 192.1
 33 values hashing to 762e7098997b7d2cb04de7a17d92a260
 
 statement ok
-DROP VIEW view_1_tab4_294
+DROP VIEW IF EXISTS view_1_tab4_294 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_294
+DROP VIEW IF EXISTS view_2_tab4_294 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_294
+DROP VIEW IF EXISTS view_3_tab4_294 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30863,13 +30863,13 @@ SELECT pk FROM tab0 WHERE col0 >= 736 OR col0 >= 503 OR col0 >= 107
 91 values hashing to 5465a924e6d69737fcb0a260c38e450d
 
 statement ok
-DROP VIEW view_1_tab0_295
+DROP VIEW IF EXISTS view_1_tab0_295 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_295
+DROP VIEW IF EXISTS view_2_tab0_295 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_295
+DROP VIEW IF EXISTS view_3_tab0_295 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30960,13 +30960,13 @@ SELECT pk FROM tab1 WHERE col0 >= 736 OR col0 >= 503 OR col0 >= 107
 91 values hashing to 5465a924e6d69737fcb0a260c38e450d
 
 statement ok
-DROP VIEW view_1_tab1_295
+DROP VIEW IF EXISTS view_1_tab1_295 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_295
+DROP VIEW IF EXISTS view_2_tab1_295 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_295
+DROP VIEW IF EXISTS view_3_tab1_295 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31057,13 +31057,13 @@ SELECT pk FROM tab2 WHERE col0 >= 736 OR col0 >= 503 OR col0 >= 107
 91 values hashing to 5465a924e6d69737fcb0a260c38e450d
 
 statement ok
-DROP VIEW view_1_tab2_295
+DROP VIEW IF EXISTS view_1_tab2_295 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_295
+DROP VIEW IF EXISTS view_2_tab2_295 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_295
+DROP VIEW IF EXISTS view_3_tab2_295 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31154,13 +31154,13 @@ SELECT pk FROM tab3 WHERE col0 >= 736 OR col0 >= 503 OR col0 >= 107
 91 values hashing to 5465a924e6d69737fcb0a260c38e450d
 
 statement ok
-DROP VIEW view_1_tab3_295
+DROP VIEW IF EXISTS view_1_tab3_295 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_295
+DROP VIEW IF EXISTS view_2_tab3_295 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_295
+DROP VIEW IF EXISTS view_3_tab3_295 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31251,13 +31251,13 @@ SELECT pk FROM tab4 WHERE col0 >= 736 OR col0 >= 503 OR col0 >= 107
 91 values hashing to 5465a924e6d69737fcb0a260c38e450d
 
 statement ok
-DROP VIEW view_1_tab4_295
+DROP VIEW IF EXISTS view_1_tab4_295 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_295
+DROP VIEW IF EXISTS view_2_tab4_295 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_295
+DROP VIEW IF EXISTS view_3_tab4_295 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31348,13 +31348,13 @@ SELECT pk FROM tab0 WHERE col4 >= 265.28
 78 values hashing to bf177f5883365d40f61d7a55facb89a6
 
 statement ok
-DROP VIEW view_1_tab0_296
+DROP VIEW IF EXISTS view_1_tab0_296 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_296
+DROP VIEW IF EXISTS view_2_tab0_296 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_296
+DROP VIEW IF EXISTS view_3_tab0_296 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31445,13 +31445,13 @@ SELECT pk FROM tab1 WHERE col4 >= 265.28
 78 values hashing to bf177f5883365d40f61d7a55facb89a6
 
 statement ok
-DROP VIEW view_1_tab1_296
+DROP VIEW IF EXISTS view_1_tab1_296 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_296
+DROP VIEW IF EXISTS view_2_tab1_296 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_296
+DROP VIEW IF EXISTS view_3_tab1_296 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31542,13 +31542,13 @@ SELECT pk FROM tab2 WHERE col4 >= 265.28
 78 values hashing to bf177f5883365d40f61d7a55facb89a6
 
 statement ok
-DROP VIEW view_1_tab2_296
+DROP VIEW IF EXISTS view_1_tab2_296 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_296
+DROP VIEW IF EXISTS view_2_tab2_296 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_296
+DROP VIEW IF EXISTS view_3_tab2_296 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31639,13 +31639,13 @@ SELECT pk FROM tab3 WHERE col4 >= 265.28
 78 values hashing to bf177f5883365d40f61d7a55facb89a6
 
 statement ok
-DROP VIEW view_1_tab3_296
+DROP VIEW IF EXISTS view_1_tab3_296 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_296
+DROP VIEW IF EXISTS view_2_tab3_296 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_296
+DROP VIEW IF EXISTS view_3_tab3_296 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31736,13 +31736,13 @@ SELECT pk FROM tab4 WHERE col4 >= 265.28
 78 values hashing to bf177f5883365d40f61d7a55facb89a6
 
 statement ok
-DROP VIEW view_1_tab4_296
+DROP VIEW IF EXISTS view_1_tab4_296 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_296
+DROP VIEW IF EXISTS view_2_tab4_296 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_296
+DROP VIEW IF EXISTS view_3_tab4_296 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31835,13 +31835,13 @@ SELECT pk FROM tab0 WHERE ((col0 > 709) OR (((col3 >= 434 AND col1 >= 915.22 AND
 99 values hashing to ffd3dd7b611ce53af641c2899d3aa331
 
 statement ok
-DROP VIEW view_1_tab0_297
+DROP VIEW IF EXISTS view_1_tab0_297 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_297
+DROP VIEW IF EXISTS view_2_tab0_297 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_297
+DROP VIEW IF EXISTS view_3_tab0_297 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31934,13 +31934,13 @@ SELECT pk FROM tab1 WHERE ((col0 > 709) OR (((col3 >= 434 AND col1 >= 915.22 AND
 99 values hashing to ffd3dd7b611ce53af641c2899d3aa331
 
 statement ok
-DROP VIEW view_1_tab1_297
+DROP VIEW IF EXISTS view_1_tab1_297 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_297
+DROP VIEW IF EXISTS view_2_tab1_297 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_297
+DROP VIEW IF EXISTS view_3_tab1_297 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32033,13 +32033,13 @@ SELECT pk FROM tab2 WHERE ((col0 > 709) OR (((col3 >= 434 AND col1 >= 915.22 AND
 99 values hashing to ffd3dd7b611ce53af641c2899d3aa331
 
 statement ok
-DROP VIEW view_1_tab2_297
+DROP VIEW IF EXISTS view_1_tab2_297 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_297
+DROP VIEW IF EXISTS view_2_tab2_297 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_297
+DROP VIEW IF EXISTS view_3_tab2_297 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32132,13 +32132,13 @@ SELECT pk FROM tab3 WHERE ((col0 > 709) OR (((col3 >= 434 AND col1 >= 915.22 AND
 99 values hashing to ffd3dd7b611ce53af641c2899d3aa331
 
 statement ok
-DROP VIEW view_1_tab3_297
+DROP VIEW IF EXISTS view_1_tab3_297 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_297
+DROP VIEW IF EXISTS view_2_tab3_297 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_297
+DROP VIEW IF EXISTS view_3_tab3_297 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32231,13 +32231,13 @@ SELECT pk FROM tab4 WHERE ((col0 > 709) OR (((col3 >= 434 AND col1 >= 915.22 AND
 99 values hashing to ffd3dd7b611ce53af641c2899d3aa331
 
 statement ok
-DROP VIEW view_1_tab4_297
+DROP VIEW IF EXISTS view_1_tab4_297 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_297
+DROP VIEW IF EXISTS view_2_tab4_297 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_297
+DROP VIEW IF EXISTS view_3_tab4_297 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32328,13 +32328,13 @@ SELECT pk FROM tab0 WHERE ((col4 > 362.56))
 72 values hashing to 23a57a82eba5793b2d4ff2981e3db5f7
 
 statement ok
-DROP VIEW view_1_tab0_298
+DROP VIEW IF EXISTS view_1_tab0_298 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_298
+DROP VIEW IF EXISTS view_2_tab0_298 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_298
+DROP VIEW IF EXISTS view_3_tab0_298 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32425,13 +32425,13 @@ SELECT pk FROM tab1 WHERE ((col4 > 362.56))
 72 values hashing to 23a57a82eba5793b2d4ff2981e3db5f7
 
 statement ok
-DROP VIEW view_1_tab1_298
+DROP VIEW IF EXISTS view_1_tab1_298 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_298
+DROP VIEW IF EXISTS view_2_tab1_298 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_298
+DROP VIEW IF EXISTS view_3_tab1_298 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32522,13 +32522,13 @@ SELECT pk FROM tab2 WHERE ((col4 > 362.56))
 72 values hashing to 23a57a82eba5793b2d4ff2981e3db5f7
 
 statement ok
-DROP VIEW view_1_tab2_298
+DROP VIEW IF EXISTS view_1_tab2_298 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_298
+DROP VIEW IF EXISTS view_2_tab2_298 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_298
+DROP VIEW IF EXISTS view_3_tab2_298 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32619,13 +32619,13 @@ SELECT pk FROM tab3 WHERE ((col4 > 362.56))
 72 values hashing to 23a57a82eba5793b2d4ff2981e3db5f7
 
 statement ok
-DROP VIEW view_1_tab3_298
+DROP VIEW IF EXISTS view_1_tab3_298 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_298
+DROP VIEW IF EXISTS view_2_tab3_298 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_298
+DROP VIEW IF EXISTS view_3_tab3_298 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32716,13 +32716,13 @@ SELECT pk FROM tab4 WHERE ((col4 > 362.56))
 72 values hashing to 23a57a82eba5793b2d4ff2981e3db5f7
 
 statement ok
-DROP VIEW view_1_tab4_298
+DROP VIEW IF EXISTS view_1_tab4_298 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_298
+DROP VIEW IF EXISTS view_2_tab4_298 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_298
+DROP VIEW IF EXISTS view_3_tab4_298 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32813,13 +32813,13 @@ SELECT pk FROM tab0 WHERE col3 < 424
 46 values hashing to 9db1ecd96a41c7ec2ce72e3dc018a2cf
 
 statement ok
-DROP VIEW view_1_tab0_299
+DROP VIEW IF EXISTS view_1_tab0_299 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_299
+DROP VIEW IF EXISTS view_2_tab0_299 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_299
+DROP VIEW IF EXISTS view_3_tab0_299 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32910,13 +32910,13 @@ SELECT pk FROM tab1 WHERE col3 < 424
 46 values hashing to 9db1ecd96a41c7ec2ce72e3dc018a2cf
 
 statement ok
-DROP VIEW view_1_tab1_299
+DROP VIEW IF EXISTS view_1_tab1_299 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_299
+DROP VIEW IF EXISTS view_2_tab1_299 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_299
+DROP VIEW IF EXISTS view_3_tab1_299 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33007,13 +33007,13 @@ SELECT pk FROM tab2 WHERE col3 < 424
 46 values hashing to 9db1ecd96a41c7ec2ce72e3dc018a2cf
 
 statement ok
-DROP VIEW view_1_tab2_299
+DROP VIEW IF EXISTS view_1_tab2_299 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_299
+DROP VIEW IF EXISTS view_2_tab2_299 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_299
+DROP VIEW IF EXISTS view_3_tab2_299 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33104,13 +33104,13 @@ SELECT pk FROM tab3 WHERE col3 < 424
 46 values hashing to 9db1ecd96a41c7ec2ce72e3dc018a2cf
 
 statement ok
-DROP VIEW view_1_tab3_299
+DROP VIEW IF EXISTS view_1_tab3_299 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_299
+DROP VIEW IF EXISTS view_2_tab3_299 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_299
+DROP VIEW IF EXISTS view_3_tab3_299 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33201,13 +33201,13 @@ SELECT pk FROM tab4 WHERE col3 < 424
 46 values hashing to 9db1ecd96a41c7ec2ce72e3dc018a2cf
 
 statement ok
-DROP VIEW view_1_tab4_299
+DROP VIEW IF EXISTS view_1_tab4_299 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_299
+DROP VIEW IF EXISTS view_2_tab4_299 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_299
+DROP VIEW IF EXISTS view_3_tab4_299 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33298,13 +33298,13 @@ SELECT pk FROM tab0 WHERE col1 < 522.96
 52 values hashing to 541393ecbbe55565e237b429b02554d2
 
 statement ok
-DROP VIEW view_1_tab0_300
+DROP VIEW IF EXISTS view_1_tab0_300 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_300
+DROP VIEW IF EXISTS view_2_tab0_300 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_300
+DROP VIEW IF EXISTS view_3_tab0_300 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33395,13 +33395,13 @@ SELECT pk FROM tab1 WHERE col1 < 522.96
 52 values hashing to 541393ecbbe55565e237b429b02554d2
 
 statement ok
-DROP VIEW view_1_tab1_300
+DROP VIEW IF EXISTS view_1_tab1_300 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_300
+DROP VIEW IF EXISTS view_2_tab1_300 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_300
+DROP VIEW IF EXISTS view_3_tab1_300 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33492,13 +33492,13 @@ SELECT pk FROM tab2 WHERE col1 < 522.96
 52 values hashing to 541393ecbbe55565e237b429b02554d2
 
 statement ok
-DROP VIEW view_1_tab2_300
+DROP VIEW IF EXISTS view_1_tab2_300 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_300
+DROP VIEW IF EXISTS view_2_tab2_300 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_300
+DROP VIEW IF EXISTS view_3_tab2_300 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33589,13 +33589,13 @@ SELECT pk FROM tab3 WHERE col1 < 522.96
 52 values hashing to 541393ecbbe55565e237b429b02554d2
 
 statement ok
-DROP VIEW view_1_tab3_300
+DROP VIEW IF EXISTS view_1_tab3_300 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_300
+DROP VIEW IF EXISTS view_2_tab3_300 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_300
+DROP VIEW IF EXISTS view_3_tab3_300 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33686,13 +33686,13 @@ SELECT pk FROM tab4 WHERE col1 < 522.96
 52 values hashing to 541393ecbbe55565e237b429b02554d2
 
 statement ok
-DROP VIEW view_1_tab4_300
+DROP VIEW IF EXISTS view_1_tab4_300 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_300
+DROP VIEW IF EXISTS view_2_tab4_300 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_300
+DROP VIEW IF EXISTS view_3_tab4_300 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33783,13 +33783,13 @@ SELECT pk FROM tab0 WHERE col3 < 503 OR col3 IN (327,997) AND col0 >= 541 AND (c
 51 values hashing to 1b474b99568c490591ed555a661e89bb
 
 statement ok
-DROP VIEW view_1_tab0_301
+DROP VIEW IF EXISTS view_1_tab0_301 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_301
+DROP VIEW IF EXISTS view_2_tab0_301 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_301
+DROP VIEW IF EXISTS view_3_tab0_301 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33880,13 +33880,13 @@ SELECT pk FROM tab1 WHERE col3 < 503 OR col3 IN (327,997) AND col0 >= 541 AND (c
 51 values hashing to 1b474b99568c490591ed555a661e89bb
 
 statement ok
-DROP VIEW view_1_tab1_301
+DROP VIEW IF EXISTS view_1_tab1_301 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_301
+DROP VIEW IF EXISTS view_2_tab1_301 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_301
+DROP VIEW IF EXISTS view_3_tab1_301 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33977,13 +33977,13 @@ SELECT pk FROM tab2 WHERE col3 < 503 OR col3 IN (327,997) AND col0 >= 541 AND (c
 51 values hashing to 1b474b99568c490591ed555a661e89bb
 
 statement ok
-DROP VIEW view_1_tab2_301
+DROP VIEW IF EXISTS view_1_tab2_301 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_301
+DROP VIEW IF EXISTS view_2_tab2_301 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_301
+DROP VIEW IF EXISTS view_3_tab2_301 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34074,13 +34074,13 @@ SELECT pk FROM tab3 WHERE col3 < 503 OR col3 IN (327,997) AND col0 >= 541 AND (c
 51 values hashing to 1b474b99568c490591ed555a661e89bb
 
 statement ok
-DROP VIEW view_1_tab3_301
+DROP VIEW IF EXISTS view_1_tab3_301 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_301
+DROP VIEW IF EXISTS view_2_tab3_301 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_301
+DROP VIEW IF EXISTS view_3_tab3_301 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34171,11 +34171,11 @@ SELECT pk FROM tab4 WHERE col3 < 503 OR col3 IN (327,997) AND col0 >= 541 AND (c
 51 values hashing to 1b474b99568c490591ed555a661e89bb
 
 statement ok
-DROP VIEW view_1_tab4_301
+DROP VIEW IF EXISTS view_1_tab4_301 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_301
+DROP VIEW IF EXISTS view_2_tab4_301 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_301
+DROP VIEW IF EXISTS view_3_tab4_301 CASCADE
 

--- a/test/index/view/100/slt_good_2.test
+++ b/test/index/view/100/slt_good_2.test
@@ -456,13 +456,13 @@ SELECT pk FROM tab0 WHERE col0 >= 789 AND (col4 >= 141.85 AND col1 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_521
+DROP VIEW IF EXISTS view_1_tab0_521 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_521
+DROP VIEW IF EXISTS view_2_tab0_521 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_521
+DROP VIEW IF EXISTS view_3_tab0_521 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -548,13 +548,13 @@ SELECT pk FROM tab1 WHERE col0 >= 789 AND (col4 >= 141.85 AND col1 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_521
+DROP VIEW IF EXISTS view_1_tab1_521 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_521
+DROP VIEW IF EXISTS view_2_tab1_521 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_521
+DROP VIEW IF EXISTS view_3_tab1_521 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -640,13 +640,13 @@ SELECT pk FROM tab2 WHERE col0 >= 789 AND (col4 >= 141.85 AND col1 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_521
+DROP VIEW IF EXISTS view_1_tab2_521 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_521
+DROP VIEW IF EXISTS view_2_tab2_521 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_521
+DROP VIEW IF EXISTS view_3_tab2_521 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -732,13 +732,13 @@ SELECT pk FROM tab3 WHERE col0 >= 789 AND (col4 >= 141.85 AND col1 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_521
+DROP VIEW IF EXISTS view_1_tab3_521 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_521
+DROP VIEW IF EXISTS view_2_tab3_521 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_521
+DROP VIEW IF EXISTS view_3_tab3_521 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -824,13 +824,13 @@ SELECT pk FROM tab4 WHERE col0 >= 789 AND (col4 >= 141.85 AND col1 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_521
+DROP VIEW IF EXISTS view_1_tab4_521 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_521
+DROP VIEW IF EXISTS view_2_tab4_521 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_521
+DROP VIEW IF EXISTS view_3_tab4_521 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -921,13 +921,13 @@ SELECT pk FROM tab0 WHERE (col0 > 333)
 68 values hashing to 8a9f460682d7c9ced371eafa52142f78
 
 statement ok
-DROP VIEW view_1_tab0_523
+DROP VIEW IF EXISTS view_1_tab0_523 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_523
+DROP VIEW IF EXISTS view_2_tab0_523 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_523
+DROP VIEW IF EXISTS view_3_tab0_523 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1018,13 +1018,13 @@ SELECT pk FROM tab1 WHERE (col0 > 333)
 68 values hashing to 8a9f460682d7c9ced371eafa52142f78
 
 statement ok
-DROP VIEW view_1_tab1_523
+DROP VIEW IF EXISTS view_1_tab1_523 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_523
+DROP VIEW IF EXISTS view_2_tab1_523 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_523
+DROP VIEW IF EXISTS view_3_tab1_523 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1115,13 +1115,13 @@ SELECT pk FROM tab2 WHERE (col0 > 333)
 68 values hashing to 8a9f460682d7c9ced371eafa52142f78
 
 statement ok
-DROP VIEW view_1_tab2_523
+DROP VIEW IF EXISTS view_1_tab2_523 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_523
+DROP VIEW IF EXISTS view_2_tab2_523 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_523
+DROP VIEW IF EXISTS view_3_tab2_523 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1212,13 +1212,13 @@ SELECT pk FROM tab3 WHERE (col0 > 333)
 68 values hashing to 8a9f460682d7c9ced371eafa52142f78
 
 statement ok
-DROP VIEW view_1_tab3_523
+DROP VIEW IF EXISTS view_1_tab3_523 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_523
+DROP VIEW IF EXISTS view_2_tab3_523 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_523
+DROP VIEW IF EXISTS view_3_tab3_523 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1309,13 +1309,13 @@ SELECT pk FROM tab4 WHERE (col0 > 333)
 68 values hashing to 8a9f460682d7c9ced371eafa52142f78
 
 statement ok
-DROP VIEW view_1_tab4_523
+DROP VIEW IF EXISTS view_1_tab4_523 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_523
+DROP VIEW IF EXISTS view_2_tab4_523 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_523
+DROP VIEW IF EXISTS view_3_tab4_523 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1406,13 +1406,13 @@ SELECT pk FROM tab0 WHERE col3 > 693 OR col0 > 732 OR col3 IS NULL OR col4 >= 53
 75 values hashing to 71cf3485d900af3a9950fd548a1b37d0
 
 statement ok
-DROP VIEW view_1_tab0_524
+DROP VIEW IF EXISTS view_1_tab0_524 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_524
+DROP VIEW IF EXISTS view_2_tab0_524 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_524
+DROP VIEW IF EXISTS view_3_tab0_524 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1503,13 +1503,13 @@ SELECT pk FROM tab1 WHERE col3 > 693 OR col0 > 732 OR col3 IS NULL OR col4 >= 53
 75 values hashing to 71cf3485d900af3a9950fd548a1b37d0
 
 statement ok
-DROP VIEW view_1_tab1_524
+DROP VIEW IF EXISTS view_1_tab1_524 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_524
+DROP VIEW IF EXISTS view_2_tab1_524 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_524
+DROP VIEW IF EXISTS view_3_tab1_524 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1600,13 +1600,13 @@ SELECT pk FROM tab2 WHERE col3 > 693 OR col0 > 732 OR col3 IS NULL OR col4 >= 53
 75 values hashing to 71cf3485d900af3a9950fd548a1b37d0
 
 statement ok
-DROP VIEW view_1_tab2_524
+DROP VIEW IF EXISTS view_1_tab2_524 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_524
+DROP VIEW IF EXISTS view_2_tab2_524 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_524
+DROP VIEW IF EXISTS view_3_tab2_524 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1697,13 +1697,13 @@ SELECT pk FROM tab3 WHERE col3 > 693 OR col0 > 732 OR col3 IS NULL OR col4 >= 53
 75 values hashing to 71cf3485d900af3a9950fd548a1b37d0
 
 statement ok
-DROP VIEW view_1_tab3_524
+DROP VIEW IF EXISTS view_1_tab3_524 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_524
+DROP VIEW IF EXISTS view_2_tab3_524 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_524
+DROP VIEW IF EXISTS view_3_tab3_524 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1794,13 +1794,13 @@ SELECT pk FROM tab4 WHERE col3 > 693 OR col0 > 732 OR col3 IS NULL OR col4 >= 53
 75 values hashing to 71cf3485d900af3a9950fd548a1b37d0
 
 statement ok
-DROP VIEW view_1_tab4_524
+DROP VIEW IF EXISTS view_1_tab4_524 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_524
+DROP VIEW IF EXISTS view_2_tab4_524 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_524
+DROP VIEW IF EXISTS view_3_tab4_524 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1886,13 +1886,13 @@ SELECT pk FROM tab0 WHERE (((col1 BETWEEN 950.56 AND 148.61)))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_525
+DROP VIEW IF EXISTS view_1_tab0_525 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_525
+DROP VIEW IF EXISTS view_2_tab0_525 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_525
+DROP VIEW IF EXISTS view_3_tab0_525 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1978,13 +1978,13 @@ SELECT pk FROM tab1 WHERE (((col1 BETWEEN 950.56 AND 148.61)))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_525
+DROP VIEW IF EXISTS view_1_tab1_525 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_525
+DROP VIEW IF EXISTS view_2_tab1_525 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_525
+DROP VIEW IF EXISTS view_3_tab1_525 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2070,13 +2070,13 @@ SELECT pk FROM tab2 WHERE (((col1 BETWEEN 950.56 AND 148.61)))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_525
+DROP VIEW IF EXISTS view_1_tab2_525 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_525
+DROP VIEW IF EXISTS view_2_tab2_525 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_525
+DROP VIEW IF EXISTS view_3_tab2_525 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2162,13 +2162,13 @@ SELECT pk FROM tab3 WHERE (((col1 BETWEEN 950.56 AND 148.61)))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_525
+DROP VIEW IF EXISTS view_1_tab3_525 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_525
+DROP VIEW IF EXISTS view_2_tab3_525 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_525
+DROP VIEW IF EXISTS view_3_tab3_525 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2254,13 +2254,13 @@ SELECT pk FROM tab4 WHERE (((col1 BETWEEN 950.56 AND 148.61)))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_525
+DROP VIEW IF EXISTS view_1_tab4_525 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_525
+DROP VIEW IF EXISTS view_2_tab4_525 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_525
+DROP VIEW IF EXISTS view_3_tab4_525 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2351,13 +2351,13 @@ SELECT pk FROM tab0 WHERE (col4 = 717.55 OR col3 >= 156 AND col0 < 727 OR col3 <
 90 values hashing to 24a25d27bface5604e5edd4f7c7a9d56
 
 statement ok
-DROP VIEW view_1_tab0_526
+DROP VIEW IF EXISTS view_1_tab0_526 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_526
+DROP VIEW IF EXISTS view_2_tab0_526 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_526
+DROP VIEW IF EXISTS view_3_tab0_526 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2448,13 +2448,13 @@ SELECT pk FROM tab1 WHERE (col4 = 717.55 OR col3 >= 156 AND col0 < 727 OR col3 <
 90 values hashing to 24a25d27bface5604e5edd4f7c7a9d56
 
 statement ok
-DROP VIEW view_1_tab1_526
+DROP VIEW IF EXISTS view_1_tab1_526 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_526
+DROP VIEW IF EXISTS view_2_tab1_526 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_526
+DROP VIEW IF EXISTS view_3_tab1_526 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2545,13 +2545,13 @@ SELECT pk FROM tab2 WHERE (col4 = 717.55 OR col3 >= 156 AND col0 < 727 OR col3 <
 90 values hashing to 24a25d27bface5604e5edd4f7c7a9d56
 
 statement ok
-DROP VIEW view_1_tab2_526
+DROP VIEW IF EXISTS view_1_tab2_526 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_526
+DROP VIEW IF EXISTS view_2_tab2_526 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_526
+DROP VIEW IF EXISTS view_3_tab2_526 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2642,13 +2642,13 @@ SELECT pk FROM tab3 WHERE (col4 = 717.55 OR col3 >= 156 AND col0 < 727 OR col3 <
 90 values hashing to 24a25d27bface5604e5edd4f7c7a9d56
 
 statement ok
-DROP VIEW view_1_tab3_526
+DROP VIEW IF EXISTS view_1_tab3_526 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_526
+DROP VIEW IF EXISTS view_2_tab3_526 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_526
+DROP VIEW IF EXISTS view_3_tab3_526 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2739,13 +2739,13 @@ SELECT pk FROM tab4 WHERE (col4 = 717.55 OR col3 >= 156 AND col0 < 727 OR col3 <
 90 values hashing to 24a25d27bface5604e5edd4f7c7a9d56
 
 statement ok
-DROP VIEW view_1_tab4_526
+DROP VIEW IF EXISTS view_1_tab4_526 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_526
+DROP VIEW IF EXISTS view_2_tab4_526 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_526
+DROP VIEW IF EXISTS view_3_tab4_526 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2836,13 +2836,13 @@ SELECT pk FROM tab0 WHERE col0 < 811
 76 values hashing to 0e4ae97f6522c8b6d9e67ae89bc812fb
 
 statement ok
-DROP VIEW view_1_tab0_527
+DROP VIEW IF EXISTS view_1_tab0_527 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_527
+DROP VIEW IF EXISTS view_2_tab0_527 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_527
+DROP VIEW IF EXISTS view_3_tab0_527 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2933,13 +2933,13 @@ SELECT pk FROM tab1 WHERE col0 < 811
 76 values hashing to 0e4ae97f6522c8b6d9e67ae89bc812fb
 
 statement ok
-DROP VIEW view_1_tab1_527
+DROP VIEW IF EXISTS view_1_tab1_527 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_527
+DROP VIEW IF EXISTS view_2_tab1_527 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_527
+DROP VIEW IF EXISTS view_3_tab1_527 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3030,13 +3030,13 @@ SELECT pk FROM tab2 WHERE col0 < 811
 76 values hashing to 0e4ae97f6522c8b6d9e67ae89bc812fb
 
 statement ok
-DROP VIEW view_1_tab2_527
+DROP VIEW IF EXISTS view_1_tab2_527 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_527
+DROP VIEW IF EXISTS view_2_tab2_527 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_527
+DROP VIEW IF EXISTS view_3_tab2_527 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3127,13 +3127,13 @@ SELECT pk FROM tab3 WHERE col0 < 811
 76 values hashing to 0e4ae97f6522c8b6d9e67ae89bc812fb
 
 statement ok
-DROP VIEW view_1_tab3_527
+DROP VIEW IF EXISTS view_1_tab3_527 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_527
+DROP VIEW IF EXISTS view_2_tab3_527 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_527
+DROP VIEW IF EXISTS view_3_tab3_527 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3224,13 +3224,13 @@ SELECT pk FROM tab4 WHERE col0 < 811
 76 values hashing to 0e4ae97f6522c8b6d9e67ae89bc812fb
 
 statement ok
-DROP VIEW view_1_tab4_527
+DROP VIEW IF EXISTS view_1_tab4_527 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_527
+DROP VIEW IF EXISTS view_2_tab4_527 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_527
+DROP VIEW IF EXISTS view_3_tab4_527 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3321,13 +3321,13 @@ SELECT pk FROM tab0 WHERE col3 < 340
 41 values hashing to b52ff2d9346c7fc76ab11c583b1aaf99
 
 statement ok
-DROP VIEW view_1_tab0_528
+DROP VIEW IF EXISTS view_1_tab0_528 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_528
+DROP VIEW IF EXISTS view_2_tab0_528 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_528
+DROP VIEW IF EXISTS view_3_tab0_528 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3418,13 +3418,13 @@ SELECT pk FROM tab1 WHERE col3 < 340
 41 values hashing to b52ff2d9346c7fc76ab11c583b1aaf99
 
 statement ok
-DROP VIEW view_1_tab1_528
+DROP VIEW IF EXISTS view_1_tab1_528 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_528
+DROP VIEW IF EXISTS view_2_tab1_528 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_528
+DROP VIEW IF EXISTS view_3_tab1_528 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3515,13 +3515,13 @@ SELECT pk FROM tab2 WHERE col3 < 340
 41 values hashing to b52ff2d9346c7fc76ab11c583b1aaf99
 
 statement ok
-DROP VIEW view_1_tab2_528
+DROP VIEW IF EXISTS view_1_tab2_528 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_528
+DROP VIEW IF EXISTS view_2_tab2_528 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_528
+DROP VIEW IF EXISTS view_3_tab2_528 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3612,13 +3612,13 @@ SELECT pk FROM tab3 WHERE col3 < 340
 41 values hashing to b52ff2d9346c7fc76ab11c583b1aaf99
 
 statement ok
-DROP VIEW view_1_tab3_528
+DROP VIEW IF EXISTS view_1_tab3_528 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_528
+DROP VIEW IF EXISTS view_2_tab3_528 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_528
+DROP VIEW IF EXISTS view_3_tab3_528 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3709,13 +3709,13 @@ SELECT pk FROM tab4 WHERE col3 < 340
 41 values hashing to b52ff2d9346c7fc76ab11c583b1aaf99
 
 statement ok
-DROP VIEW view_1_tab4_528
+DROP VIEW IF EXISTS view_1_tab4_528 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_528
+DROP VIEW IF EXISTS view_2_tab4_528 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_528
+DROP VIEW IF EXISTS view_3_tab4_528 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3806,13 +3806,13 @@ SELECT pk FROM tab0 WHERE (col0 > 428)
 57 values hashing to 1bb74fd4cd726f3e47b5d17102d8dfa6
 
 statement ok
-DROP VIEW view_1_tab0_530
+DROP VIEW IF EXISTS view_1_tab0_530 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_530
+DROP VIEW IF EXISTS view_2_tab0_530 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_530
+DROP VIEW IF EXISTS view_3_tab0_530 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3903,13 +3903,13 @@ SELECT pk FROM tab1 WHERE (col0 > 428)
 57 values hashing to 1bb74fd4cd726f3e47b5d17102d8dfa6
 
 statement ok
-DROP VIEW view_1_tab1_530
+DROP VIEW IF EXISTS view_1_tab1_530 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_530
+DROP VIEW IF EXISTS view_2_tab1_530 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_530
+DROP VIEW IF EXISTS view_3_tab1_530 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4000,13 +4000,13 @@ SELECT pk FROM tab2 WHERE (col0 > 428)
 57 values hashing to 1bb74fd4cd726f3e47b5d17102d8dfa6
 
 statement ok
-DROP VIEW view_1_tab2_530
+DROP VIEW IF EXISTS view_1_tab2_530 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_530
+DROP VIEW IF EXISTS view_2_tab2_530 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_530
+DROP VIEW IF EXISTS view_3_tab2_530 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4097,13 +4097,13 @@ SELECT pk FROM tab3 WHERE (col0 > 428)
 57 values hashing to 1bb74fd4cd726f3e47b5d17102d8dfa6
 
 statement ok
-DROP VIEW view_1_tab3_530
+DROP VIEW IF EXISTS view_1_tab3_530 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_530
+DROP VIEW IF EXISTS view_2_tab3_530 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_530
+DROP VIEW IF EXISTS view_3_tab3_530 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4194,13 +4194,13 @@ SELECT pk FROM tab4 WHERE (col0 > 428)
 57 values hashing to 1bb74fd4cd726f3e47b5d17102d8dfa6
 
 statement ok
-DROP VIEW view_1_tab4_530
+DROP VIEW IF EXISTS view_1_tab4_530 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_530
+DROP VIEW IF EXISTS view_2_tab4_530 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_530
+DROP VIEW IF EXISTS view_3_tab4_530 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4291,13 +4291,13 @@ SELECT pk FROM tab0 WHERE col1 > 562.45
 45 values hashing to 22e5fc87a754ca0d11529508963418ab
 
 statement ok
-DROP VIEW view_1_tab0_531
+DROP VIEW IF EXISTS view_1_tab0_531 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_531
+DROP VIEW IF EXISTS view_2_tab0_531 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_531
+DROP VIEW IF EXISTS view_3_tab0_531 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4388,13 +4388,13 @@ SELECT pk FROM tab1 WHERE col1 > 562.45
 45 values hashing to 22e5fc87a754ca0d11529508963418ab
 
 statement ok
-DROP VIEW view_1_tab1_531
+DROP VIEW IF EXISTS view_1_tab1_531 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_531
+DROP VIEW IF EXISTS view_2_tab1_531 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_531
+DROP VIEW IF EXISTS view_3_tab1_531 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4485,13 +4485,13 @@ SELECT pk FROM tab2 WHERE col1 > 562.45
 45 values hashing to 22e5fc87a754ca0d11529508963418ab
 
 statement ok
-DROP VIEW view_1_tab2_531
+DROP VIEW IF EXISTS view_1_tab2_531 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_531
+DROP VIEW IF EXISTS view_2_tab2_531 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_531
+DROP VIEW IF EXISTS view_3_tab2_531 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4582,13 +4582,13 @@ SELECT pk FROM tab3 WHERE col1 > 562.45
 45 values hashing to 22e5fc87a754ca0d11529508963418ab
 
 statement ok
-DROP VIEW view_1_tab3_531
+DROP VIEW IF EXISTS view_1_tab3_531 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_531
+DROP VIEW IF EXISTS view_2_tab3_531 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_531
+DROP VIEW IF EXISTS view_3_tab3_531 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4679,13 +4679,13 @@ SELECT pk FROM tab4 WHERE col1 > 562.45
 45 values hashing to 22e5fc87a754ca0d11529508963418ab
 
 statement ok
-DROP VIEW view_1_tab4_531
+DROP VIEW IF EXISTS view_1_tab4_531 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_531
+DROP VIEW IF EXISTS view_2_tab4_531 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_531
+DROP VIEW IF EXISTS view_3_tab4_531 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4776,13 +4776,13 @@ SELECT pk FROM tab0 WHERE col0 > 264
 72 values hashing to 2dd089fae396d072402e65199dd94bcd
 
 statement ok
-DROP VIEW view_1_tab0_532
+DROP VIEW IF EXISTS view_1_tab0_532 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_532
+DROP VIEW IF EXISTS view_2_tab0_532 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_532
+DROP VIEW IF EXISTS view_3_tab0_532 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4873,13 +4873,13 @@ SELECT pk FROM tab1 WHERE col0 > 264
 72 values hashing to 2dd089fae396d072402e65199dd94bcd
 
 statement ok
-DROP VIEW view_1_tab1_532
+DROP VIEW IF EXISTS view_1_tab1_532 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_532
+DROP VIEW IF EXISTS view_2_tab1_532 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_532
+DROP VIEW IF EXISTS view_3_tab1_532 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4970,13 +4970,13 @@ SELECT pk FROM tab2 WHERE col0 > 264
 72 values hashing to 2dd089fae396d072402e65199dd94bcd
 
 statement ok
-DROP VIEW view_1_tab2_532
+DROP VIEW IF EXISTS view_1_tab2_532 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_532
+DROP VIEW IF EXISTS view_2_tab2_532 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_532
+DROP VIEW IF EXISTS view_3_tab2_532 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5067,13 +5067,13 @@ SELECT pk FROM tab3 WHERE col0 > 264
 72 values hashing to 2dd089fae396d072402e65199dd94bcd
 
 statement ok
-DROP VIEW view_1_tab3_532
+DROP VIEW IF EXISTS view_1_tab3_532 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_532
+DROP VIEW IF EXISTS view_2_tab3_532 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_532
+DROP VIEW IF EXISTS view_3_tab3_532 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5164,13 +5164,13 @@ SELECT pk FROM tab4 WHERE col0 > 264
 72 values hashing to 2dd089fae396d072402e65199dd94bcd
 
 statement ok
-DROP VIEW view_1_tab4_532
+DROP VIEW IF EXISTS view_1_tab4_532 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_532
+DROP VIEW IF EXISTS view_2_tab4_532 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_532
+DROP VIEW IF EXISTS view_3_tab4_532 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5261,13 +5261,13 @@ SELECT pk FROM tab0 WHERE col3 < 528 OR col0 <= 427
 78 values hashing to 7cd53392d25caeac90336da8d094a95e
 
 statement ok
-DROP VIEW view_1_tab0_533
+DROP VIEW IF EXISTS view_1_tab0_533 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_533
+DROP VIEW IF EXISTS view_2_tab0_533 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_533
+DROP VIEW IF EXISTS view_3_tab0_533 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5358,13 +5358,13 @@ SELECT pk FROM tab1 WHERE col3 < 528 OR col0 <= 427
 78 values hashing to 7cd53392d25caeac90336da8d094a95e
 
 statement ok
-DROP VIEW view_1_tab1_533
+DROP VIEW IF EXISTS view_1_tab1_533 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_533
+DROP VIEW IF EXISTS view_2_tab1_533 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_533
+DROP VIEW IF EXISTS view_3_tab1_533 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5455,13 +5455,13 @@ SELECT pk FROM tab2 WHERE col3 < 528 OR col0 <= 427
 78 values hashing to 7cd53392d25caeac90336da8d094a95e
 
 statement ok
-DROP VIEW view_1_tab2_533
+DROP VIEW IF EXISTS view_1_tab2_533 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_533
+DROP VIEW IF EXISTS view_2_tab2_533 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_533
+DROP VIEW IF EXISTS view_3_tab2_533 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5552,13 +5552,13 @@ SELECT pk FROM tab3 WHERE col3 < 528 OR col0 <= 427
 78 values hashing to 7cd53392d25caeac90336da8d094a95e
 
 statement ok
-DROP VIEW view_1_tab3_533
+DROP VIEW IF EXISTS view_1_tab3_533 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_533
+DROP VIEW IF EXISTS view_2_tab3_533 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_533
+DROP VIEW IF EXISTS view_3_tab3_533 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5649,13 +5649,13 @@ SELECT pk FROM tab4 WHERE col3 < 528 OR col0 <= 427
 78 values hashing to 7cd53392d25caeac90336da8d094a95e
 
 statement ok
-DROP VIEW view_1_tab4_533
+DROP VIEW IF EXISTS view_1_tab4_533 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_533
+DROP VIEW IF EXISTS view_2_tab4_533 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_533
+DROP VIEW IF EXISTS view_3_tab4_533 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5744,13 +5744,13 @@ SELECT pk FROM tab0 WHERE col0 < 152 OR (((col1 >= 904.26) AND ((col0 > 91))) OR
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab0_534
+DROP VIEW IF EXISTS view_1_tab0_534 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_534
+DROP VIEW IF EXISTS view_2_tab0_534 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_534
+DROP VIEW IF EXISTS view_3_tab0_534 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5839,13 +5839,13 @@ SELECT pk FROM tab1 WHERE col0 < 152 OR (((col1 >= 904.26) AND ((col0 > 91))) OR
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab1_534
+DROP VIEW IF EXISTS view_1_tab1_534 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_534
+DROP VIEW IF EXISTS view_2_tab1_534 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_534
+DROP VIEW IF EXISTS view_3_tab1_534 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5934,13 +5934,13 @@ SELECT pk FROM tab2 WHERE col0 < 152 OR (((col1 >= 904.26) AND ((col0 > 91))) OR
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab2_534
+DROP VIEW IF EXISTS view_1_tab2_534 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_534
+DROP VIEW IF EXISTS view_2_tab2_534 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_534
+DROP VIEW IF EXISTS view_3_tab2_534 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6029,13 +6029,13 @@ SELECT pk FROM tab3 WHERE col0 < 152 OR (((col1 >= 904.26) AND ((col0 > 91))) OR
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab3_534
+DROP VIEW IF EXISTS view_1_tab3_534 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_534
+DROP VIEW IF EXISTS view_2_tab3_534 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_534
+DROP VIEW IF EXISTS view_3_tab3_534 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6124,13 +6124,13 @@ SELECT pk FROM tab4 WHERE col0 < 152 OR (((col1 >= 904.26) AND ((col0 > 91))) OR
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab4_534
+DROP VIEW IF EXISTS view_1_tab4_534 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_534
+DROP VIEW IF EXISTS view_2_tab4_534 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_534
+DROP VIEW IF EXISTS view_3_tab4_534 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6221,13 +6221,13 @@ SELECT pk FROM tab0 WHERE col1 > 649.69
 40 values hashing to b799f04f5ddf03018d4509678f9b53b6
 
 statement ok
-DROP VIEW view_1_tab0_535
+DROP VIEW IF EXISTS view_1_tab0_535 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_535
+DROP VIEW IF EXISTS view_2_tab0_535 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_535
+DROP VIEW IF EXISTS view_3_tab0_535 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6318,13 +6318,13 @@ SELECT pk FROM tab1 WHERE col1 > 649.69
 40 values hashing to b799f04f5ddf03018d4509678f9b53b6
 
 statement ok
-DROP VIEW view_1_tab1_535
+DROP VIEW IF EXISTS view_1_tab1_535 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_535
+DROP VIEW IF EXISTS view_2_tab1_535 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_535
+DROP VIEW IF EXISTS view_3_tab1_535 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6415,13 +6415,13 @@ SELECT pk FROM tab2 WHERE col1 > 649.69
 40 values hashing to b799f04f5ddf03018d4509678f9b53b6
 
 statement ok
-DROP VIEW view_1_tab2_535
+DROP VIEW IF EXISTS view_1_tab2_535 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_535
+DROP VIEW IF EXISTS view_2_tab2_535 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_535
+DROP VIEW IF EXISTS view_3_tab2_535 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6512,13 +6512,13 @@ SELECT pk FROM tab3 WHERE col1 > 649.69
 40 values hashing to b799f04f5ddf03018d4509678f9b53b6
 
 statement ok
-DROP VIEW view_1_tab3_535
+DROP VIEW IF EXISTS view_1_tab3_535 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_535
+DROP VIEW IF EXISTS view_2_tab3_535 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_535
+DROP VIEW IF EXISTS view_3_tab3_535 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6609,13 +6609,13 @@ SELECT pk FROM tab4 WHERE col1 > 649.69
 40 values hashing to b799f04f5ddf03018d4509678f9b53b6
 
 statement ok
-DROP VIEW view_1_tab4_535
+DROP VIEW IF EXISTS view_1_tab4_535 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_535
+DROP VIEW IF EXISTS view_2_tab4_535 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_535
+DROP VIEW IF EXISTS view_3_tab4_535 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6706,13 +6706,13 @@ SELECT pk FROM tab0 WHERE col0 < 914
 95 values hashing to 99efb628b2c7737038b2242f2d51a14d
 
 statement ok
-DROP VIEW view_1_tab0_536
+DROP VIEW IF EXISTS view_1_tab0_536 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_536
+DROP VIEW IF EXISTS view_2_tab0_536 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_536
+DROP VIEW IF EXISTS view_3_tab0_536 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6803,13 +6803,13 @@ SELECT pk FROM tab1 WHERE col0 < 914
 95 values hashing to 99efb628b2c7737038b2242f2d51a14d
 
 statement ok
-DROP VIEW view_1_tab1_536
+DROP VIEW IF EXISTS view_1_tab1_536 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_536
+DROP VIEW IF EXISTS view_2_tab1_536 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_536
+DROP VIEW IF EXISTS view_3_tab1_536 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6900,13 +6900,13 @@ SELECT pk FROM tab2 WHERE col0 < 914
 95 values hashing to 99efb628b2c7737038b2242f2d51a14d
 
 statement ok
-DROP VIEW view_1_tab2_536
+DROP VIEW IF EXISTS view_1_tab2_536 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_536
+DROP VIEW IF EXISTS view_2_tab2_536 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_536
+DROP VIEW IF EXISTS view_3_tab2_536 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6997,13 +6997,13 @@ SELECT pk FROM tab3 WHERE col0 < 914
 95 values hashing to 99efb628b2c7737038b2242f2d51a14d
 
 statement ok
-DROP VIEW view_1_tab3_536
+DROP VIEW IF EXISTS view_1_tab3_536 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_536
+DROP VIEW IF EXISTS view_2_tab3_536 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_536
+DROP VIEW IF EXISTS view_3_tab3_536 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7094,13 +7094,13 @@ SELECT pk FROM tab4 WHERE col0 < 914
 95 values hashing to 99efb628b2c7737038b2242f2d51a14d
 
 statement ok
-DROP VIEW view_1_tab4_536
+DROP VIEW IF EXISTS view_1_tab4_536 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_536
+DROP VIEW IF EXISTS view_2_tab4_536 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_536
+DROP VIEW IF EXISTS view_3_tab4_536 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7207,13 +7207,13 @@ SELECT pk FROM tab0 WHERE col3 > 964
 65
 
 statement ok
-DROP VIEW view_1_tab0_537
+DROP VIEW IF EXISTS view_1_tab0_537 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_537
+DROP VIEW IF EXISTS view_2_tab0_537 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_537
+DROP VIEW IF EXISTS view_3_tab0_537 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7320,13 +7320,13 @@ SELECT pk FROM tab1 WHERE col3 > 964
 65
 
 statement ok
-DROP VIEW view_1_tab1_537
+DROP VIEW IF EXISTS view_1_tab1_537 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_537
+DROP VIEW IF EXISTS view_2_tab1_537 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_537
+DROP VIEW IF EXISTS view_3_tab1_537 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7433,13 +7433,13 @@ SELECT pk FROM tab2 WHERE col3 > 964
 65
 
 statement ok
-DROP VIEW view_1_tab2_537
+DROP VIEW IF EXISTS view_1_tab2_537 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_537
+DROP VIEW IF EXISTS view_2_tab2_537 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_537
+DROP VIEW IF EXISTS view_3_tab2_537 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7546,13 +7546,13 @@ SELECT pk FROM tab3 WHERE col3 > 964
 65
 
 statement ok
-DROP VIEW view_1_tab3_537
+DROP VIEW IF EXISTS view_1_tab3_537 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_537
+DROP VIEW IF EXISTS view_2_tab3_537 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_537
+DROP VIEW IF EXISTS view_3_tab3_537 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7659,13 +7659,13 @@ SELECT pk FROM tab4 WHERE col3 > 964
 65
 
 statement ok
-DROP VIEW view_1_tab4_537
+DROP VIEW IF EXISTS view_1_tab4_537 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_537
+DROP VIEW IF EXISTS view_2_tab4_537 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_537
+DROP VIEW IF EXISTS view_3_tab4_537 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7754,13 +7754,13 @@ SELECT pk FROM tab0 WHERE (((col0 IS NULL) OR col0 >= 7 OR (col1 >= 61.58) OR co
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab0_538
+DROP VIEW IF EXISTS view_1_tab0_538 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_538
+DROP VIEW IF EXISTS view_2_tab0_538 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_538
+DROP VIEW IF EXISTS view_3_tab0_538 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7849,13 +7849,13 @@ SELECT pk FROM tab1 WHERE (((col0 IS NULL) OR col0 >= 7 OR (col1 >= 61.58) OR co
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab1_538
+DROP VIEW IF EXISTS view_1_tab1_538 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_538
+DROP VIEW IF EXISTS view_2_tab1_538 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_538
+DROP VIEW IF EXISTS view_3_tab1_538 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7944,13 +7944,13 @@ SELECT pk FROM tab2 WHERE (((col0 IS NULL) OR col0 >= 7 OR (col1 >= 61.58) OR co
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab2_538
+DROP VIEW IF EXISTS view_1_tab2_538 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_538
+DROP VIEW IF EXISTS view_2_tab2_538 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_538
+DROP VIEW IF EXISTS view_3_tab2_538 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8039,13 +8039,13 @@ SELECT pk FROM tab3 WHERE (((col0 IS NULL) OR col0 >= 7 OR (col1 >= 61.58) OR co
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab3_538
+DROP VIEW IF EXISTS view_1_tab3_538 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_538
+DROP VIEW IF EXISTS view_2_tab3_538 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_538
+DROP VIEW IF EXISTS view_3_tab3_538 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8134,13 +8134,13 @@ SELECT pk FROM tab4 WHERE (((col0 IS NULL) OR col0 >= 7 OR (col1 >= 61.58) OR co
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab4_538
+DROP VIEW IF EXISTS view_1_tab4_538 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_538
+DROP VIEW IF EXISTS view_2_tab4_538 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_538
+DROP VIEW IF EXISTS view_3_tab4_538 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8231,13 +8231,13 @@ SELECT pk FROM tab0 WHERE ((((col4 IN (272.1,413.34) AND col0 < 382) OR col0 >= 
 82 values hashing to 617dec3e7ac542d5321a7249d0b29f37
 
 statement ok
-DROP VIEW view_1_tab0_539
+DROP VIEW IF EXISTS view_1_tab0_539 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_539
+DROP VIEW IF EXISTS view_2_tab0_539 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_539
+DROP VIEW IF EXISTS view_3_tab0_539 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8328,13 +8328,13 @@ SELECT pk FROM tab1 WHERE ((((col4 IN (272.1,413.34) AND col0 < 382) OR col0 >= 
 82 values hashing to 617dec3e7ac542d5321a7249d0b29f37
 
 statement ok
-DROP VIEW view_1_tab1_539
+DROP VIEW IF EXISTS view_1_tab1_539 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_539
+DROP VIEW IF EXISTS view_2_tab1_539 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_539
+DROP VIEW IF EXISTS view_3_tab1_539 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8425,13 +8425,13 @@ SELECT pk FROM tab2 WHERE ((((col4 IN (272.1,413.34) AND col0 < 382) OR col0 >= 
 82 values hashing to 617dec3e7ac542d5321a7249d0b29f37
 
 statement ok
-DROP VIEW view_1_tab2_539
+DROP VIEW IF EXISTS view_1_tab2_539 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_539
+DROP VIEW IF EXISTS view_2_tab2_539 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_539
+DROP VIEW IF EXISTS view_3_tab2_539 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8522,13 +8522,13 @@ SELECT pk FROM tab3 WHERE ((((col4 IN (272.1,413.34) AND col0 < 382) OR col0 >= 
 82 values hashing to 617dec3e7ac542d5321a7249d0b29f37
 
 statement ok
-DROP VIEW view_1_tab3_539
+DROP VIEW IF EXISTS view_1_tab3_539 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_539
+DROP VIEW IF EXISTS view_2_tab3_539 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_539
+DROP VIEW IF EXISTS view_3_tab3_539 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8619,13 +8619,13 @@ SELECT pk FROM tab4 WHERE ((((col4 IN (272.1,413.34) AND col0 < 382) OR col0 >= 
 82 values hashing to 617dec3e7ac542d5321a7249d0b29f37
 
 statement ok
-DROP VIEW view_1_tab4_539
+DROP VIEW IF EXISTS view_1_tab4_539 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_539
+DROP VIEW IF EXISTS view_2_tab4_539 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_539
+DROP VIEW IF EXISTS view_3_tab4_539 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8718,13 +8718,13 @@ SELECT pk FROM tab0 WHERE (col0 IN (844,789))
 51
 
 statement ok
-DROP VIEW view_1_tab0_540
+DROP VIEW IF EXISTS view_1_tab0_540 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_540
+DROP VIEW IF EXISTS view_2_tab0_540 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_540
+DROP VIEW IF EXISTS view_3_tab0_540 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8817,13 +8817,13 @@ SELECT pk FROM tab1 WHERE (col0 IN (844,789))
 51
 
 statement ok
-DROP VIEW view_1_tab1_540
+DROP VIEW IF EXISTS view_1_tab1_540 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_540
+DROP VIEW IF EXISTS view_2_tab1_540 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_540
+DROP VIEW IF EXISTS view_3_tab1_540 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8916,13 +8916,13 @@ SELECT pk FROM tab2 WHERE (col0 IN (844,789))
 51
 
 statement ok
-DROP VIEW view_1_tab2_540
+DROP VIEW IF EXISTS view_1_tab2_540 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_540
+DROP VIEW IF EXISTS view_2_tab2_540 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_540
+DROP VIEW IF EXISTS view_3_tab2_540 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9015,13 +9015,13 @@ SELECT pk FROM tab3 WHERE (col0 IN (844,789))
 51
 
 statement ok
-DROP VIEW view_1_tab3_540
+DROP VIEW IF EXISTS view_1_tab3_540 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_540
+DROP VIEW IF EXISTS view_2_tab3_540 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_540
+DROP VIEW IF EXISTS view_3_tab3_540 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9114,13 +9114,13 @@ SELECT pk FROM tab4 WHERE (col0 IN (844,789))
 51
 
 statement ok
-DROP VIEW view_1_tab4_540
+DROP VIEW IF EXISTS view_1_tab4_540 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_540
+DROP VIEW IF EXISTS view_2_tab4_540 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_540
+DROP VIEW IF EXISTS view_3_tab4_540 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9211,13 +9211,13 @@ SELECT pk FROM tab0 WHERE col0 < 766 AND col1 > 808.9 OR col1 > 474.74 OR (col3 
 54 values hashing to 9213df71149d28d3602fc054be2f58e6
 
 statement ok
-DROP VIEW view_1_tab0_541
+DROP VIEW IF EXISTS view_1_tab0_541 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_541
+DROP VIEW IF EXISTS view_2_tab0_541 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_541
+DROP VIEW IF EXISTS view_3_tab0_541 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9308,13 +9308,13 @@ SELECT pk FROM tab1 WHERE col0 < 766 AND col1 > 808.9 OR col1 > 474.74 OR (col3 
 54 values hashing to 9213df71149d28d3602fc054be2f58e6
 
 statement ok
-DROP VIEW view_1_tab1_541
+DROP VIEW IF EXISTS view_1_tab1_541 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_541
+DROP VIEW IF EXISTS view_2_tab1_541 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_541
+DROP VIEW IF EXISTS view_3_tab1_541 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9405,13 +9405,13 @@ SELECT pk FROM tab2 WHERE col0 < 766 AND col1 > 808.9 OR col1 > 474.74 OR (col3 
 54 values hashing to 9213df71149d28d3602fc054be2f58e6
 
 statement ok
-DROP VIEW view_1_tab2_541
+DROP VIEW IF EXISTS view_1_tab2_541 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_541
+DROP VIEW IF EXISTS view_2_tab2_541 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_541
+DROP VIEW IF EXISTS view_3_tab2_541 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9502,13 +9502,13 @@ SELECT pk FROM tab3 WHERE col0 < 766 AND col1 > 808.9 OR col1 > 474.74 OR (col3 
 54 values hashing to 9213df71149d28d3602fc054be2f58e6
 
 statement ok
-DROP VIEW view_1_tab3_541
+DROP VIEW IF EXISTS view_1_tab3_541 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_541
+DROP VIEW IF EXISTS view_2_tab3_541 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_541
+DROP VIEW IF EXISTS view_3_tab3_541 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9599,13 +9599,13 @@ SELECT pk FROM tab4 WHERE col0 < 766 AND col1 > 808.9 OR col1 > 474.74 OR (col3 
 54 values hashing to 9213df71149d28d3602fc054be2f58e6
 
 statement ok
-DROP VIEW view_1_tab4_541
+DROP VIEW IF EXISTS view_1_tab4_541 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_541
+DROP VIEW IF EXISTS view_2_tab4_541 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_541
+DROP VIEW IF EXISTS view_3_tab4_541 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9696,13 +9696,13 @@ SELECT pk FROM tab0 WHERE col0 > 759
 31 values hashing to b25eae4444366386067b8e25aca22877
 
 statement ok
-DROP VIEW view_1_tab0_542
+DROP VIEW IF EXISTS view_1_tab0_542 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_542
+DROP VIEW IF EXISTS view_2_tab0_542 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_542
+DROP VIEW IF EXISTS view_3_tab0_542 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9793,13 +9793,13 @@ SELECT pk FROM tab1 WHERE col0 > 759
 31 values hashing to b25eae4444366386067b8e25aca22877
 
 statement ok
-DROP VIEW view_1_tab1_542
+DROP VIEW IF EXISTS view_1_tab1_542 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_542
+DROP VIEW IF EXISTS view_2_tab1_542 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_542
+DROP VIEW IF EXISTS view_3_tab1_542 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9890,13 +9890,13 @@ SELECT pk FROM tab2 WHERE col0 > 759
 31 values hashing to b25eae4444366386067b8e25aca22877
 
 statement ok
-DROP VIEW view_1_tab2_542
+DROP VIEW IF EXISTS view_1_tab2_542 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_542
+DROP VIEW IF EXISTS view_2_tab2_542 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_542
+DROP VIEW IF EXISTS view_3_tab2_542 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9987,13 +9987,13 @@ SELECT pk FROM tab3 WHERE col0 > 759
 31 values hashing to b25eae4444366386067b8e25aca22877
 
 statement ok
-DROP VIEW view_1_tab3_542
+DROP VIEW IF EXISTS view_1_tab3_542 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_542
+DROP VIEW IF EXISTS view_2_tab3_542 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_542
+DROP VIEW IF EXISTS view_3_tab3_542 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10084,13 +10084,13 @@ SELECT pk FROM tab4 WHERE col0 > 759
 31 values hashing to b25eae4444366386067b8e25aca22877
 
 statement ok
-DROP VIEW view_1_tab4_542
+DROP VIEW IF EXISTS view_1_tab4_542 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_542
+DROP VIEW IF EXISTS view_2_tab4_542 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_542
+DROP VIEW IF EXISTS view_3_tab4_542 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10176,13 +10176,13 @@ SELECT pk FROM tab0 WHERE col3 = 919
 ----
 
 statement ok
-DROP VIEW view_1_tab0_543
+DROP VIEW IF EXISTS view_1_tab0_543 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_543
+DROP VIEW IF EXISTS view_2_tab0_543 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_543
+DROP VIEW IF EXISTS view_3_tab0_543 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10268,13 +10268,13 @@ SELECT pk FROM tab1 WHERE col3 = 919
 ----
 
 statement ok
-DROP VIEW view_1_tab1_543
+DROP VIEW IF EXISTS view_1_tab1_543 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_543
+DROP VIEW IF EXISTS view_2_tab1_543 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_543
+DROP VIEW IF EXISTS view_3_tab1_543 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10360,13 +10360,13 @@ SELECT pk FROM tab2 WHERE col3 = 919
 ----
 
 statement ok
-DROP VIEW view_1_tab2_543
+DROP VIEW IF EXISTS view_1_tab2_543 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_543
+DROP VIEW IF EXISTS view_2_tab2_543 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_543
+DROP VIEW IF EXISTS view_3_tab2_543 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10452,13 +10452,13 @@ SELECT pk FROM tab3 WHERE col3 = 919
 ----
 
 statement ok
-DROP VIEW view_1_tab3_543
+DROP VIEW IF EXISTS view_1_tab3_543 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_543
+DROP VIEW IF EXISTS view_2_tab3_543 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_543
+DROP VIEW IF EXISTS view_3_tab3_543 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10544,13 +10544,13 @@ SELECT pk FROM tab4 WHERE col3 = 919
 ----
 
 statement ok
-DROP VIEW view_1_tab4_543
+DROP VIEW IF EXISTS view_1_tab4_543 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_543
+DROP VIEW IF EXISTS view_2_tab4_543 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_543
+DROP VIEW IF EXISTS view_3_tab4_543 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10641,13 +10641,13 @@ SELECT pk FROM tab0 WHERE (((col3 > 386 OR col0 <= 556) AND col3 >= 841))
 18 values hashing to 07ff8a0995e1b1767fc5e6624c909fd3
 
 statement ok
-DROP VIEW view_1_tab0_544
+DROP VIEW IF EXISTS view_1_tab0_544 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_544
+DROP VIEW IF EXISTS view_2_tab0_544 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_544
+DROP VIEW IF EXISTS view_3_tab0_544 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10738,13 +10738,13 @@ SELECT pk FROM tab1 WHERE (((col3 > 386 OR col0 <= 556) AND col3 >= 841))
 18 values hashing to 07ff8a0995e1b1767fc5e6624c909fd3
 
 statement ok
-DROP VIEW view_1_tab1_544
+DROP VIEW IF EXISTS view_1_tab1_544 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_544
+DROP VIEW IF EXISTS view_2_tab1_544 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_544
+DROP VIEW IF EXISTS view_3_tab1_544 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10835,13 +10835,13 @@ SELECT pk FROM tab2 WHERE (((col3 > 386 OR col0 <= 556) AND col3 >= 841))
 18 values hashing to 07ff8a0995e1b1767fc5e6624c909fd3
 
 statement ok
-DROP VIEW view_1_tab2_544
+DROP VIEW IF EXISTS view_1_tab2_544 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_544
+DROP VIEW IF EXISTS view_2_tab2_544 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_544
+DROP VIEW IF EXISTS view_3_tab2_544 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10932,13 +10932,13 @@ SELECT pk FROM tab3 WHERE (((col3 > 386 OR col0 <= 556) AND col3 >= 841))
 18 values hashing to 07ff8a0995e1b1767fc5e6624c909fd3
 
 statement ok
-DROP VIEW view_1_tab3_544
+DROP VIEW IF EXISTS view_1_tab3_544 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_544
+DROP VIEW IF EXISTS view_2_tab3_544 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_544
+DROP VIEW IF EXISTS view_3_tab3_544 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11029,13 +11029,13 @@ SELECT pk FROM tab4 WHERE (((col3 > 386 OR col0 <= 556) AND col3 >= 841))
 18 values hashing to 07ff8a0995e1b1767fc5e6624c909fd3
 
 statement ok
-DROP VIEW view_1_tab4_544
+DROP VIEW IF EXISTS view_1_tab4_544 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_544
+DROP VIEW IF EXISTS view_2_tab4_544 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_544
+DROP VIEW IF EXISTS view_3_tab4_544 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11141,13 +11141,13 @@ SELECT pk FROM tab0 WHERE ((((col4 <= 13.6 AND col0 >= 3 OR (col0 < 68)))) AND c
 84
 
 statement ok
-DROP VIEW view_1_tab0_545
+DROP VIEW IF EXISTS view_1_tab0_545 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_545
+DROP VIEW IF EXISTS view_2_tab0_545 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_545
+DROP VIEW IF EXISTS view_3_tab0_545 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11253,13 +11253,13 @@ SELECT pk FROM tab1 WHERE ((((col4 <= 13.6 AND col0 >= 3 OR (col0 < 68)))) AND c
 84
 
 statement ok
-DROP VIEW view_1_tab1_545
+DROP VIEW IF EXISTS view_1_tab1_545 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_545
+DROP VIEW IF EXISTS view_2_tab1_545 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_545
+DROP VIEW IF EXISTS view_3_tab1_545 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11365,13 +11365,13 @@ SELECT pk FROM tab2 WHERE ((((col4 <= 13.6 AND col0 >= 3 OR (col0 < 68)))) AND c
 84
 
 statement ok
-DROP VIEW view_1_tab2_545
+DROP VIEW IF EXISTS view_1_tab2_545 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_545
+DROP VIEW IF EXISTS view_2_tab2_545 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_545
+DROP VIEW IF EXISTS view_3_tab2_545 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11477,13 +11477,13 @@ SELECT pk FROM tab3 WHERE ((((col4 <= 13.6 AND col0 >= 3 OR (col0 < 68)))) AND c
 84
 
 statement ok
-DROP VIEW view_1_tab3_545
+DROP VIEW IF EXISTS view_1_tab3_545 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_545
+DROP VIEW IF EXISTS view_2_tab3_545 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_545
+DROP VIEW IF EXISTS view_3_tab3_545 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11589,13 +11589,13 @@ SELECT pk FROM tab4 WHERE ((((col4 <= 13.6 AND col0 >= 3 OR (col0 < 68)))) AND c
 84
 
 statement ok
-DROP VIEW view_1_tab4_545
+DROP VIEW IF EXISTS view_1_tab4_545 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_545
+DROP VIEW IF EXISTS view_2_tab4_545 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_545
+DROP VIEW IF EXISTS view_3_tab4_545 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11686,13 +11686,13 @@ SELECT pk FROM tab0 WHERE col3 > 332
 61 values hashing to 139c03fa11c8dfefe5cd4294a92dca48
 
 statement ok
-DROP VIEW view_1_tab0_546
+DROP VIEW IF EXISTS view_1_tab0_546 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_546
+DROP VIEW IF EXISTS view_2_tab0_546 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_546
+DROP VIEW IF EXISTS view_3_tab0_546 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11783,13 +11783,13 @@ SELECT pk FROM tab1 WHERE col3 > 332
 61 values hashing to 139c03fa11c8dfefe5cd4294a92dca48
 
 statement ok
-DROP VIEW view_1_tab1_546
+DROP VIEW IF EXISTS view_1_tab1_546 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_546
+DROP VIEW IF EXISTS view_2_tab1_546 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_546
+DROP VIEW IF EXISTS view_3_tab1_546 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11880,13 +11880,13 @@ SELECT pk FROM tab2 WHERE col3 > 332
 61 values hashing to 139c03fa11c8dfefe5cd4294a92dca48
 
 statement ok
-DROP VIEW view_1_tab2_546
+DROP VIEW IF EXISTS view_1_tab2_546 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_546
+DROP VIEW IF EXISTS view_2_tab2_546 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_546
+DROP VIEW IF EXISTS view_3_tab2_546 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11977,13 +11977,13 @@ SELECT pk FROM tab3 WHERE col3 > 332
 61 values hashing to 139c03fa11c8dfefe5cd4294a92dca48
 
 statement ok
-DROP VIEW view_1_tab3_546
+DROP VIEW IF EXISTS view_1_tab3_546 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_546
+DROP VIEW IF EXISTS view_2_tab3_546 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_546
+DROP VIEW IF EXISTS view_3_tab3_546 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12074,13 +12074,13 @@ SELECT pk FROM tab4 WHERE col3 > 332
 61 values hashing to 139c03fa11c8dfefe5cd4294a92dca48
 
 statement ok
-DROP VIEW view_1_tab4_546
+DROP VIEW IF EXISTS view_1_tab4_546 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_546
+DROP VIEW IF EXISTS view_2_tab4_546 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_546
+DROP VIEW IF EXISTS view_3_tab4_546 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12171,13 +12171,13 @@ SELECT pk FROM tab0 WHERE ((col3 < 401))
 48 values hashing to 1bdbcd11b33df94c0d87106ea28a866f
 
 statement ok
-DROP VIEW view_1_tab0_547
+DROP VIEW IF EXISTS view_1_tab0_547 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_547
+DROP VIEW IF EXISTS view_2_tab0_547 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_547
+DROP VIEW IF EXISTS view_3_tab0_547 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12268,13 +12268,13 @@ SELECT pk FROM tab1 WHERE ((col3 < 401))
 48 values hashing to 1bdbcd11b33df94c0d87106ea28a866f
 
 statement ok
-DROP VIEW view_1_tab1_547
+DROP VIEW IF EXISTS view_1_tab1_547 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_547
+DROP VIEW IF EXISTS view_2_tab1_547 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_547
+DROP VIEW IF EXISTS view_3_tab1_547 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12365,13 +12365,13 @@ SELECT pk FROM tab2 WHERE ((col3 < 401))
 48 values hashing to 1bdbcd11b33df94c0d87106ea28a866f
 
 statement ok
-DROP VIEW view_1_tab2_547
+DROP VIEW IF EXISTS view_1_tab2_547 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_547
+DROP VIEW IF EXISTS view_2_tab2_547 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_547
+DROP VIEW IF EXISTS view_3_tab2_547 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12462,13 +12462,13 @@ SELECT pk FROM tab3 WHERE ((col3 < 401))
 48 values hashing to 1bdbcd11b33df94c0d87106ea28a866f
 
 statement ok
-DROP VIEW view_1_tab3_547
+DROP VIEW IF EXISTS view_1_tab3_547 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_547
+DROP VIEW IF EXISTS view_2_tab3_547 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_547
+DROP VIEW IF EXISTS view_3_tab3_547 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12559,13 +12559,13 @@ SELECT pk FROM tab4 WHERE ((col3 < 401))
 48 values hashing to 1bdbcd11b33df94c0d87106ea28a866f
 
 statement ok
-DROP VIEW view_1_tab4_547
+DROP VIEW IF EXISTS view_1_tab4_547 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_547
+DROP VIEW IF EXISTS view_2_tab4_547 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_547
+DROP VIEW IF EXISTS view_3_tab4_547 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12656,13 +12656,13 @@ SELECT pk FROM tab0 WHERE (col3 <= 777 AND (col3 > 311))
 41 values hashing to 3a6fc2069f944f99179f9dbab9ed04e9
 
 statement ok
-DROP VIEW view_1_tab0_548
+DROP VIEW IF EXISTS view_1_tab0_548 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_548
+DROP VIEW IF EXISTS view_2_tab0_548 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_548
+DROP VIEW IF EXISTS view_3_tab0_548 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12753,13 +12753,13 @@ SELECT pk FROM tab1 WHERE (col3 <= 777 AND (col3 > 311))
 41 values hashing to 3a6fc2069f944f99179f9dbab9ed04e9
 
 statement ok
-DROP VIEW view_1_tab1_548
+DROP VIEW IF EXISTS view_1_tab1_548 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_548
+DROP VIEW IF EXISTS view_2_tab1_548 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_548
+DROP VIEW IF EXISTS view_3_tab1_548 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12850,13 +12850,13 @@ SELECT pk FROM tab2 WHERE (col3 <= 777 AND (col3 > 311))
 41 values hashing to 3a6fc2069f944f99179f9dbab9ed04e9
 
 statement ok
-DROP VIEW view_1_tab2_548
+DROP VIEW IF EXISTS view_1_tab2_548 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_548
+DROP VIEW IF EXISTS view_2_tab2_548 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_548
+DROP VIEW IF EXISTS view_3_tab2_548 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12947,13 +12947,13 @@ SELECT pk FROM tab3 WHERE (col3 <= 777 AND (col3 > 311))
 41 values hashing to 3a6fc2069f944f99179f9dbab9ed04e9
 
 statement ok
-DROP VIEW view_1_tab3_548
+DROP VIEW IF EXISTS view_1_tab3_548 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_548
+DROP VIEW IF EXISTS view_2_tab3_548 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_548
+DROP VIEW IF EXISTS view_3_tab3_548 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13044,13 +13044,13 @@ SELECT pk FROM tab4 WHERE (col3 <= 777 AND (col3 > 311))
 41 values hashing to 3a6fc2069f944f99179f9dbab9ed04e9
 
 statement ok
-DROP VIEW view_1_tab4_548
+DROP VIEW IF EXISTS view_1_tab4_548 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_548
+DROP VIEW IF EXISTS view_2_tab4_548 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_548
+DROP VIEW IF EXISTS view_3_tab4_548 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13141,13 +13141,13 @@ SELECT pk FROM tab0 WHERE col4 <= 557.21
 55 values hashing to 8a188e963d7c11801b348633c441e267
 
 statement ok
-DROP VIEW view_1_tab0_549
+DROP VIEW IF EXISTS view_1_tab0_549 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_549
+DROP VIEW IF EXISTS view_2_tab0_549 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_549
+DROP VIEW IF EXISTS view_3_tab0_549 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13238,13 +13238,13 @@ SELECT pk FROM tab1 WHERE col4 <= 557.21
 55 values hashing to 8a188e963d7c11801b348633c441e267
 
 statement ok
-DROP VIEW view_1_tab1_549
+DROP VIEW IF EXISTS view_1_tab1_549 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_549
+DROP VIEW IF EXISTS view_2_tab1_549 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_549
+DROP VIEW IF EXISTS view_3_tab1_549 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13335,13 +13335,13 @@ SELECT pk FROM tab2 WHERE col4 <= 557.21
 55 values hashing to 8a188e963d7c11801b348633c441e267
 
 statement ok
-DROP VIEW view_1_tab2_549
+DROP VIEW IF EXISTS view_1_tab2_549 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_549
+DROP VIEW IF EXISTS view_2_tab2_549 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_549
+DROP VIEW IF EXISTS view_3_tab2_549 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13432,13 +13432,13 @@ SELECT pk FROM tab3 WHERE col4 <= 557.21
 55 values hashing to 8a188e963d7c11801b348633c441e267
 
 statement ok
-DROP VIEW view_1_tab3_549
+DROP VIEW IF EXISTS view_1_tab3_549 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_549
+DROP VIEW IF EXISTS view_2_tab3_549 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_549
+DROP VIEW IF EXISTS view_3_tab3_549 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13529,13 +13529,13 @@ SELECT pk FROM tab4 WHERE col4 <= 557.21
 55 values hashing to 8a188e963d7c11801b348633c441e267
 
 statement ok
-DROP VIEW view_1_tab4_549
+DROP VIEW IF EXISTS view_1_tab4_549 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_549
+DROP VIEW IF EXISTS view_2_tab4_549 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_549
+DROP VIEW IF EXISTS view_3_tab4_549 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13626,13 +13626,13 @@ SELECT pk FROM tab0 WHERE (col1 < 902.3)
 85 values hashing to d929e5081a45daa1b326472dbad181b3
 
 statement ok
-DROP VIEW view_1_tab0_550
+DROP VIEW IF EXISTS view_1_tab0_550 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_550
+DROP VIEW IF EXISTS view_2_tab0_550 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_550
+DROP VIEW IF EXISTS view_3_tab0_550 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13723,13 +13723,13 @@ SELECT pk FROM tab1 WHERE (col1 < 902.3)
 85 values hashing to d929e5081a45daa1b326472dbad181b3
 
 statement ok
-DROP VIEW view_1_tab1_550
+DROP VIEW IF EXISTS view_1_tab1_550 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_550
+DROP VIEW IF EXISTS view_2_tab1_550 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_550
+DROP VIEW IF EXISTS view_3_tab1_550 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13820,13 +13820,13 @@ SELECT pk FROM tab2 WHERE (col1 < 902.3)
 85 values hashing to d929e5081a45daa1b326472dbad181b3
 
 statement ok
-DROP VIEW view_1_tab2_550
+DROP VIEW IF EXISTS view_1_tab2_550 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_550
+DROP VIEW IF EXISTS view_2_tab2_550 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_550
+DROP VIEW IF EXISTS view_3_tab2_550 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13917,13 +13917,13 @@ SELECT pk FROM tab3 WHERE (col1 < 902.3)
 85 values hashing to d929e5081a45daa1b326472dbad181b3
 
 statement ok
-DROP VIEW view_1_tab3_550
+DROP VIEW IF EXISTS view_1_tab3_550 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_550
+DROP VIEW IF EXISTS view_2_tab3_550 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_550
+DROP VIEW IF EXISTS view_3_tab3_550 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14014,13 +14014,13 @@ SELECT pk FROM tab4 WHERE (col1 < 902.3)
 85 values hashing to d929e5081a45daa1b326472dbad181b3
 
 statement ok
-DROP VIEW view_1_tab4_550
+DROP VIEW IF EXISTS view_1_tab4_550 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_550
+DROP VIEW IF EXISTS view_2_tab4_550 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_550
+DROP VIEW IF EXISTS view_3_tab4_550 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14109,13 +14109,13 @@ SELECT pk FROM tab0 WHERE (col3 >= 534) OR col0 >= 193 OR (col3 > 616 OR (col3 I
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab0_551
+DROP VIEW IF EXISTS view_1_tab0_551 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_551
+DROP VIEW IF EXISTS view_2_tab0_551 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_551
+DROP VIEW IF EXISTS view_3_tab0_551 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14204,13 +14204,13 @@ SELECT pk FROM tab1 WHERE (col3 >= 534) OR col0 >= 193 OR (col3 > 616 OR (col3 I
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab1_551
+DROP VIEW IF EXISTS view_1_tab1_551 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_551
+DROP VIEW IF EXISTS view_2_tab1_551 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_551
+DROP VIEW IF EXISTS view_3_tab1_551 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14299,13 +14299,13 @@ SELECT pk FROM tab2 WHERE (col3 >= 534) OR col0 >= 193 OR (col3 > 616 OR (col3 I
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab2_551
+DROP VIEW IF EXISTS view_1_tab2_551 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_551
+DROP VIEW IF EXISTS view_2_tab2_551 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_551
+DROP VIEW IF EXISTS view_3_tab2_551 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14394,13 +14394,13 @@ SELECT pk FROM tab3 WHERE (col3 >= 534) OR col0 >= 193 OR (col3 > 616 OR (col3 I
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab3_551
+DROP VIEW IF EXISTS view_1_tab3_551 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_551
+DROP VIEW IF EXISTS view_2_tab3_551 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_551
+DROP VIEW IF EXISTS view_3_tab3_551 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14489,13 +14489,13 @@ SELECT pk FROM tab4 WHERE (col3 >= 534) OR col0 >= 193 OR (col3 > 616 OR (col3 I
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab4_551
+DROP VIEW IF EXISTS view_1_tab4_551 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_551
+DROP VIEW IF EXISTS view_2_tab4_551 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_551
+DROP VIEW IF EXISTS view_3_tab4_551 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14581,13 +14581,13 @@ SELECT pk FROM tab0 WHERE (col3 IS NULL AND (col0 >= 558) AND col4 IS NULL AND c
 ----
 
 statement ok
-DROP VIEW view_1_tab0_552
+DROP VIEW IF EXISTS view_1_tab0_552 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_552
+DROP VIEW IF EXISTS view_2_tab0_552 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_552
+DROP VIEW IF EXISTS view_3_tab0_552 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14673,13 +14673,13 @@ SELECT pk FROM tab1 WHERE (col3 IS NULL AND (col0 >= 558) AND col4 IS NULL AND c
 ----
 
 statement ok
-DROP VIEW view_1_tab1_552
+DROP VIEW IF EXISTS view_1_tab1_552 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_552
+DROP VIEW IF EXISTS view_2_tab1_552 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_552
+DROP VIEW IF EXISTS view_3_tab1_552 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14765,13 +14765,13 @@ SELECT pk FROM tab2 WHERE (col3 IS NULL AND (col0 >= 558) AND col4 IS NULL AND c
 ----
 
 statement ok
-DROP VIEW view_1_tab2_552
+DROP VIEW IF EXISTS view_1_tab2_552 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_552
+DROP VIEW IF EXISTS view_2_tab2_552 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_552
+DROP VIEW IF EXISTS view_3_tab2_552 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14857,13 +14857,13 @@ SELECT pk FROM tab3 WHERE (col3 IS NULL AND (col0 >= 558) AND col4 IS NULL AND c
 ----
 
 statement ok
-DROP VIEW view_1_tab3_552
+DROP VIEW IF EXISTS view_1_tab3_552 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_552
+DROP VIEW IF EXISTS view_2_tab3_552 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_552
+DROP VIEW IF EXISTS view_3_tab3_552 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14949,13 +14949,13 @@ SELECT pk FROM tab4 WHERE (col3 IS NULL AND (col0 >= 558) AND col4 IS NULL AND c
 ----
 
 statement ok
-DROP VIEW view_1_tab4_552
+DROP VIEW IF EXISTS view_1_tab4_552 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_552
+DROP VIEW IF EXISTS view_2_tab4_552 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_552
+DROP VIEW IF EXISTS view_3_tab4_552 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15061,13 +15061,13 @@ SELECT pk FROM tab0 WHERE col1 < 94.39
 88
 
 statement ok
-DROP VIEW view_1_tab0_554
+DROP VIEW IF EXISTS view_1_tab0_554 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_554
+DROP VIEW IF EXISTS view_2_tab0_554 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_554
+DROP VIEW IF EXISTS view_3_tab0_554 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15173,13 +15173,13 @@ SELECT pk FROM tab1 WHERE col1 < 94.39
 88
 
 statement ok
-DROP VIEW view_1_tab1_554
+DROP VIEW IF EXISTS view_1_tab1_554 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_554
+DROP VIEW IF EXISTS view_2_tab1_554 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_554
+DROP VIEW IF EXISTS view_3_tab1_554 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15285,13 +15285,13 @@ SELECT pk FROM tab2 WHERE col1 < 94.39
 88
 
 statement ok
-DROP VIEW view_1_tab2_554
+DROP VIEW IF EXISTS view_1_tab2_554 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_554
+DROP VIEW IF EXISTS view_2_tab2_554 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_554
+DROP VIEW IF EXISTS view_3_tab2_554 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15397,13 +15397,13 @@ SELECT pk FROM tab3 WHERE col1 < 94.39
 88
 
 statement ok
-DROP VIEW view_1_tab3_554
+DROP VIEW IF EXISTS view_1_tab3_554 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_554
+DROP VIEW IF EXISTS view_2_tab3_554 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_554
+DROP VIEW IF EXISTS view_3_tab3_554 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15509,13 +15509,13 @@ SELECT pk FROM tab4 WHERE col1 < 94.39
 88
 
 statement ok
-DROP VIEW view_1_tab4_554
+DROP VIEW IF EXISTS view_1_tab4_554 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_554
+DROP VIEW IF EXISTS view_2_tab4_554 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_554
+DROP VIEW IF EXISTS view_3_tab4_554 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15608,13 +15608,13 @@ SELECT pk FROM tab0 WHERE ((col1 >= 570.11 AND (col3 <= 158))) OR col1 >= 228.8 
 99 values hashing to 59f386e277e147a6435c2b3d1c98c7a8
 
 statement ok
-DROP VIEW view_1_tab0_555
+DROP VIEW IF EXISTS view_1_tab0_555 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_555
+DROP VIEW IF EXISTS view_2_tab0_555 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_555
+DROP VIEW IF EXISTS view_3_tab0_555 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15707,13 +15707,13 @@ SELECT pk FROM tab1 WHERE ((col1 >= 570.11 AND (col3 <= 158))) OR col1 >= 228.8 
 99 values hashing to 59f386e277e147a6435c2b3d1c98c7a8
 
 statement ok
-DROP VIEW view_1_tab1_555
+DROP VIEW IF EXISTS view_1_tab1_555 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_555
+DROP VIEW IF EXISTS view_2_tab1_555 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_555
+DROP VIEW IF EXISTS view_3_tab1_555 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15806,13 +15806,13 @@ SELECT pk FROM tab2 WHERE ((col1 >= 570.11 AND (col3 <= 158))) OR col1 >= 228.8 
 99 values hashing to 59f386e277e147a6435c2b3d1c98c7a8
 
 statement ok
-DROP VIEW view_1_tab2_555
+DROP VIEW IF EXISTS view_1_tab2_555 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_555
+DROP VIEW IF EXISTS view_2_tab2_555 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_555
+DROP VIEW IF EXISTS view_3_tab2_555 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15905,13 +15905,13 @@ SELECT pk FROM tab3 WHERE ((col1 >= 570.11 AND (col3 <= 158))) OR col1 >= 228.8 
 99 values hashing to 59f386e277e147a6435c2b3d1c98c7a8
 
 statement ok
-DROP VIEW view_1_tab3_555
+DROP VIEW IF EXISTS view_1_tab3_555 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_555
+DROP VIEW IF EXISTS view_2_tab3_555 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_555
+DROP VIEW IF EXISTS view_3_tab3_555 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16004,13 +16004,13 @@ SELECT pk FROM tab4 WHERE ((col1 >= 570.11 AND (col3 <= 158))) OR col1 >= 228.8 
 99 values hashing to 59f386e277e147a6435c2b3d1c98c7a8
 
 statement ok
-DROP VIEW view_1_tab4_555
+DROP VIEW IF EXISTS view_1_tab4_555 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_555
+DROP VIEW IF EXISTS view_2_tab4_555 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_555
+DROP VIEW IF EXISTS view_3_tab4_555 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16101,13 +16101,13 @@ SELECT pk FROM tab0 WHERE col3 BETWEEN 132 AND 850
 72 values hashing to d0ff4be1066638ae0098d9d00e778944
 
 statement ok
-DROP VIEW view_1_tab0_556
+DROP VIEW IF EXISTS view_1_tab0_556 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_556
+DROP VIEW IF EXISTS view_2_tab0_556 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_556
+DROP VIEW IF EXISTS view_3_tab0_556 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16198,13 +16198,13 @@ SELECT pk FROM tab1 WHERE col3 BETWEEN 132 AND 850
 72 values hashing to d0ff4be1066638ae0098d9d00e778944
 
 statement ok
-DROP VIEW view_1_tab1_556
+DROP VIEW IF EXISTS view_1_tab1_556 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_556
+DROP VIEW IF EXISTS view_2_tab1_556 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_556
+DROP VIEW IF EXISTS view_3_tab1_556 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16295,13 +16295,13 @@ SELECT pk FROM tab2 WHERE col3 BETWEEN 132 AND 850
 72 values hashing to d0ff4be1066638ae0098d9d00e778944
 
 statement ok
-DROP VIEW view_1_tab2_556
+DROP VIEW IF EXISTS view_1_tab2_556 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_556
+DROP VIEW IF EXISTS view_2_tab2_556 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_556
+DROP VIEW IF EXISTS view_3_tab2_556 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16392,13 +16392,13 @@ SELECT pk FROM tab3 WHERE col3 BETWEEN 132 AND 850
 72 values hashing to d0ff4be1066638ae0098d9d00e778944
 
 statement ok
-DROP VIEW view_1_tab3_556
+DROP VIEW IF EXISTS view_1_tab3_556 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_556
+DROP VIEW IF EXISTS view_2_tab3_556 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_556
+DROP VIEW IF EXISTS view_3_tab3_556 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16489,13 +16489,13 @@ SELECT pk FROM tab4 WHERE col3 BETWEEN 132 AND 850
 72 values hashing to d0ff4be1066638ae0098d9d00e778944
 
 statement ok
-DROP VIEW view_1_tab4_556
+DROP VIEW IF EXISTS view_1_tab4_556 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_556
+DROP VIEW IF EXISTS view_2_tab4_556 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_556
+DROP VIEW IF EXISTS view_3_tab4_556 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16586,13 +16586,13 @@ SELECT pk FROM tab0 WHERE (((col3 > 799)))
 20 values hashing to 579257c89a104be8ca2d7a211b4075e6
 
 statement ok
-DROP VIEW view_1_tab0_557
+DROP VIEW IF EXISTS view_1_tab0_557 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_557
+DROP VIEW IF EXISTS view_2_tab0_557 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_557
+DROP VIEW IF EXISTS view_3_tab0_557 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16683,13 +16683,13 @@ SELECT pk FROM tab1 WHERE (((col3 > 799)))
 20 values hashing to 579257c89a104be8ca2d7a211b4075e6
 
 statement ok
-DROP VIEW view_1_tab1_557
+DROP VIEW IF EXISTS view_1_tab1_557 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_557
+DROP VIEW IF EXISTS view_2_tab1_557 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_557
+DROP VIEW IF EXISTS view_3_tab1_557 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16780,13 +16780,13 @@ SELECT pk FROM tab2 WHERE (((col3 > 799)))
 20 values hashing to 579257c89a104be8ca2d7a211b4075e6
 
 statement ok
-DROP VIEW view_1_tab2_557
+DROP VIEW IF EXISTS view_1_tab2_557 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_557
+DROP VIEW IF EXISTS view_2_tab2_557 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_557
+DROP VIEW IF EXISTS view_3_tab2_557 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16877,13 +16877,13 @@ SELECT pk FROM tab3 WHERE (((col3 > 799)))
 20 values hashing to 579257c89a104be8ca2d7a211b4075e6
 
 statement ok
-DROP VIEW view_1_tab3_557
+DROP VIEW IF EXISTS view_1_tab3_557 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_557
+DROP VIEW IF EXISTS view_2_tab3_557 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_557
+DROP VIEW IF EXISTS view_3_tab3_557 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16974,13 +16974,13 @@ SELECT pk FROM tab4 WHERE (((col3 > 799)))
 20 values hashing to 579257c89a104be8ca2d7a211b4075e6
 
 statement ok
-DROP VIEW view_1_tab4_557
+DROP VIEW IF EXISTS view_1_tab4_557 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_557
+DROP VIEW IF EXISTS view_2_tab4_557 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_557
+DROP VIEW IF EXISTS view_3_tab4_557 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17071,13 +17071,13 @@ SELECT pk FROM tab0 WHERE col1 < 344.47 OR (col3 <= 281) OR col3 <= 82 AND col0 
 58 values hashing to 9a7c900839ac3705c2864850d40c716f
 
 statement ok
-DROP VIEW view_1_tab0_558
+DROP VIEW IF EXISTS view_1_tab0_558 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_558
+DROP VIEW IF EXISTS view_2_tab0_558 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_558
+DROP VIEW IF EXISTS view_3_tab0_558 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17168,13 +17168,13 @@ SELECT pk FROM tab1 WHERE col1 < 344.47 OR (col3 <= 281) OR col3 <= 82 AND col0 
 58 values hashing to 9a7c900839ac3705c2864850d40c716f
 
 statement ok
-DROP VIEW view_1_tab1_558
+DROP VIEW IF EXISTS view_1_tab1_558 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_558
+DROP VIEW IF EXISTS view_2_tab1_558 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_558
+DROP VIEW IF EXISTS view_3_tab1_558 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17265,13 +17265,13 @@ SELECT pk FROM tab2 WHERE col1 < 344.47 OR (col3 <= 281) OR col3 <= 82 AND col0 
 58 values hashing to 9a7c900839ac3705c2864850d40c716f
 
 statement ok
-DROP VIEW view_1_tab2_558
+DROP VIEW IF EXISTS view_1_tab2_558 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_558
+DROP VIEW IF EXISTS view_2_tab2_558 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_558
+DROP VIEW IF EXISTS view_3_tab2_558 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17362,13 +17362,13 @@ SELECT pk FROM tab3 WHERE col1 < 344.47 OR (col3 <= 281) OR col3 <= 82 AND col0 
 58 values hashing to 9a7c900839ac3705c2864850d40c716f
 
 statement ok
-DROP VIEW view_1_tab3_558
+DROP VIEW IF EXISTS view_1_tab3_558 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_558
+DROP VIEW IF EXISTS view_2_tab3_558 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_558
+DROP VIEW IF EXISTS view_3_tab3_558 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17459,13 +17459,13 @@ SELECT pk FROM tab4 WHERE col1 < 344.47 OR (col3 <= 281) OR col3 <= 82 AND col0 
 58 values hashing to 9a7c900839ac3705c2864850d40c716f
 
 statement ok
-DROP VIEW view_1_tab4_558
+DROP VIEW IF EXISTS view_1_tab4_558 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_558
+DROP VIEW IF EXISTS view_2_tab4_558 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_558
+DROP VIEW IF EXISTS view_3_tab4_558 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17551,13 +17551,13 @@ SELECT pk FROM tab0 WHERE col1 BETWEEN 308.75 AND 57.44
 ----
 
 statement ok
-DROP VIEW view_1_tab0_559
+DROP VIEW IF EXISTS view_1_tab0_559 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_559
+DROP VIEW IF EXISTS view_2_tab0_559 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_559
+DROP VIEW IF EXISTS view_3_tab0_559 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17643,13 +17643,13 @@ SELECT pk FROM tab1 WHERE col1 BETWEEN 308.75 AND 57.44
 ----
 
 statement ok
-DROP VIEW view_1_tab1_559
+DROP VIEW IF EXISTS view_1_tab1_559 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_559
+DROP VIEW IF EXISTS view_2_tab1_559 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_559
+DROP VIEW IF EXISTS view_3_tab1_559 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17735,13 +17735,13 @@ SELECT pk FROM tab2 WHERE col1 BETWEEN 308.75 AND 57.44
 ----
 
 statement ok
-DROP VIEW view_1_tab2_559
+DROP VIEW IF EXISTS view_1_tab2_559 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_559
+DROP VIEW IF EXISTS view_2_tab2_559 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_559
+DROP VIEW IF EXISTS view_3_tab2_559 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17827,13 +17827,13 @@ SELECT pk FROM tab3 WHERE col1 BETWEEN 308.75 AND 57.44
 ----
 
 statement ok
-DROP VIEW view_1_tab3_559
+DROP VIEW IF EXISTS view_1_tab3_559 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_559
+DROP VIEW IF EXISTS view_2_tab3_559 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_559
+DROP VIEW IF EXISTS view_3_tab3_559 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17919,13 +17919,13 @@ SELECT pk FROM tab4 WHERE col1 BETWEEN 308.75 AND 57.44
 ----
 
 statement ok
-DROP VIEW view_1_tab4_559
+DROP VIEW IF EXISTS view_1_tab4_559 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_559
+DROP VIEW IF EXISTS view_2_tab4_559 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_559
+DROP VIEW IF EXISTS view_3_tab4_559 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18016,13 +18016,13 @@ SELECT pk FROM tab0 WHERE (((col0 > 391)))
 61 values hashing to ac62ac22ade6bfcc0bee9796ab543919
 
 statement ok
-DROP VIEW view_1_tab0_560
+DROP VIEW IF EXISTS view_1_tab0_560 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_560
+DROP VIEW IF EXISTS view_2_tab0_560 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_560
+DROP VIEW IF EXISTS view_3_tab0_560 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18113,13 +18113,13 @@ SELECT pk FROM tab1 WHERE (((col0 > 391)))
 61 values hashing to ac62ac22ade6bfcc0bee9796ab543919
 
 statement ok
-DROP VIEW view_1_tab1_560
+DROP VIEW IF EXISTS view_1_tab1_560 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_560
+DROP VIEW IF EXISTS view_2_tab1_560 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_560
+DROP VIEW IF EXISTS view_3_tab1_560 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18210,13 +18210,13 @@ SELECT pk FROM tab2 WHERE (((col0 > 391)))
 61 values hashing to ac62ac22ade6bfcc0bee9796ab543919
 
 statement ok
-DROP VIEW view_1_tab2_560
+DROP VIEW IF EXISTS view_1_tab2_560 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_560
+DROP VIEW IF EXISTS view_2_tab2_560 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_560
+DROP VIEW IF EXISTS view_3_tab2_560 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18307,13 +18307,13 @@ SELECT pk FROM tab3 WHERE (((col0 > 391)))
 61 values hashing to ac62ac22ade6bfcc0bee9796ab543919
 
 statement ok
-DROP VIEW view_1_tab3_560
+DROP VIEW IF EXISTS view_1_tab3_560 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_560
+DROP VIEW IF EXISTS view_2_tab3_560 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_560
+DROP VIEW IF EXISTS view_3_tab3_560 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18404,13 +18404,13 @@ SELECT pk FROM tab4 WHERE (((col0 > 391)))
 61 values hashing to ac62ac22ade6bfcc0bee9796ab543919
 
 statement ok
-DROP VIEW view_1_tab4_560
+DROP VIEW IF EXISTS view_1_tab4_560 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_560
+DROP VIEW IF EXISTS view_2_tab4_560 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_560
+DROP VIEW IF EXISTS view_3_tab4_560 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18496,13 +18496,13 @@ SELECT pk FROM tab0 WHERE col0 = 548
 ----
 
 statement ok
-DROP VIEW view_1_tab0_561
+DROP VIEW IF EXISTS view_1_tab0_561 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_561
+DROP VIEW IF EXISTS view_2_tab0_561 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_561
+DROP VIEW IF EXISTS view_3_tab0_561 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18588,13 +18588,13 @@ SELECT pk FROM tab1 WHERE col0 = 548
 ----
 
 statement ok
-DROP VIEW view_1_tab1_561
+DROP VIEW IF EXISTS view_1_tab1_561 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_561
+DROP VIEW IF EXISTS view_2_tab1_561 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_561
+DROP VIEW IF EXISTS view_3_tab1_561 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18680,13 +18680,13 @@ SELECT pk FROM tab2 WHERE col0 = 548
 ----
 
 statement ok
-DROP VIEW view_1_tab2_561
+DROP VIEW IF EXISTS view_1_tab2_561 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_561
+DROP VIEW IF EXISTS view_2_tab2_561 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_561
+DROP VIEW IF EXISTS view_3_tab2_561 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18772,13 +18772,13 @@ SELECT pk FROM tab3 WHERE col0 = 548
 ----
 
 statement ok
-DROP VIEW view_1_tab3_561
+DROP VIEW IF EXISTS view_1_tab3_561 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_561
+DROP VIEW IF EXISTS view_2_tab3_561 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_561
+DROP VIEW IF EXISTS view_3_tab3_561 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18864,13 +18864,13 @@ SELECT pk FROM tab4 WHERE col0 = 548
 ----
 
 statement ok
-DROP VIEW view_1_tab4_561
+DROP VIEW IF EXISTS view_1_tab4_561 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_561
+DROP VIEW IF EXISTS view_2_tab4_561 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_561
+DROP VIEW IF EXISTS view_3_tab4_561 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18961,13 +18961,13 @@ SELECT pk FROM tab0 WHERE col0 > 444
 56 values hashing to a02417a05ef78596b438cbfa07a33bdd
 
 statement ok
-DROP VIEW view_1_tab0_562
+DROP VIEW IF EXISTS view_1_tab0_562 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_562
+DROP VIEW IF EXISTS view_2_tab0_562 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_562
+DROP VIEW IF EXISTS view_3_tab0_562 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19058,13 +19058,13 @@ SELECT pk FROM tab1 WHERE col0 > 444
 56 values hashing to a02417a05ef78596b438cbfa07a33bdd
 
 statement ok
-DROP VIEW view_1_tab1_562
+DROP VIEW IF EXISTS view_1_tab1_562 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_562
+DROP VIEW IF EXISTS view_2_tab1_562 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_562
+DROP VIEW IF EXISTS view_3_tab1_562 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19155,13 +19155,13 @@ SELECT pk FROM tab2 WHERE col0 > 444
 56 values hashing to a02417a05ef78596b438cbfa07a33bdd
 
 statement ok
-DROP VIEW view_1_tab2_562
+DROP VIEW IF EXISTS view_1_tab2_562 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_562
+DROP VIEW IF EXISTS view_2_tab2_562 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_562
+DROP VIEW IF EXISTS view_3_tab2_562 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19252,13 +19252,13 @@ SELECT pk FROM tab3 WHERE col0 > 444
 56 values hashing to a02417a05ef78596b438cbfa07a33bdd
 
 statement ok
-DROP VIEW view_1_tab3_562
+DROP VIEW IF EXISTS view_1_tab3_562 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_562
+DROP VIEW IF EXISTS view_2_tab3_562 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_562
+DROP VIEW IF EXISTS view_3_tab3_562 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19349,13 +19349,13 @@ SELECT pk FROM tab4 WHERE col0 > 444
 56 values hashing to a02417a05ef78596b438cbfa07a33bdd
 
 statement ok
-DROP VIEW view_1_tab4_562
+DROP VIEW IF EXISTS view_1_tab4_562 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_562
+DROP VIEW IF EXISTS view_2_tab4_562 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_562
+DROP VIEW IF EXISTS view_3_tab4_562 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19446,13 +19446,13 @@ SELECT pk FROM tab0 WHERE col0 < 680
 66 values hashing to 1f5a70284e3c639853886a7cec03e360
 
 statement ok
-DROP VIEW view_1_tab0_563
+DROP VIEW IF EXISTS view_1_tab0_563 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_563
+DROP VIEW IF EXISTS view_2_tab0_563 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_563
+DROP VIEW IF EXISTS view_3_tab0_563 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19543,13 +19543,13 @@ SELECT pk FROM tab1 WHERE col0 < 680
 66 values hashing to 1f5a70284e3c639853886a7cec03e360
 
 statement ok
-DROP VIEW view_1_tab1_563
+DROP VIEW IF EXISTS view_1_tab1_563 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_563
+DROP VIEW IF EXISTS view_2_tab1_563 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_563
+DROP VIEW IF EXISTS view_3_tab1_563 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19640,13 +19640,13 @@ SELECT pk FROM tab2 WHERE col0 < 680
 66 values hashing to 1f5a70284e3c639853886a7cec03e360
 
 statement ok
-DROP VIEW view_1_tab2_563
+DROP VIEW IF EXISTS view_1_tab2_563 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_563
+DROP VIEW IF EXISTS view_2_tab2_563 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_563
+DROP VIEW IF EXISTS view_3_tab2_563 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19737,13 +19737,13 @@ SELECT pk FROM tab3 WHERE col0 < 680
 66 values hashing to 1f5a70284e3c639853886a7cec03e360
 
 statement ok
-DROP VIEW view_1_tab3_563
+DROP VIEW IF EXISTS view_1_tab3_563 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_563
+DROP VIEW IF EXISTS view_2_tab3_563 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_563
+DROP VIEW IF EXISTS view_3_tab3_563 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19834,13 +19834,13 @@ SELECT pk FROM tab4 WHERE col0 < 680
 66 values hashing to 1f5a70284e3c639853886a7cec03e360
 
 statement ok
-DROP VIEW view_1_tab4_563
+DROP VIEW IF EXISTS view_1_tab4_563 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_563
+DROP VIEW IF EXISTS view_2_tab4_563 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_563
+DROP VIEW IF EXISTS view_3_tab4_563 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19926,13 +19926,13 @@ SELECT pk FROM tab0 WHERE col4 = 987.12
 ----
 
 statement ok
-DROP VIEW view_1_tab0_564
+DROP VIEW IF EXISTS view_1_tab0_564 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_564
+DROP VIEW IF EXISTS view_2_tab0_564 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_564
+DROP VIEW IF EXISTS view_3_tab0_564 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20018,13 +20018,13 @@ SELECT pk FROM tab1 WHERE col4 = 987.12
 ----
 
 statement ok
-DROP VIEW view_1_tab1_564
+DROP VIEW IF EXISTS view_1_tab1_564 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_564
+DROP VIEW IF EXISTS view_2_tab1_564 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_564
+DROP VIEW IF EXISTS view_3_tab1_564 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20110,13 +20110,13 @@ SELECT pk FROM tab2 WHERE col4 = 987.12
 ----
 
 statement ok
-DROP VIEW view_1_tab2_564
+DROP VIEW IF EXISTS view_1_tab2_564 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_564
+DROP VIEW IF EXISTS view_2_tab2_564 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_564
+DROP VIEW IF EXISTS view_3_tab2_564 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20202,13 +20202,13 @@ SELECT pk FROM tab3 WHERE col4 = 987.12
 ----
 
 statement ok
-DROP VIEW view_1_tab3_564
+DROP VIEW IF EXISTS view_1_tab3_564 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_564
+DROP VIEW IF EXISTS view_2_tab3_564 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_564
+DROP VIEW IF EXISTS view_3_tab3_564 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20294,13 +20294,13 @@ SELECT pk FROM tab4 WHERE col4 = 987.12
 ----
 
 statement ok
-DROP VIEW view_1_tab4_564
+DROP VIEW IF EXISTS view_1_tab4_564 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_564
+DROP VIEW IF EXISTS view_2_tab4_564 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_564
+DROP VIEW IF EXISTS view_3_tab4_564 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20386,13 +20386,13 @@ SELECT pk FROM tab0 WHERE (col4 > 357.73 OR col0 >= 898 AND (col4 = 369.9) OR co
 ----
 
 statement ok
-DROP VIEW view_1_tab0_565
+DROP VIEW IF EXISTS view_1_tab0_565 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_565
+DROP VIEW IF EXISTS view_2_tab0_565 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_565
+DROP VIEW IF EXISTS view_3_tab0_565 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20478,13 +20478,13 @@ SELECT pk FROM tab1 WHERE (col4 > 357.73 OR col0 >= 898 AND (col4 = 369.9) OR co
 ----
 
 statement ok
-DROP VIEW view_1_tab1_565
+DROP VIEW IF EXISTS view_1_tab1_565 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_565
+DROP VIEW IF EXISTS view_2_tab1_565 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_565
+DROP VIEW IF EXISTS view_3_tab1_565 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20570,13 +20570,13 @@ SELECT pk FROM tab2 WHERE (col4 > 357.73 OR col0 >= 898 AND (col4 = 369.9) OR co
 ----
 
 statement ok
-DROP VIEW view_1_tab2_565
+DROP VIEW IF EXISTS view_1_tab2_565 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_565
+DROP VIEW IF EXISTS view_2_tab2_565 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_565
+DROP VIEW IF EXISTS view_3_tab2_565 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20662,13 +20662,13 @@ SELECT pk FROM tab3 WHERE (col4 > 357.73 OR col0 >= 898 AND (col4 = 369.9) OR co
 ----
 
 statement ok
-DROP VIEW view_1_tab3_565
+DROP VIEW IF EXISTS view_1_tab3_565 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_565
+DROP VIEW IF EXISTS view_2_tab3_565 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_565
+DROP VIEW IF EXISTS view_3_tab3_565 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20754,13 +20754,13 @@ SELECT pk FROM tab4 WHERE (col4 > 357.73 OR col0 >= 898 AND (col4 = 369.9) OR co
 ----
 
 statement ok
-DROP VIEW view_1_tab4_565
+DROP VIEW IF EXISTS view_1_tab4_565 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_565
+DROP VIEW IF EXISTS view_2_tab4_565 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_565
+DROP VIEW IF EXISTS view_3_tab4_565 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20851,13 +20851,13 @@ SELECT pk FROM tab0 WHERE (col3 > 999 AND col1 = 524.55) OR col3 > 124
 90 values hashing to 10d84ebcab4a71420cc1bf69ac6434cd
 
 statement ok
-DROP VIEW view_1_tab0_566
+DROP VIEW IF EXISTS view_1_tab0_566 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_566
+DROP VIEW IF EXISTS view_2_tab0_566 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_566
+DROP VIEW IF EXISTS view_3_tab0_566 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20948,13 +20948,13 @@ SELECT pk FROM tab1 WHERE (col3 > 999 AND col1 = 524.55) OR col3 > 124
 90 values hashing to 10d84ebcab4a71420cc1bf69ac6434cd
 
 statement ok
-DROP VIEW view_1_tab1_566
+DROP VIEW IF EXISTS view_1_tab1_566 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_566
+DROP VIEW IF EXISTS view_2_tab1_566 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_566
+DROP VIEW IF EXISTS view_3_tab1_566 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21045,13 +21045,13 @@ SELECT pk FROM tab2 WHERE (col3 > 999 AND col1 = 524.55) OR col3 > 124
 90 values hashing to 10d84ebcab4a71420cc1bf69ac6434cd
 
 statement ok
-DROP VIEW view_1_tab2_566
+DROP VIEW IF EXISTS view_1_tab2_566 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_566
+DROP VIEW IF EXISTS view_2_tab2_566 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_566
+DROP VIEW IF EXISTS view_3_tab2_566 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21142,13 +21142,13 @@ SELECT pk FROM tab3 WHERE (col3 > 999 AND col1 = 524.55) OR col3 > 124
 90 values hashing to 10d84ebcab4a71420cc1bf69ac6434cd
 
 statement ok
-DROP VIEW view_1_tab3_566
+DROP VIEW IF EXISTS view_1_tab3_566 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_566
+DROP VIEW IF EXISTS view_2_tab3_566 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_566
+DROP VIEW IF EXISTS view_3_tab3_566 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21239,13 +21239,13 @@ SELECT pk FROM tab4 WHERE (col3 > 999 AND col1 = 524.55) OR col3 > 124
 90 values hashing to 10d84ebcab4a71420cc1bf69ac6434cd
 
 statement ok
-DROP VIEW view_1_tab4_566
+DROP VIEW IF EXISTS view_1_tab4_566 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_566
+DROP VIEW IF EXISTS view_2_tab4_566 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_566
+DROP VIEW IF EXISTS view_3_tab4_566 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21336,13 +21336,13 @@ SELECT pk FROM tab0 WHERE col3 < 361
 41 values hashing to b52ff2d9346c7fc76ab11c583b1aaf99
 
 statement ok
-DROP VIEW view_1_tab0_567
+DROP VIEW IF EXISTS view_1_tab0_567 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_567
+DROP VIEW IF EXISTS view_2_tab0_567 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_567
+DROP VIEW IF EXISTS view_3_tab0_567 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21433,13 +21433,13 @@ SELECT pk FROM tab1 WHERE col3 < 361
 41 values hashing to b52ff2d9346c7fc76ab11c583b1aaf99
 
 statement ok
-DROP VIEW view_1_tab1_567
+DROP VIEW IF EXISTS view_1_tab1_567 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_567
+DROP VIEW IF EXISTS view_2_tab1_567 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_567
+DROP VIEW IF EXISTS view_3_tab1_567 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21530,13 +21530,13 @@ SELECT pk FROM tab2 WHERE col3 < 361
 41 values hashing to b52ff2d9346c7fc76ab11c583b1aaf99
 
 statement ok
-DROP VIEW view_1_tab2_567
+DROP VIEW IF EXISTS view_1_tab2_567 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_567
+DROP VIEW IF EXISTS view_2_tab2_567 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_567
+DROP VIEW IF EXISTS view_3_tab2_567 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21627,13 +21627,13 @@ SELECT pk FROM tab3 WHERE col3 < 361
 41 values hashing to b52ff2d9346c7fc76ab11c583b1aaf99
 
 statement ok
-DROP VIEW view_1_tab3_567
+DROP VIEW IF EXISTS view_1_tab3_567 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_567
+DROP VIEW IF EXISTS view_2_tab3_567 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_567
+DROP VIEW IF EXISTS view_3_tab3_567 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21724,13 +21724,13 @@ SELECT pk FROM tab4 WHERE col3 < 361
 41 values hashing to b52ff2d9346c7fc76ab11c583b1aaf99
 
 statement ok
-DROP VIEW view_1_tab4_567
+DROP VIEW IF EXISTS view_1_tab4_567 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_567
+DROP VIEW IF EXISTS view_2_tab4_567 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_567
+DROP VIEW IF EXISTS view_3_tab4_567 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21821,13 +21821,13 @@ SELECT pk FROM tab0 WHERE (col0 > 569)
 42 values hashing to 12b6a09e49655beb1518de72513c9eb7
 
 statement ok
-DROP VIEW view_1_tab0_568
+DROP VIEW IF EXISTS view_1_tab0_568 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_568
+DROP VIEW IF EXISTS view_2_tab0_568 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_568
+DROP VIEW IF EXISTS view_3_tab0_568 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21918,13 +21918,13 @@ SELECT pk FROM tab1 WHERE (col0 > 569)
 42 values hashing to 12b6a09e49655beb1518de72513c9eb7
 
 statement ok
-DROP VIEW view_1_tab1_568
+DROP VIEW IF EXISTS view_1_tab1_568 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_568
+DROP VIEW IF EXISTS view_2_tab1_568 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_568
+DROP VIEW IF EXISTS view_3_tab1_568 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22015,13 +22015,13 @@ SELECT pk FROM tab2 WHERE (col0 > 569)
 42 values hashing to 12b6a09e49655beb1518de72513c9eb7
 
 statement ok
-DROP VIEW view_1_tab2_568
+DROP VIEW IF EXISTS view_1_tab2_568 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_568
+DROP VIEW IF EXISTS view_2_tab2_568 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_568
+DROP VIEW IF EXISTS view_3_tab2_568 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22112,13 +22112,13 @@ SELECT pk FROM tab3 WHERE (col0 > 569)
 42 values hashing to 12b6a09e49655beb1518de72513c9eb7
 
 statement ok
-DROP VIEW view_1_tab3_568
+DROP VIEW IF EXISTS view_1_tab3_568 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_568
+DROP VIEW IF EXISTS view_2_tab3_568 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_568
+DROP VIEW IF EXISTS view_3_tab3_568 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22209,13 +22209,13 @@ SELECT pk FROM tab4 WHERE (col0 > 569)
 42 values hashing to 12b6a09e49655beb1518de72513c9eb7
 
 statement ok
-DROP VIEW view_1_tab4_568
+DROP VIEW IF EXISTS view_1_tab4_568 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_568
+DROP VIEW IF EXISTS view_2_tab4_568 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_568
+DROP VIEW IF EXISTS view_3_tab4_568 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22318,13 +22318,13 @@ SELECT pk FROM tab0 WHERE (col3 > 930)
 82
 
 statement ok
-DROP VIEW view_1_tab0_569
+DROP VIEW IF EXISTS view_1_tab0_569 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_569
+DROP VIEW IF EXISTS view_2_tab0_569 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_569
+DROP VIEW IF EXISTS view_3_tab0_569 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22427,13 +22427,13 @@ SELECT pk FROM tab1 WHERE (col3 > 930)
 82
 
 statement ok
-DROP VIEW view_1_tab1_569
+DROP VIEW IF EXISTS view_1_tab1_569 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_569
+DROP VIEW IF EXISTS view_2_tab1_569 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_569
+DROP VIEW IF EXISTS view_3_tab1_569 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22536,13 +22536,13 @@ SELECT pk FROM tab2 WHERE (col3 > 930)
 82
 
 statement ok
-DROP VIEW view_1_tab2_569
+DROP VIEW IF EXISTS view_1_tab2_569 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_569
+DROP VIEW IF EXISTS view_2_tab2_569 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_569
+DROP VIEW IF EXISTS view_3_tab2_569 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22645,13 +22645,13 @@ SELECT pk FROM tab3 WHERE (col3 > 930)
 82
 
 statement ok
-DROP VIEW view_1_tab3_569
+DROP VIEW IF EXISTS view_1_tab3_569 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_569
+DROP VIEW IF EXISTS view_2_tab3_569 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_569
+DROP VIEW IF EXISTS view_3_tab3_569 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22754,13 +22754,13 @@ SELECT pk FROM tab4 WHERE (col3 > 930)
 82
 
 statement ok
-DROP VIEW view_1_tab4_569
+DROP VIEW IF EXISTS view_1_tab4_569 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_569
+DROP VIEW IF EXISTS view_2_tab4_569 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_569
+DROP VIEW IF EXISTS view_3_tab4_569 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22851,13 +22851,13 @@ SELECT pk FROM tab0 WHERE ((col4 < 748.78) OR ((col3 > 788)))
 81 values hashing to 6a18948d2f265d56a551c994c91f7b56
 
 statement ok
-DROP VIEW view_1_tab0_571
+DROP VIEW IF EXISTS view_1_tab0_571 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_571
+DROP VIEW IF EXISTS view_2_tab0_571 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_571
+DROP VIEW IF EXISTS view_3_tab0_571 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22948,13 +22948,13 @@ SELECT pk FROM tab1 WHERE ((col4 < 748.78) OR ((col3 > 788)))
 81 values hashing to 6a18948d2f265d56a551c994c91f7b56
 
 statement ok
-DROP VIEW view_1_tab1_571
+DROP VIEW IF EXISTS view_1_tab1_571 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_571
+DROP VIEW IF EXISTS view_2_tab1_571 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_571
+DROP VIEW IF EXISTS view_3_tab1_571 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23045,13 +23045,13 @@ SELECT pk FROM tab2 WHERE ((col4 < 748.78) OR ((col3 > 788)))
 81 values hashing to 6a18948d2f265d56a551c994c91f7b56
 
 statement ok
-DROP VIEW view_1_tab2_571
+DROP VIEW IF EXISTS view_1_tab2_571 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_571
+DROP VIEW IF EXISTS view_2_tab2_571 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_571
+DROP VIEW IF EXISTS view_3_tab2_571 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23142,13 +23142,13 @@ SELECT pk FROM tab3 WHERE ((col4 < 748.78) OR ((col3 > 788)))
 81 values hashing to 6a18948d2f265d56a551c994c91f7b56
 
 statement ok
-DROP VIEW view_1_tab3_571
+DROP VIEW IF EXISTS view_1_tab3_571 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_571
+DROP VIEW IF EXISTS view_2_tab3_571 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_571
+DROP VIEW IF EXISTS view_3_tab3_571 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23239,13 +23239,13 @@ SELECT pk FROM tab4 WHERE ((col4 < 748.78) OR ((col3 > 788)))
 81 values hashing to 6a18948d2f265d56a551c994c91f7b56
 
 statement ok
-DROP VIEW view_1_tab4_571
+DROP VIEW IF EXISTS view_1_tab4_571 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_571
+DROP VIEW IF EXISTS view_2_tab4_571 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_571
+DROP VIEW IF EXISTS view_3_tab4_571 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23334,13 +23334,13 @@ SELECT pk FROM tab0 WHERE col3 < 953 OR col0 < 269 OR (col1 > 109.76) AND (col3 
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab0_572
+DROP VIEW IF EXISTS view_1_tab0_572 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_572
+DROP VIEW IF EXISTS view_2_tab0_572 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_572
+DROP VIEW IF EXISTS view_3_tab0_572 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23429,13 +23429,13 @@ SELECT pk FROM tab1 WHERE col3 < 953 OR col0 < 269 OR (col1 > 109.76) AND (col3 
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab1_572
+DROP VIEW IF EXISTS view_1_tab1_572 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_572
+DROP VIEW IF EXISTS view_2_tab1_572 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_572
+DROP VIEW IF EXISTS view_3_tab1_572 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23524,13 +23524,13 @@ SELECT pk FROM tab2 WHERE col3 < 953 OR col0 < 269 OR (col1 > 109.76) AND (col3 
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab2_572
+DROP VIEW IF EXISTS view_1_tab2_572 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_572
+DROP VIEW IF EXISTS view_2_tab2_572 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_572
+DROP VIEW IF EXISTS view_3_tab2_572 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23619,13 +23619,13 @@ SELECT pk FROM tab3 WHERE col3 < 953 OR col0 < 269 OR (col1 > 109.76) AND (col3 
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab3_572
+DROP VIEW IF EXISTS view_1_tab3_572 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_572
+DROP VIEW IF EXISTS view_2_tab3_572 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_572
+DROP VIEW IF EXISTS view_3_tab3_572 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23714,13 +23714,13 @@ SELECT pk FROM tab4 WHERE col3 < 953 OR col0 < 269 OR (col1 > 109.76) AND (col3 
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab4_572
+DROP VIEW IF EXISTS view_1_tab4_572 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_572
+DROP VIEW IF EXISTS view_2_tab4_572 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_572
+DROP VIEW IF EXISTS view_3_tab4_572 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23811,13 +23811,13 @@ SELECT pk FROM tab0 WHERE (col3 < 460 AND (col4 IN (384.47,269.1) AND col3 < 705
 34 values hashing to 417a2ad63ea1a2dc4c50dc6071197632
 
 statement ok
-DROP VIEW view_1_tab0_573
+DROP VIEW IF EXISTS view_1_tab0_573 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_573
+DROP VIEW IF EXISTS view_2_tab0_573 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_573
+DROP VIEW IF EXISTS view_3_tab0_573 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23908,13 +23908,13 @@ SELECT pk FROM tab1 WHERE (col3 < 460 AND (col4 IN (384.47,269.1) AND col3 < 705
 34 values hashing to 417a2ad63ea1a2dc4c50dc6071197632
 
 statement ok
-DROP VIEW view_1_tab1_573
+DROP VIEW IF EXISTS view_1_tab1_573 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_573
+DROP VIEW IF EXISTS view_2_tab1_573 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_573
+DROP VIEW IF EXISTS view_3_tab1_573 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24005,13 +24005,13 @@ SELECT pk FROM tab2 WHERE (col3 < 460 AND (col4 IN (384.47,269.1) AND col3 < 705
 34 values hashing to 417a2ad63ea1a2dc4c50dc6071197632
 
 statement ok
-DROP VIEW view_1_tab2_573
+DROP VIEW IF EXISTS view_1_tab2_573 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_573
+DROP VIEW IF EXISTS view_2_tab2_573 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_573
+DROP VIEW IF EXISTS view_3_tab2_573 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24102,13 +24102,13 @@ SELECT pk FROM tab3 WHERE (col3 < 460 AND (col4 IN (384.47,269.1) AND col3 < 705
 34 values hashing to 417a2ad63ea1a2dc4c50dc6071197632
 
 statement ok
-DROP VIEW view_1_tab3_573
+DROP VIEW IF EXISTS view_1_tab3_573 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_573
+DROP VIEW IF EXISTS view_2_tab3_573 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_573
+DROP VIEW IF EXISTS view_3_tab3_573 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24199,13 +24199,13 @@ SELECT pk FROM tab4 WHERE (col3 < 460 AND (col4 IN (384.47,269.1) AND col3 < 705
 34 values hashing to 417a2ad63ea1a2dc4c50dc6071197632
 
 statement ok
-DROP VIEW view_1_tab4_573
+DROP VIEW IF EXISTS view_1_tab4_573 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_573
+DROP VIEW IF EXISTS view_2_tab4_573 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_573
+DROP VIEW IF EXISTS view_3_tab4_573 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24291,13 +24291,13 @@ SELECT pk FROM tab0 WHERE (col0 < 198 AND col0 = 671)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_574
+DROP VIEW IF EXISTS view_1_tab0_574 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_574
+DROP VIEW IF EXISTS view_2_tab0_574 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_574
+DROP VIEW IF EXISTS view_3_tab0_574 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24383,13 +24383,13 @@ SELECT pk FROM tab1 WHERE (col0 < 198 AND col0 = 671)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_574
+DROP VIEW IF EXISTS view_1_tab1_574 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_574
+DROP VIEW IF EXISTS view_2_tab1_574 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_574
+DROP VIEW IF EXISTS view_3_tab1_574 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24475,13 +24475,13 @@ SELECT pk FROM tab2 WHERE (col0 < 198 AND col0 = 671)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_574
+DROP VIEW IF EXISTS view_1_tab2_574 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_574
+DROP VIEW IF EXISTS view_2_tab2_574 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_574
+DROP VIEW IF EXISTS view_3_tab2_574 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24567,13 +24567,13 @@ SELECT pk FROM tab3 WHERE (col0 < 198 AND col0 = 671)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_574
+DROP VIEW IF EXISTS view_1_tab3_574 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_574
+DROP VIEW IF EXISTS view_2_tab3_574 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_574
+DROP VIEW IF EXISTS view_3_tab3_574 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24659,13 +24659,13 @@ SELECT pk FROM tab4 WHERE (col0 < 198 AND col0 = 671)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_574
+DROP VIEW IF EXISTS view_1_tab4_574 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_574
+DROP VIEW IF EXISTS view_2_tab4_574 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_574
+DROP VIEW IF EXISTS view_3_tab4_574 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24756,13 +24756,13 @@ SELECT pk FROM tab0 WHERE col3 <= 421
 51 values hashing to 09fda650ce498f7b06e1212ae78be9e5
 
 statement ok
-DROP VIEW view_1_tab0_575
+DROP VIEW IF EXISTS view_1_tab0_575 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_575
+DROP VIEW IF EXISTS view_2_tab0_575 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_575
+DROP VIEW IF EXISTS view_3_tab0_575 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24853,13 +24853,13 @@ SELECT pk FROM tab1 WHERE col3 <= 421
 51 values hashing to 09fda650ce498f7b06e1212ae78be9e5
 
 statement ok
-DROP VIEW view_1_tab1_575
+DROP VIEW IF EXISTS view_1_tab1_575 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_575
+DROP VIEW IF EXISTS view_2_tab1_575 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_575
+DROP VIEW IF EXISTS view_3_tab1_575 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24950,13 +24950,13 @@ SELECT pk FROM tab2 WHERE col3 <= 421
 51 values hashing to 09fda650ce498f7b06e1212ae78be9e5
 
 statement ok
-DROP VIEW view_1_tab2_575
+DROP VIEW IF EXISTS view_1_tab2_575 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_575
+DROP VIEW IF EXISTS view_2_tab2_575 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_575
+DROP VIEW IF EXISTS view_3_tab2_575 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25047,13 +25047,13 @@ SELECT pk FROM tab3 WHERE col3 <= 421
 51 values hashing to 09fda650ce498f7b06e1212ae78be9e5
 
 statement ok
-DROP VIEW view_1_tab3_575
+DROP VIEW IF EXISTS view_1_tab3_575 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_575
+DROP VIEW IF EXISTS view_2_tab3_575 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_575
+DROP VIEW IF EXISTS view_3_tab3_575 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25144,13 +25144,13 @@ SELECT pk FROM tab4 WHERE col3 <= 421
 51 values hashing to 09fda650ce498f7b06e1212ae78be9e5
 
 statement ok
-DROP VIEW view_1_tab4_575
+DROP VIEW IF EXISTS view_1_tab4_575 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_575
+DROP VIEW IF EXISTS view_2_tab4_575 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_575
+DROP VIEW IF EXISTS view_3_tab4_575 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25262,13 +25262,13 @@ SELECT pk FROM tab0 WHERE col3 < 76
 93
 
 statement ok
-DROP VIEW view_1_tab0_576
+DROP VIEW IF EXISTS view_1_tab0_576 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_576
+DROP VIEW IF EXISTS view_2_tab0_576 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_576
+DROP VIEW IF EXISTS view_3_tab0_576 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25380,13 +25380,13 @@ SELECT pk FROM tab1 WHERE col3 < 76
 93
 
 statement ok
-DROP VIEW view_1_tab1_576
+DROP VIEW IF EXISTS view_1_tab1_576 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_576
+DROP VIEW IF EXISTS view_2_tab1_576 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_576
+DROP VIEW IF EXISTS view_3_tab1_576 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25498,13 +25498,13 @@ SELECT pk FROM tab2 WHERE col3 < 76
 93
 
 statement ok
-DROP VIEW view_1_tab2_576
+DROP VIEW IF EXISTS view_1_tab2_576 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_576
+DROP VIEW IF EXISTS view_2_tab2_576 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_576
+DROP VIEW IF EXISTS view_3_tab2_576 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25616,13 +25616,13 @@ SELECT pk FROM tab3 WHERE col3 < 76
 93
 
 statement ok
-DROP VIEW view_1_tab3_576
+DROP VIEW IF EXISTS view_1_tab3_576 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_576
+DROP VIEW IF EXISTS view_2_tab3_576 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_576
+DROP VIEW IF EXISTS view_3_tab3_576 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25734,13 +25734,13 @@ SELECT pk FROM tab4 WHERE col3 < 76
 93
 
 statement ok
-DROP VIEW view_1_tab4_576
+DROP VIEW IF EXISTS view_1_tab4_576 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_576
+DROP VIEW IF EXISTS view_2_tab4_576 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_576
+DROP VIEW IF EXISTS view_3_tab4_576 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25831,13 +25831,13 @@ SELECT pk FROM tab0 WHERE col1 < 628.40
 60 values hashing to cee27017317d2fec82b368371056f78c
 
 statement ok
-DROP VIEW view_1_tab0_577
+DROP VIEW IF EXISTS view_1_tab0_577 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_577
+DROP VIEW IF EXISTS view_2_tab0_577 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_577
+DROP VIEW IF EXISTS view_3_tab0_577 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25928,13 +25928,13 @@ SELECT pk FROM tab1 WHERE col1 < 628.40
 60 values hashing to cee27017317d2fec82b368371056f78c
 
 statement ok
-DROP VIEW view_1_tab1_577
+DROP VIEW IF EXISTS view_1_tab1_577 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_577
+DROP VIEW IF EXISTS view_2_tab1_577 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_577
+DROP VIEW IF EXISTS view_3_tab1_577 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26025,13 +26025,13 @@ SELECT pk FROM tab2 WHERE col1 < 628.40
 60 values hashing to cee27017317d2fec82b368371056f78c
 
 statement ok
-DROP VIEW view_1_tab2_577
+DROP VIEW IF EXISTS view_1_tab2_577 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_577
+DROP VIEW IF EXISTS view_2_tab2_577 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_577
+DROP VIEW IF EXISTS view_3_tab2_577 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26122,13 +26122,13 @@ SELECT pk FROM tab3 WHERE col1 < 628.40
 60 values hashing to cee27017317d2fec82b368371056f78c
 
 statement ok
-DROP VIEW view_1_tab3_577
+DROP VIEW IF EXISTS view_1_tab3_577 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_577
+DROP VIEW IF EXISTS view_2_tab3_577 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_577
+DROP VIEW IF EXISTS view_3_tab3_577 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26219,13 +26219,13 @@ SELECT pk FROM tab4 WHERE col1 < 628.40
 60 values hashing to cee27017317d2fec82b368371056f78c
 
 statement ok
-DROP VIEW view_1_tab4_577
+DROP VIEW IF EXISTS view_1_tab4_577 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_577
+DROP VIEW IF EXISTS view_2_tab4_577 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_577
+DROP VIEW IF EXISTS view_3_tab4_577 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26316,13 +26316,13 @@ SELECT pk FROM tab0 WHERE (col4 < 974.61)
 95 values hashing to d2072bfcc16506dd5bf1a5723c8cd7ea
 
 statement ok
-DROP VIEW view_1_tab0_578
+DROP VIEW IF EXISTS view_1_tab0_578 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_578
+DROP VIEW IF EXISTS view_2_tab0_578 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_578
+DROP VIEW IF EXISTS view_3_tab0_578 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26413,13 +26413,13 @@ SELECT pk FROM tab1 WHERE (col4 < 974.61)
 95 values hashing to d2072bfcc16506dd5bf1a5723c8cd7ea
 
 statement ok
-DROP VIEW view_1_tab1_578
+DROP VIEW IF EXISTS view_1_tab1_578 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_578
+DROP VIEW IF EXISTS view_2_tab1_578 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_578
+DROP VIEW IF EXISTS view_3_tab1_578 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26510,13 +26510,13 @@ SELECT pk FROM tab2 WHERE (col4 < 974.61)
 95 values hashing to d2072bfcc16506dd5bf1a5723c8cd7ea
 
 statement ok
-DROP VIEW view_1_tab2_578
+DROP VIEW IF EXISTS view_1_tab2_578 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_578
+DROP VIEW IF EXISTS view_2_tab2_578 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_578
+DROP VIEW IF EXISTS view_3_tab2_578 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26607,13 +26607,13 @@ SELECT pk FROM tab3 WHERE (col4 < 974.61)
 95 values hashing to d2072bfcc16506dd5bf1a5723c8cd7ea
 
 statement ok
-DROP VIEW view_1_tab3_578
+DROP VIEW IF EXISTS view_1_tab3_578 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_578
+DROP VIEW IF EXISTS view_2_tab3_578 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_578
+DROP VIEW IF EXISTS view_3_tab3_578 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26704,13 +26704,13 @@ SELECT pk FROM tab4 WHERE (col4 < 974.61)
 95 values hashing to d2072bfcc16506dd5bf1a5723c8cd7ea
 
 statement ok
-DROP VIEW view_1_tab4_578
+DROP VIEW IF EXISTS view_1_tab4_578 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_578
+DROP VIEW IF EXISTS view_2_tab4_578 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_578
+DROP VIEW IF EXISTS view_3_tab4_578 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26815,13 +26815,13 @@ SELECT pk FROM tab0 WHERE col1 > 64.38
 96 values hashing to 35b4b8de351ec570cb8eb2f47499ec70
 
 statement ok
-DROP VIEW view_1_tab0_579
+DROP VIEW IF EXISTS view_1_tab0_579 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_579
+DROP VIEW IF EXISTS view_2_tab0_579 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_579
+DROP VIEW IF EXISTS view_3_tab0_579 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26926,13 +26926,13 @@ SELECT pk FROM tab1 WHERE col1 > 64.38
 96 values hashing to 35b4b8de351ec570cb8eb2f47499ec70
 
 statement ok
-DROP VIEW view_1_tab1_579
+DROP VIEW IF EXISTS view_1_tab1_579 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_579
+DROP VIEW IF EXISTS view_2_tab1_579 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_579
+DROP VIEW IF EXISTS view_3_tab1_579 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27037,13 +27037,13 @@ SELECT pk FROM tab2 WHERE col1 > 64.38
 96 values hashing to 35b4b8de351ec570cb8eb2f47499ec70
 
 statement ok
-DROP VIEW view_1_tab2_579
+DROP VIEW IF EXISTS view_1_tab2_579 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_579
+DROP VIEW IF EXISTS view_2_tab2_579 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_579
+DROP VIEW IF EXISTS view_3_tab2_579 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27148,13 +27148,13 @@ SELECT pk FROM tab3 WHERE col1 > 64.38
 96 values hashing to 35b4b8de351ec570cb8eb2f47499ec70
 
 statement ok
-DROP VIEW view_1_tab3_579
+DROP VIEW IF EXISTS view_1_tab3_579 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_579
+DROP VIEW IF EXISTS view_2_tab3_579 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_579
+DROP VIEW IF EXISTS view_3_tab3_579 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27259,13 +27259,13 @@ SELECT pk FROM tab4 WHERE col1 > 64.38
 96 values hashing to 35b4b8de351ec570cb8eb2f47499ec70
 
 statement ok
-DROP VIEW view_1_tab4_579
+DROP VIEW IF EXISTS view_1_tab4_579 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_579
+DROP VIEW IF EXISTS view_2_tab4_579 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_579
+DROP VIEW IF EXISTS view_3_tab4_579 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27356,13 +27356,13 @@ SELECT pk FROM tab0 WHERE col4 = 297.0 OR col3 IS NULL OR col1 <= 773.73
 76 values hashing to 593057ce1166d7487f4b469fbf882585
 
 statement ok
-DROP VIEW view_1_tab0_580
+DROP VIEW IF EXISTS view_1_tab0_580 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_580
+DROP VIEW IF EXISTS view_2_tab0_580 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_580
+DROP VIEW IF EXISTS view_3_tab0_580 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27453,13 +27453,13 @@ SELECT pk FROM tab1 WHERE col4 = 297.0 OR col3 IS NULL OR col1 <= 773.73
 76 values hashing to 593057ce1166d7487f4b469fbf882585
 
 statement ok
-DROP VIEW view_1_tab1_580
+DROP VIEW IF EXISTS view_1_tab1_580 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_580
+DROP VIEW IF EXISTS view_2_tab1_580 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_580
+DROP VIEW IF EXISTS view_3_tab1_580 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27550,13 +27550,13 @@ SELECT pk FROM tab2 WHERE col4 = 297.0 OR col3 IS NULL OR col1 <= 773.73
 76 values hashing to 593057ce1166d7487f4b469fbf882585
 
 statement ok
-DROP VIEW view_1_tab2_580
+DROP VIEW IF EXISTS view_1_tab2_580 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_580
+DROP VIEW IF EXISTS view_2_tab2_580 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_580
+DROP VIEW IF EXISTS view_3_tab2_580 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27647,13 +27647,13 @@ SELECT pk FROM tab3 WHERE col4 = 297.0 OR col3 IS NULL OR col1 <= 773.73
 76 values hashing to 593057ce1166d7487f4b469fbf882585
 
 statement ok
-DROP VIEW view_1_tab3_580
+DROP VIEW IF EXISTS view_1_tab3_580 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_580
+DROP VIEW IF EXISTS view_2_tab3_580 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_580
+DROP VIEW IF EXISTS view_3_tab3_580 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27744,13 +27744,13 @@ SELECT pk FROM tab4 WHERE col4 = 297.0 OR col3 IS NULL OR col1 <= 773.73
 76 values hashing to 593057ce1166d7487f4b469fbf882585
 
 statement ok
-DROP VIEW view_1_tab4_580
+DROP VIEW IF EXISTS view_1_tab4_580 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_580
+DROP VIEW IF EXISTS view_2_tab4_580 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_580
+DROP VIEW IF EXISTS view_3_tab4_580 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27841,13 +27841,13 @@ SELECT pk FROM tab0 WHERE (col1 > 315.20 OR col0 < 855) AND col3 > 496
 42 values hashing to 53517dd22c38964022d9da0783ee9e07
 
 statement ok
-DROP VIEW view_1_tab0_581
+DROP VIEW IF EXISTS view_1_tab0_581 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_581
+DROP VIEW IF EXISTS view_2_tab0_581 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_581
+DROP VIEW IF EXISTS view_3_tab0_581 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27938,13 +27938,13 @@ SELECT pk FROM tab1 WHERE (col1 > 315.20 OR col0 < 855) AND col3 > 496
 42 values hashing to 53517dd22c38964022d9da0783ee9e07
 
 statement ok
-DROP VIEW view_1_tab1_581
+DROP VIEW IF EXISTS view_1_tab1_581 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_581
+DROP VIEW IF EXISTS view_2_tab1_581 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_581
+DROP VIEW IF EXISTS view_3_tab1_581 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28035,13 +28035,13 @@ SELECT pk FROM tab2 WHERE (col1 > 315.20 OR col0 < 855) AND col3 > 496
 42 values hashing to 53517dd22c38964022d9da0783ee9e07
 
 statement ok
-DROP VIEW view_1_tab2_581
+DROP VIEW IF EXISTS view_1_tab2_581 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_581
+DROP VIEW IF EXISTS view_2_tab2_581 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_581
+DROP VIEW IF EXISTS view_3_tab2_581 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28132,13 +28132,13 @@ SELECT pk FROM tab3 WHERE (col1 > 315.20 OR col0 < 855) AND col3 > 496
 42 values hashing to 53517dd22c38964022d9da0783ee9e07
 
 statement ok
-DROP VIEW view_1_tab3_581
+DROP VIEW IF EXISTS view_1_tab3_581 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_581
+DROP VIEW IF EXISTS view_2_tab3_581 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_581
+DROP VIEW IF EXISTS view_3_tab3_581 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28229,13 +28229,13 @@ SELECT pk FROM tab4 WHERE (col1 > 315.20 OR col0 < 855) AND col3 > 496
 42 values hashing to 53517dd22c38964022d9da0783ee9e07
 
 statement ok
-DROP VIEW view_1_tab4_581
+DROP VIEW IF EXISTS view_1_tab4_581 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_581
+DROP VIEW IF EXISTS view_2_tab4_581 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_581
+DROP VIEW IF EXISTS view_3_tab4_581 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28326,13 +28326,13 @@ SELECT pk FROM tab0 WHERE (((col3 >= 407) AND col3 > 449))
 46 values hashing to bf16880fa15c590cef3647c73b665ced
 
 statement ok
-DROP VIEW view_1_tab0_582
+DROP VIEW IF EXISTS view_1_tab0_582 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_582
+DROP VIEW IF EXISTS view_2_tab0_582 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_582
+DROP VIEW IF EXISTS view_3_tab0_582 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28423,13 +28423,13 @@ SELECT pk FROM tab1 WHERE (((col3 >= 407) AND col3 > 449))
 46 values hashing to bf16880fa15c590cef3647c73b665ced
 
 statement ok
-DROP VIEW view_1_tab1_582
+DROP VIEW IF EXISTS view_1_tab1_582 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_582
+DROP VIEW IF EXISTS view_2_tab1_582 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_582
+DROP VIEW IF EXISTS view_3_tab1_582 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28520,13 +28520,13 @@ SELECT pk FROM tab2 WHERE (((col3 >= 407) AND col3 > 449))
 46 values hashing to bf16880fa15c590cef3647c73b665ced
 
 statement ok
-DROP VIEW view_1_tab2_582
+DROP VIEW IF EXISTS view_1_tab2_582 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_582
+DROP VIEW IF EXISTS view_2_tab2_582 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_582
+DROP VIEW IF EXISTS view_3_tab2_582 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28617,13 +28617,13 @@ SELECT pk FROM tab3 WHERE (((col3 >= 407) AND col3 > 449))
 46 values hashing to bf16880fa15c590cef3647c73b665ced
 
 statement ok
-DROP VIEW view_1_tab3_582
+DROP VIEW IF EXISTS view_1_tab3_582 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_582
+DROP VIEW IF EXISTS view_2_tab3_582 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_582
+DROP VIEW IF EXISTS view_3_tab3_582 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28714,13 +28714,13 @@ SELECT pk FROM tab4 WHERE (((col3 >= 407) AND col3 > 449))
 46 values hashing to bf16880fa15c590cef3647c73b665ced
 
 statement ok
-DROP VIEW view_1_tab4_582
+DROP VIEW IF EXISTS view_1_tab4_582 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_582
+DROP VIEW IF EXISTS view_2_tab4_582 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_582
+DROP VIEW IF EXISTS view_3_tab4_582 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28813,13 +28813,13 @@ SELECT pk FROM tab0 WHERE ((col0 <= 976))
 99 values hashing to 59f788949c9a65f55e830edfbf26f6c9
 
 statement ok
-DROP VIEW view_1_tab0_583
+DROP VIEW IF EXISTS view_1_tab0_583 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_583
+DROP VIEW IF EXISTS view_2_tab0_583 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_583
+DROP VIEW IF EXISTS view_3_tab0_583 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28912,13 +28912,13 @@ SELECT pk FROM tab1 WHERE ((col0 <= 976))
 99 values hashing to 59f788949c9a65f55e830edfbf26f6c9
 
 statement ok
-DROP VIEW view_1_tab1_583
+DROP VIEW IF EXISTS view_1_tab1_583 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_583
+DROP VIEW IF EXISTS view_2_tab1_583 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_583
+DROP VIEW IF EXISTS view_3_tab1_583 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29011,13 +29011,13 @@ SELECT pk FROM tab2 WHERE ((col0 <= 976))
 99 values hashing to 59f788949c9a65f55e830edfbf26f6c9
 
 statement ok
-DROP VIEW view_1_tab2_583
+DROP VIEW IF EXISTS view_1_tab2_583 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_583
+DROP VIEW IF EXISTS view_2_tab2_583 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_583
+DROP VIEW IF EXISTS view_3_tab2_583 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29110,13 +29110,13 @@ SELECT pk FROM tab3 WHERE ((col0 <= 976))
 99 values hashing to 59f788949c9a65f55e830edfbf26f6c9
 
 statement ok
-DROP VIEW view_1_tab3_583
+DROP VIEW IF EXISTS view_1_tab3_583 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_583
+DROP VIEW IF EXISTS view_2_tab3_583 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_583
+DROP VIEW IF EXISTS view_3_tab3_583 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29209,13 +29209,13 @@ SELECT pk FROM tab4 WHERE ((col0 <= 976))
 99 values hashing to 59f788949c9a65f55e830edfbf26f6c9
 
 statement ok
-DROP VIEW view_1_tab4_583
+DROP VIEW IF EXISTS view_1_tab4_583 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_583
+DROP VIEW IF EXISTS view_2_tab4_583 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_583
+DROP VIEW IF EXISTS view_3_tab4_583 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29301,13 +29301,13 @@ SELECT pk FROM tab0 WHERE col4 = 526.64
 ----
 
 statement ok
-DROP VIEW view_1_tab0_584
+DROP VIEW IF EXISTS view_1_tab0_584 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_584
+DROP VIEW IF EXISTS view_2_tab0_584 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_584
+DROP VIEW IF EXISTS view_3_tab0_584 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29393,13 +29393,13 @@ SELECT pk FROM tab1 WHERE col4 = 526.64
 ----
 
 statement ok
-DROP VIEW view_1_tab1_584
+DROP VIEW IF EXISTS view_1_tab1_584 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_584
+DROP VIEW IF EXISTS view_2_tab1_584 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_584
+DROP VIEW IF EXISTS view_3_tab1_584 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29485,13 +29485,13 @@ SELECT pk FROM tab2 WHERE col4 = 526.64
 ----
 
 statement ok
-DROP VIEW view_1_tab2_584
+DROP VIEW IF EXISTS view_1_tab2_584 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_584
+DROP VIEW IF EXISTS view_2_tab2_584 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_584
+DROP VIEW IF EXISTS view_3_tab2_584 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29577,13 +29577,13 @@ SELECT pk FROM tab3 WHERE col4 = 526.64
 ----
 
 statement ok
-DROP VIEW view_1_tab3_584
+DROP VIEW IF EXISTS view_1_tab3_584 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_584
+DROP VIEW IF EXISTS view_2_tab3_584 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_584
+DROP VIEW IF EXISTS view_3_tab3_584 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29669,13 +29669,13 @@ SELECT pk FROM tab4 WHERE col4 = 526.64
 ----
 
 statement ok
-DROP VIEW view_1_tab4_584
+DROP VIEW IF EXISTS view_1_tab4_584 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_584
+DROP VIEW IF EXISTS view_2_tab4_584 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_584
+DROP VIEW IF EXISTS view_3_tab4_584 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29766,13 +29766,13 @@ SELECT pk FROM tab0 WHERE col1 < 353.14
 30 values hashing to 6f1ce59bec006ee2d6778913eee37530
 
 statement ok
-DROP VIEW view_1_tab0_585
+DROP VIEW IF EXISTS view_1_tab0_585 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_585
+DROP VIEW IF EXISTS view_2_tab0_585 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_585
+DROP VIEW IF EXISTS view_3_tab0_585 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29863,13 +29863,13 @@ SELECT pk FROM tab1 WHERE col1 < 353.14
 30 values hashing to 6f1ce59bec006ee2d6778913eee37530
 
 statement ok
-DROP VIEW view_1_tab1_585
+DROP VIEW IF EXISTS view_1_tab1_585 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_585
+DROP VIEW IF EXISTS view_2_tab1_585 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_585
+DROP VIEW IF EXISTS view_3_tab1_585 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29960,13 +29960,13 @@ SELECT pk FROM tab2 WHERE col1 < 353.14
 30 values hashing to 6f1ce59bec006ee2d6778913eee37530
 
 statement ok
-DROP VIEW view_1_tab2_585
+DROP VIEW IF EXISTS view_1_tab2_585 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_585
+DROP VIEW IF EXISTS view_2_tab2_585 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_585
+DROP VIEW IF EXISTS view_3_tab2_585 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30057,13 +30057,13 @@ SELECT pk FROM tab3 WHERE col1 < 353.14
 30 values hashing to 6f1ce59bec006ee2d6778913eee37530
 
 statement ok
-DROP VIEW view_1_tab3_585
+DROP VIEW IF EXISTS view_1_tab3_585 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_585
+DROP VIEW IF EXISTS view_2_tab3_585 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_585
+DROP VIEW IF EXISTS view_3_tab3_585 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30154,13 +30154,13 @@ SELECT pk FROM tab4 WHERE col1 < 353.14
 30 values hashing to 6f1ce59bec006ee2d6778913eee37530
 
 statement ok
-DROP VIEW view_1_tab4_585
+DROP VIEW IF EXISTS view_1_tab4_585 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_585
+DROP VIEW IF EXISTS view_2_tab4_585 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_585
+DROP VIEW IF EXISTS view_3_tab4_585 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30251,13 +30251,13 @@ SELECT pk FROM tab0 WHERE (col0 >= 683)
 34 values hashing to 2c05e49579e4d5d7715ad100394083e6
 
 statement ok
-DROP VIEW view_1_tab0_586
+DROP VIEW IF EXISTS view_1_tab0_586 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_586
+DROP VIEW IF EXISTS view_2_tab0_586 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_586
+DROP VIEW IF EXISTS view_3_tab0_586 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30348,13 +30348,13 @@ SELECT pk FROM tab1 WHERE (col0 >= 683)
 34 values hashing to 2c05e49579e4d5d7715ad100394083e6
 
 statement ok
-DROP VIEW view_1_tab1_586
+DROP VIEW IF EXISTS view_1_tab1_586 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_586
+DROP VIEW IF EXISTS view_2_tab1_586 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_586
+DROP VIEW IF EXISTS view_3_tab1_586 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30445,13 +30445,13 @@ SELECT pk FROM tab2 WHERE (col0 >= 683)
 34 values hashing to 2c05e49579e4d5d7715ad100394083e6
 
 statement ok
-DROP VIEW view_1_tab2_586
+DROP VIEW IF EXISTS view_1_tab2_586 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_586
+DROP VIEW IF EXISTS view_2_tab2_586 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_586
+DROP VIEW IF EXISTS view_3_tab2_586 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30542,13 +30542,13 @@ SELECT pk FROM tab3 WHERE (col0 >= 683)
 34 values hashing to 2c05e49579e4d5d7715ad100394083e6
 
 statement ok
-DROP VIEW view_1_tab3_586
+DROP VIEW IF EXISTS view_1_tab3_586 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_586
+DROP VIEW IF EXISTS view_2_tab3_586 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_586
+DROP VIEW IF EXISTS view_3_tab3_586 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30639,13 +30639,13 @@ SELECT pk FROM tab4 WHERE (col0 >= 683)
 34 values hashing to 2c05e49579e4d5d7715ad100394083e6
 
 statement ok
-DROP VIEW view_1_tab4_586
+DROP VIEW IF EXISTS view_1_tab4_586 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_586
+DROP VIEW IF EXISTS view_2_tab4_586 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_586
+DROP VIEW IF EXISTS view_3_tab4_586 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30736,13 +30736,13 @@ SELECT pk FROM tab0 WHERE (col4 <= 383.7 AND col0 < 347 AND col1 > 373.8 OR (col
 16 values hashing to a3591a75e5ca9ee50be120fdf2351ae9
 
 statement ok
-DROP VIEW view_1_tab0_587
+DROP VIEW IF EXISTS view_1_tab0_587 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_587
+DROP VIEW IF EXISTS view_2_tab0_587 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_587
+DROP VIEW IF EXISTS view_3_tab0_587 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30833,13 +30833,13 @@ SELECT pk FROM tab1 WHERE (col4 <= 383.7 AND col0 < 347 AND col1 > 373.8 OR (col
 16 values hashing to a3591a75e5ca9ee50be120fdf2351ae9
 
 statement ok
-DROP VIEW view_1_tab1_587
+DROP VIEW IF EXISTS view_1_tab1_587 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_587
+DROP VIEW IF EXISTS view_2_tab1_587 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_587
+DROP VIEW IF EXISTS view_3_tab1_587 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30930,13 +30930,13 @@ SELECT pk FROM tab2 WHERE (col4 <= 383.7 AND col0 < 347 AND col1 > 373.8 OR (col
 16 values hashing to a3591a75e5ca9ee50be120fdf2351ae9
 
 statement ok
-DROP VIEW view_1_tab2_587
+DROP VIEW IF EXISTS view_1_tab2_587 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_587
+DROP VIEW IF EXISTS view_2_tab2_587 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_587
+DROP VIEW IF EXISTS view_3_tab2_587 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31027,13 +31027,13 @@ SELECT pk FROM tab3 WHERE (col4 <= 383.7 AND col0 < 347 AND col1 > 373.8 OR (col
 16 values hashing to a3591a75e5ca9ee50be120fdf2351ae9
 
 statement ok
-DROP VIEW view_1_tab3_587
+DROP VIEW IF EXISTS view_1_tab3_587 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_587
+DROP VIEW IF EXISTS view_2_tab3_587 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_587
+DROP VIEW IF EXISTS view_3_tab3_587 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31124,13 +31124,13 @@ SELECT pk FROM tab4 WHERE (col4 <= 383.7 AND col0 < 347 AND col1 > 373.8 OR (col
 16 values hashing to a3591a75e5ca9ee50be120fdf2351ae9
 
 statement ok
-DROP VIEW view_1_tab4_587
+DROP VIEW IF EXISTS view_1_tab4_587 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_587
+DROP VIEW IF EXISTS view_2_tab4_587 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_587
+DROP VIEW IF EXISTS view_3_tab4_587 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31216,13 +31216,13 @@ SELECT pk FROM tab0 WHERE col3 IN (820,152,714,95,34,628)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_588
+DROP VIEW IF EXISTS view_1_tab0_588 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_588
+DROP VIEW IF EXISTS view_2_tab0_588 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_588
+DROP VIEW IF EXISTS view_3_tab0_588 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31308,13 +31308,13 @@ SELECT pk FROM tab1 WHERE col3 IN (820,152,714,95,34,628)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_588
+DROP VIEW IF EXISTS view_1_tab1_588 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_588
+DROP VIEW IF EXISTS view_2_tab1_588 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_588
+DROP VIEW IF EXISTS view_3_tab1_588 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31400,13 +31400,13 @@ SELECT pk FROM tab2 WHERE col3 IN (820,152,714,95,34,628)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_588
+DROP VIEW IF EXISTS view_1_tab2_588 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_588
+DROP VIEW IF EXISTS view_2_tab2_588 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_588
+DROP VIEW IF EXISTS view_3_tab2_588 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31492,13 +31492,13 @@ SELECT pk FROM tab3 WHERE col3 IN (820,152,714,95,34,628)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_588
+DROP VIEW IF EXISTS view_1_tab3_588 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_588
+DROP VIEW IF EXISTS view_2_tab3_588 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_588
+DROP VIEW IF EXISTS view_3_tab3_588 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31584,13 +31584,13 @@ SELECT pk FROM tab4 WHERE col3 IN (820,152,714,95,34,628)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_588
+DROP VIEW IF EXISTS view_1_tab4_588 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_588
+DROP VIEW IF EXISTS view_2_tab4_588 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_588
+DROP VIEW IF EXISTS view_3_tab4_588 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31676,13 +31676,13 @@ SELECT pk FROM tab0 WHERE col3 >= 311 AND col0 >= 2 AND col3 IS NULL AND col3 < 
 ----
 
 statement ok
-DROP VIEW view_1_tab0_589
+DROP VIEW IF EXISTS view_1_tab0_589 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_589
+DROP VIEW IF EXISTS view_2_tab0_589 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_589
+DROP VIEW IF EXISTS view_3_tab0_589 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31768,13 +31768,13 @@ SELECT pk FROM tab1 WHERE col3 >= 311 AND col0 >= 2 AND col3 IS NULL AND col3 < 
 ----
 
 statement ok
-DROP VIEW view_1_tab1_589
+DROP VIEW IF EXISTS view_1_tab1_589 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_589
+DROP VIEW IF EXISTS view_2_tab1_589 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_589
+DROP VIEW IF EXISTS view_3_tab1_589 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31860,13 +31860,13 @@ SELECT pk FROM tab2 WHERE col3 >= 311 AND col0 >= 2 AND col3 IS NULL AND col3 < 
 ----
 
 statement ok
-DROP VIEW view_1_tab2_589
+DROP VIEW IF EXISTS view_1_tab2_589 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_589
+DROP VIEW IF EXISTS view_2_tab2_589 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_589
+DROP VIEW IF EXISTS view_3_tab2_589 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31952,13 +31952,13 @@ SELECT pk FROM tab3 WHERE col3 >= 311 AND col0 >= 2 AND col3 IS NULL AND col3 < 
 ----
 
 statement ok
-DROP VIEW view_1_tab3_589
+DROP VIEW IF EXISTS view_1_tab3_589 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_589
+DROP VIEW IF EXISTS view_2_tab3_589 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_589
+DROP VIEW IF EXISTS view_3_tab3_589 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32044,13 +32044,13 @@ SELECT pk FROM tab4 WHERE col3 >= 311 AND col0 >= 2 AND col3 IS NULL AND col3 < 
 ----
 
 statement ok
-DROP VIEW view_1_tab4_589
+DROP VIEW IF EXISTS view_1_tab4_589 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_589
+DROP VIEW IF EXISTS view_2_tab4_589 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_589
+DROP VIEW IF EXISTS view_3_tab4_589 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32141,13 +32141,13 @@ SELECT pk FROM tab0 WHERE col4 BETWEEN 76.99 AND 316.5 AND col3 > 298
 15 values hashing to 50a1ab488b5e332040e5a36c29b6080d
 
 statement ok
-DROP VIEW view_1_tab0_590
+DROP VIEW IF EXISTS view_1_tab0_590 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_590
+DROP VIEW IF EXISTS view_2_tab0_590 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_590
+DROP VIEW IF EXISTS view_3_tab0_590 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32238,13 +32238,13 @@ SELECT pk FROM tab1 WHERE col4 BETWEEN 76.99 AND 316.5 AND col3 > 298
 15 values hashing to 50a1ab488b5e332040e5a36c29b6080d
 
 statement ok
-DROP VIEW view_1_tab1_590
+DROP VIEW IF EXISTS view_1_tab1_590 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_590
+DROP VIEW IF EXISTS view_2_tab1_590 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_590
+DROP VIEW IF EXISTS view_3_tab1_590 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32335,13 +32335,13 @@ SELECT pk FROM tab2 WHERE col4 BETWEEN 76.99 AND 316.5 AND col3 > 298
 15 values hashing to 50a1ab488b5e332040e5a36c29b6080d
 
 statement ok
-DROP VIEW view_1_tab2_590
+DROP VIEW IF EXISTS view_1_tab2_590 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_590
+DROP VIEW IF EXISTS view_2_tab2_590 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_590
+DROP VIEW IF EXISTS view_3_tab2_590 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32432,13 +32432,13 @@ SELECT pk FROM tab3 WHERE col4 BETWEEN 76.99 AND 316.5 AND col3 > 298
 15 values hashing to 50a1ab488b5e332040e5a36c29b6080d
 
 statement ok
-DROP VIEW view_1_tab3_590
+DROP VIEW IF EXISTS view_1_tab3_590 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_590
+DROP VIEW IF EXISTS view_2_tab3_590 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_590
+DROP VIEW IF EXISTS view_3_tab3_590 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32529,13 +32529,13 @@ SELECT pk FROM tab4 WHERE col4 BETWEEN 76.99 AND 316.5 AND col3 > 298
 15 values hashing to 50a1ab488b5e332040e5a36c29b6080d
 
 statement ok
-DROP VIEW view_1_tab4_590
+DROP VIEW IF EXISTS view_1_tab4_590 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_590
+DROP VIEW IF EXISTS view_2_tab4_590 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_590
+DROP VIEW IF EXISTS view_3_tab4_590 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32626,13 +32626,13 @@ SELECT pk FROM tab0 WHERE col0 > 61
 92 values hashing to c8f167d0a1ece653a7a6e870d2b19ebd
 
 statement ok
-DROP VIEW view_1_tab0_591
+DROP VIEW IF EXISTS view_1_tab0_591 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_591
+DROP VIEW IF EXISTS view_2_tab0_591 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_591
+DROP VIEW IF EXISTS view_3_tab0_591 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32723,13 +32723,13 @@ SELECT pk FROM tab1 WHERE col0 > 61
 92 values hashing to c8f167d0a1ece653a7a6e870d2b19ebd
 
 statement ok
-DROP VIEW view_1_tab1_591
+DROP VIEW IF EXISTS view_1_tab1_591 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_591
+DROP VIEW IF EXISTS view_2_tab1_591 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_591
+DROP VIEW IF EXISTS view_3_tab1_591 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32820,13 +32820,13 @@ SELECT pk FROM tab2 WHERE col0 > 61
 92 values hashing to c8f167d0a1ece653a7a6e870d2b19ebd
 
 statement ok
-DROP VIEW view_1_tab2_591
+DROP VIEW IF EXISTS view_1_tab2_591 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_591
+DROP VIEW IF EXISTS view_2_tab2_591 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_591
+DROP VIEW IF EXISTS view_3_tab2_591 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32917,13 +32917,13 @@ SELECT pk FROM tab3 WHERE col0 > 61
 92 values hashing to c8f167d0a1ece653a7a6e870d2b19ebd
 
 statement ok
-DROP VIEW view_1_tab3_591
+DROP VIEW IF EXISTS view_1_tab3_591 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_591
+DROP VIEW IF EXISTS view_2_tab3_591 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_591
+DROP VIEW IF EXISTS view_3_tab3_591 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33014,13 +33014,13 @@ SELECT pk FROM tab4 WHERE col0 > 61
 92 values hashing to c8f167d0a1ece653a7a6e870d2b19ebd
 
 statement ok
-DROP VIEW view_1_tab4_591
+DROP VIEW IF EXISTS view_1_tab4_591 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_591
+DROP VIEW IF EXISTS view_2_tab4_591 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_591
+DROP VIEW IF EXISTS view_3_tab4_591 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33111,13 +33111,13 @@ SELECT pk FROM tab0 WHERE (col1 >= 234.10)
 78 values hashing to c55e87d11cdd7322667612c7a06bfaa4
 
 statement ok
-DROP VIEW view_1_tab0_592
+DROP VIEW IF EXISTS view_1_tab0_592 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_592
+DROP VIEW IF EXISTS view_2_tab0_592 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_592
+DROP VIEW IF EXISTS view_3_tab0_592 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33208,13 +33208,13 @@ SELECT pk FROM tab1 WHERE (col1 >= 234.10)
 78 values hashing to c55e87d11cdd7322667612c7a06bfaa4
 
 statement ok
-DROP VIEW view_1_tab1_592
+DROP VIEW IF EXISTS view_1_tab1_592 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_592
+DROP VIEW IF EXISTS view_2_tab1_592 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_592
+DROP VIEW IF EXISTS view_3_tab1_592 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33305,13 +33305,13 @@ SELECT pk FROM tab2 WHERE (col1 >= 234.10)
 78 values hashing to c55e87d11cdd7322667612c7a06bfaa4
 
 statement ok
-DROP VIEW view_1_tab2_592
+DROP VIEW IF EXISTS view_1_tab2_592 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_592
+DROP VIEW IF EXISTS view_2_tab2_592 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_592
+DROP VIEW IF EXISTS view_3_tab2_592 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33402,13 +33402,13 @@ SELECT pk FROM tab3 WHERE (col1 >= 234.10)
 78 values hashing to c55e87d11cdd7322667612c7a06bfaa4
 
 statement ok
-DROP VIEW view_1_tab3_592
+DROP VIEW IF EXISTS view_1_tab3_592 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_592
+DROP VIEW IF EXISTS view_2_tab3_592 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_592
+DROP VIEW IF EXISTS view_3_tab3_592 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33499,13 +33499,13 @@ SELECT pk FROM tab4 WHERE (col1 >= 234.10)
 78 values hashing to c55e87d11cdd7322667612c7a06bfaa4
 
 statement ok
-DROP VIEW view_1_tab4_592
+DROP VIEW IF EXISTS view_1_tab4_592 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_592
+DROP VIEW IF EXISTS view_2_tab4_592 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_592
+DROP VIEW IF EXISTS view_3_tab4_592 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33596,13 +33596,13 @@ SELECT pk FROM tab0 WHERE ((col0 >= 903 AND col1 > 47.50))
 9 values hashing to 6413a96764d71baedae0f7dc6c05eb9b
 
 statement ok
-DROP VIEW view_1_tab0_593
+DROP VIEW IF EXISTS view_1_tab0_593 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_593
+DROP VIEW IF EXISTS view_2_tab0_593 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_593
+DROP VIEW IF EXISTS view_3_tab0_593 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33693,13 +33693,13 @@ SELECT pk FROM tab1 WHERE ((col0 >= 903 AND col1 > 47.50))
 9 values hashing to 6413a96764d71baedae0f7dc6c05eb9b
 
 statement ok
-DROP VIEW view_1_tab1_593
+DROP VIEW IF EXISTS view_1_tab1_593 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_593
+DROP VIEW IF EXISTS view_2_tab1_593 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_593
+DROP VIEW IF EXISTS view_3_tab1_593 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33790,13 +33790,13 @@ SELECT pk FROM tab2 WHERE ((col0 >= 903 AND col1 > 47.50))
 9 values hashing to 6413a96764d71baedae0f7dc6c05eb9b
 
 statement ok
-DROP VIEW view_1_tab2_593
+DROP VIEW IF EXISTS view_1_tab2_593 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_593
+DROP VIEW IF EXISTS view_2_tab2_593 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_593
+DROP VIEW IF EXISTS view_3_tab2_593 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33887,13 +33887,13 @@ SELECT pk FROM tab3 WHERE ((col0 >= 903 AND col1 > 47.50))
 9 values hashing to 6413a96764d71baedae0f7dc6c05eb9b
 
 statement ok
-DROP VIEW view_1_tab3_593
+DROP VIEW IF EXISTS view_1_tab3_593 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_593
+DROP VIEW IF EXISTS view_2_tab3_593 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_593
+DROP VIEW IF EXISTS view_3_tab3_593 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33984,13 +33984,13 @@ SELECT pk FROM tab4 WHERE ((col0 >= 903 AND col1 > 47.50))
 9 values hashing to 6413a96764d71baedae0f7dc6c05eb9b
 
 statement ok
-DROP VIEW view_1_tab4_593
+DROP VIEW IF EXISTS view_1_tab4_593 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_593
+DROP VIEW IF EXISTS view_2_tab4_593 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_593
+DROP VIEW IF EXISTS view_3_tab4_593 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34081,13 +34081,13 @@ SELECT pk FROM tab0 WHERE (col3 > 549)
 37 values hashing to 181fa25cf5671c6325680dc6dc17b530
 
 statement ok
-DROP VIEW view_1_tab0_594
+DROP VIEW IF EXISTS view_1_tab0_594 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_594
+DROP VIEW IF EXISTS view_2_tab0_594 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_594
+DROP VIEW IF EXISTS view_3_tab0_594 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34178,13 +34178,13 @@ SELECT pk FROM tab1 WHERE (col3 > 549)
 37 values hashing to 181fa25cf5671c6325680dc6dc17b530
 
 statement ok
-DROP VIEW view_1_tab1_594
+DROP VIEW IF EXISTS view_1_tab1_594 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_594
+DROP VIEW IF EXISTS view_2_tab1_594 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_594
+DROP VIEW IF EXISTS view_3_tab1_594 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34275,13 +34275,13 @@ SELECT pk FROM tab2 WHERE (col3 > 549)
 37 values hashing to 181fa25cf5671c6325680dc6dc17b530
 
 statement ok
-DROP VIEW view_1_tab2_594
+DROP VIEW IF EXISTS view_1_tab2_594 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_594
+DROP VIEW IF EXISTS view_2_tab2_594 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_594
+DROP VIEW IF EXISTS view_3_tab2_594 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34372,13 +34372,13 @@ SELECT pk FROM tab3 WHERE (col3 > 549)
 37 values hashing to 181fa25cf5671c6325680dc6dc17b530
 
 statement ok
-DROP VIEW view_1_tab3_594
+DROP VIEW IF EXISTS view_1_tab3_594 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_594
+DROP VIEW IF EXISTS view_2_tab3_594 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_594
+DROP VIEW IF EXISTS view_3_tab3_594 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34469,13 +34469,13 @@ SELECT pk FROM tab4 WHERE (col3 > 549)
 37 values hashing to 181fa25cf5671c6325680dc6dc17b530
 
 statement ok
-DROP VIEW view_1_tab4_594
+DROP VIEW IF EXISTS view_1_tab4_594 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_594
+DROP VIEW IF EXISTS view_2_tab4_594 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_594
+DROP VIEW IF EXISTS view_3_tab4_594 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34561,13 +34561,13 @@ SELECT pk FROM tab0 WHERE (col4 IN (952.5,438.34,33.7,993.81) OR (col0 >= 112)) 
 ----
 
 statement ok
-DROP VIEW view_1_tab0_595
+DROP VIEW IF EXISTS view_1_tab0_595 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_595
+DROP VIEW IF EXISTS view_2_tab0_595 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_595
+DROP VIEW IF EXISTS view_3_tab0_595 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34653,13 +34653,13 @@ SELECT pk FROM tab1 WHERE (col4 IN (952.5,438.34,33.7,993.81) OR (col0 >= 112)) 
 ----
 
 statement ok
-DROP VIEW view_1_tab1_595
+DROP VIEW IF EXISTS view_1_tab1_595 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_595
+DROP VIEW IF EXISTS view_2_tab1_595 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_595
+DROP VIEW IF EXISTS view_3_tab1_595 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34745,13 +34745,13 @@ SELECT pk FROM tab2 WHERE (col4 IN (952.5,438.34,33.7,993.81) OR (col0 >= 112)) 
 ----
 
 statement ok
-DROP VIEW view_1_tab2_595
+DROP VIEW IF EXISTS view_1_tab2_595 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_595
+DROP VIEW IF EXISTS view_2_tab2_595 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_595
+DROP VIEW IF EXISTS view_3_tab2_595 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34837,13 +34837,13 @@ SELECT pk FROM tab3 WHERE (col4 IN (952.5,438.34,33.7,993.81) OR (col0 >= 112)) 
 ----
 
 statement ok
-DROP VIEW view_1_tab3_595
+DROP VIEW IF EXISTS view_1_tab3_595 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_595
+DROP VIEW IF EXISTS view_2_tab3_595 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_595
+DROP VIEW IF EXISTS view_3_tab3_595 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34929,13 +34929,13 @@ SELECT pk FROM tab4 WHERE (col4 IN (952.5,438.34,33.7,993.81) OR (col0 >= 112)) 
 ----
 
 statement ok
-DROP VIEW view_1_tab4_595
+DROP VIEW IF EXISTS view_1_tab4_595 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_595
+DROP VIEW IF EXISTS view_2_tab4_595 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_595
+DROP VIEW IF EXISTS view_3_tab4_595 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35021,13 +35021,13 @@ SELECT pk FROM tab0 WHERE col4 IN (277.66,109.65,857.88,798.34,463.17)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_596
+DROP VIEW IF EXISTS view_1_tab0_596 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_596
+DROP VIEW IF EXISTS view_2_tab0_596 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_596
+DROP VIEW IF EXISTS view_3_tab0_596 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35113,13 +35113,13 @@ SELECT pk FROM tab1 WHERE col4 IN (277.66,109.65,857.88,798.34,463.17)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_596
+DROP VIEW IF EXISTS view_1_tab1_596 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_596
+DROP VIEW IF EXISTS view_2_tab1_596 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_596
+DROP VIEW IF EXISTS view_3_tab1_596 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35205,13 +35205,13 @@ SELECT pk FROM tab2 WHERE col4 IN (277.66,109.65,857.88,798.34,463.17)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_596
+DROP VIEW IF EXISTS view_1_tab2_596 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_596
+DROP VIEW IF EXISTS view_2_tab2_596 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_596
+DROP VIEW IF EXISTS view_3_tab2_596 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35297,13 +35297,13 @@ SELECT pk FROM tab3 WHERE col4 IN (277.66,109.65,857.88,798.34,463.17)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_596
+DROP VIEW IF EXISTS view_1_tab3_596 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_596
+DROP VIEW IF EXISTS view_2_tab3_596 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_596
+DROP VIEW IF EXISTS view_3_tab3_596 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35389,11 +35389,11 @@ SELECT pk FROM tab4 WHERE col4 IN (277.66,109.65,857.88,798.34,463.17)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_596
+DROP VIEW IF EXISTS view_1_tab4_596 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_596
+DROP VIEW IF EXISTS view_2_tab4_596 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_596
+DROP VIEW IF EXISTS view_3_tab4_596 CASCADE
 

--- a/test/index/view/100/slt_good_3.test
+++ b/test/index/view/100/slt_good_3.test
@@ -460,13 +460,13 @@ SELECT pk FROM tab0 WHERE ((col1 >= 565.79)) AND col0 > 948 AND (col4 > 207.27 O
 69
 
 statement ok
-DROP VIEW view_1_tab0_597
+DROP VIEW IF EXISTS view_1_tab0_597 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_597
+DROP VIEW IF EXISTS view_2_tab0_597 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_597
+DROP VIEW IF EXISTS view_3_tab0_597 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -559,13 +559,13 @@ SELECT pk FROM tab1 WHERE ((col1 >= 565.79)) AND col0 > 948 AND (col4 > 207.27 O
 69
 
 statement ok
-DROP VIEW view_1_tab1_597
+DROP VIEW IF EXISTS view_1_tab1_597 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_597
+DROP VIEW IF EXISTS view_2_tab1_597 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_597
+DROP VIEW IF EXISTS view_3_tab1_597 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -658,13 +658,13 @@ SELECT pk FROM tab2 WHERE ((col1 >= 565.79)) AND col0 > 948 AND (col4 > 207.27 O
 69
 
 statement ok
-DROP VIEW view_1_tab2_597
+DROP VIEW IF EXISTS view_1_tab2_597 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_597
+DROP VIEW IF EXISTS view_2_tab2_597 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_597
+DROP VIEW IF EXISTS view_3_tab2_597 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -757,13 +757,13 @@ SELECT pk FROM tab3 WHERE ((col1 >= 565.79)) AND col0 > 948 AND (col4 > 207.27 O
 69
 
 statement ok
-DROP VIEW view_1_tab3_597
+DROP VIEW IF EXISTS view_1_tab3_597 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_597
+DROP VIEW IF EXISTS view_2_tab3_597 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_597
+DROP VIEW IF EXISTS view_3_tab3_597 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -856,13 +856,13 @@ SELECT pk FROM tab4 WHERE ((col1 >= 565.79)) AND col0 > 948 AND (col4 > 207.27 O
 69
 
 statement ok
-DROP VIEW view_1_tab4_597
+DROP VIEW IF EXISTS view_1_tab4_597 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_597
+DROP VIEW IF EXISTS view_2_tab4_597 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_597
+DROP VIEW IF EXISTS view_3_tab4_597 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -953,13 +953,13 @@ SELECT pk FROM tab0 WHERE (col0 > 367)
 62 values hashing to 7129d36681b60af938fc89dba8fec07b
 
 statement ok
-DROP VIEW view_1_tab0_598
+DROP VIEW IF EXISTS view_1_tab0_598 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_598
+DROP VIEW IF EXISTS view_2_tab0_598 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_598
+DROP VIEW IF EXISTS view_3_tab0_598 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1050,13 +1050,13 @@ SELECT pk FROM tab1 WHERE (col0 > 367)
 62 values hashing to 7129d36681b60af938fc89dba8fec07b
 
 statement ok
-DROP VIEW view_1_tab1_598
+DROP VIEW IF EXISTS view_1_tab1_598 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_598
+DROP VIEW IF EXISTS view_2_tab1_598 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_598
+DROP VIEW IF EXISTS view_3_tab1_598 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1147,13 +1147,13 @@ SELECT pk FROM tab2 WHERE (col0 > 367)
 62 values hashing to 7129d36681b60af938fc89dba8fec07b
 
 statement ok
-DROP VIEW view_1_tab2_598
+DROP VIEW IF EXISTS view_1_tab2_598 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_598
+DROP VIEW IF EXISTS view_2_tab2_598 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_598
+DROP VIEW IF EXISTS view_3_tab2_598 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1244,13 +1244,13 @@ SELECT pk FROM tab3 WHERE (col0 > 367)
 62 values hashing to 7129d36681b60af938fc89dba8fec07b
 
 statement ok
-DROP VIEW view_1_tab3_598
+DROP VIEW IF EXISTS view_1_tab3_598 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_598
+DROP VIEW IF EXISTS view_2_tab3_598 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_598
+DROP VIEW IF EXISTS view_3_tab3_598 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1341,13 +1341,13 @@ SELECT pk FROM tab4 WHERE (col0 > 367)
 62 values hashing to 7129d36681b60af938fc89dba8fec07b
 
 statement ok
-DROP VIEW view_1_tab4_598
+DROP VIEW IF EXISTS view_1_tab4_598 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_598
+DROP VIEW IF EXISTS view_2_tab4_598 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_598
+DROP VIEW IF EXISTS view_3_tab4_598 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1438,13 +1438,13 @@ SELECT pk FROM tab0 WHERE col4 > 663.95
 34 values hashing to 22ace4f1eca9c5ec1901d7ac2ae55f7c
 
 statement ok
-DROP VIEW view_1_tab0_599
+DROP VIEW IF EXISTS view_1_tab0_599 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_599
+DROP VIEW IF EXISTS view_2_tab0_599 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_599
+DROP VIEW IF EXISTS view_3_tab0_599 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1535,13 +1535,13 @@ SELECT pk FROM tab1 WHERE col4 > 663.95
 34 values hashing to 22ace4f1eca9c5ec1901d7ac2ae55f7c
 
 statement ok
-DROP VIEW view_1_tab1_599
+DROP VIEW IF EXISTS view_1_tab1_599 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_599
+DROP VIEW IF EXISTS view_2_tab1_599 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_599
+DROP VIEW IF EXISTS view_3_tab1_599 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1632,13 +1632,13 @@ SELECT pk FROM tab2 WHERE col4 > 663.95
 34 values hashing to 22ace4f1eca9c5ec1901d7ac2ae55f7c
 
 statement ok
-DROP VIEW view_1_tab2_599
+DROP VIEW IF EXISTS view_1_tab2_599 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_599
+DROP VIEW IF EXISTS view_2_tab2_599 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_599
+DROP VIEW IF EXISTS view_3_tab2_599 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1729,13 +1729,13 @@ SELECT pk FROM tab3 WHERE col4 > 663.95
 34 values hashing to 22ace4f1eca9c5ec1901d7ac2ae55f7c
 
 statement ok
-DROP VIEW view_1_tab3_599
+DROP VIEW IF EXISTS view_1_tab3_599 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_599
+DROP VIEW IF EXISTS view_2_tab3_599 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_599
+DROP VIEW IF EXISTS view_3_tab3_599 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1826,13 +1826,13 @@ SELECT pk FROM tab4 WHERE col4 > 663.95
 34 values hashing to 22ace4f1eca9c5ec1901d7ac2ae55f7c
 
 statement ok
-DROP VIEW view_1_tab4_599
+DROP VIEW IF EXISTS view_1_tab4_599 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_599
+DROP VIEW IF EXISTS view_2_tab4_599 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_599
+DROP VIEW IF EXISTS view_3_tab4_599 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1918,13 +1918,13 @@ SELECT pk FROM tab0 WHERE col3 IN (10,321)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_600
+DROP VIEW IF EXISTS view_1_tab0_600 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_600
+DROP VIEW IF EXISTS view_2_tab0_600 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_600
+DROP VIEW IF EXISTS view_3_tab0_600 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2010,13 +2010,13 @@ SELECT pk FROM tab1 WHERE col3 IN (10,321)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_600
+DROP VIEW IF EXISTS view_1_tab1_600 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_600
+DROP VIEW IF EXISTS view_2_tab1_600 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_600
+DROP VIEW IF EXISTS view_3_tab1_600 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2102,13 +2102,13 @@ SELECT pk FROM tab2 WHERE col3 IN (10,321)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_600
+DROP VIEW IF EXISTS view_1_tab2_600 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_600
+DROP VIEW IF EXISTS view_2_tab2_600 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_600
+DROP VIEW IF EXISTS view_3_tab2_600 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2194,13 +2194,13 @@ SELECT pk FROM tab3 WHERE col3 IN (10,321)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_600
+DROP VIEW IF EXISTS view_1_tab3_600 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_600
+DROP VIEW IF EXISTS view_2_tab3_600 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_600
+DROP VIEW IF EXISTS view_3_tab3_600 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2286,13 +2286,13 @@ SELECT pk FROM tab4 WHERE col3 IN (10,321)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_600
+DROP VIEW IF EXISTS view_1_tab4_600 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_600
+DROP VIEW IF EXISTS view_2_tab4_600 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_600
+DROP VIEW IF EXISTS view_3_tab4_600 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2383,13 +2383,13 @@ SELECT pk FROM tab0 WHERE col3 <= 671
 74 values hashing to 3996e69615d396b54745703a560e2a4c
 
 statement ok
-DROP VIEW view_1_tab0_601
+DROP VIEW IF EXISTS view_1_tab0_601 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_601
+DROP VIEW IF EXISTS view_2_tab0_601 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_601
+DROP VIEW IF EXISTS view_3_tab0_601 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2480,13 +2480,13 @@ SELECT pk FROM tab1 WHERE col3 <= 671
 74 values hashing to 3996e69615d396b54745703a560e2a4c
 
 statement ok
-DROP VIEW view_1_tab1_601
+DROP VIEW IF EXISTS view_1_tab1_601 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_601
+DROP VIEW IF EXISTS view_2_tab1_601 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_601
+DROP VIEW IF EXISTS view_3_tab1_601 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2577,13 +2577,13 @@ SELECT pk FROM tab2 WHERE col3 <= 671
 74 values hashing to 3996e69615d396b54745703a560e2a4c
 
 statement ok
-DROP VIEW view_1_tab2_601
+DROP VIEW IF EXISTS view_1_tab2_601 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_601
+DROP VIEW IF EXISTS view_2_tab2_601 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_601
+DROP VIEW IF EXISTS view_3_tab2_601 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2674,13 +2674,13 @@ SELECT pk FROM tab3 WHERE col3 <= 671
 74 values hashing to 3996e69615d396b54745703a560e2a4c
 
 statement ok
-DROP VIEW view_1_tab3_601
+DROP VIEW IF EXISTS view_1_tab3_601 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_601
+DROP VIEW IF EXISTS view_2_tab3_601 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_601
+DROP VIEW IF EXISTS view_3_tab3_601 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2771,13 +2771,13 @@ SELECT pk FROM tab4 WHERE col3 <= 671
 74 values hashing to 3996e69615d396b54745703a560e2a4c
 
 statement ok
-DROP VIEW view_1_tab4_601
+DROP VIEW IF EXISTS view_1_tab4_601 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_601
+DROP VIEW IF EXISTS view_2_tab4_601 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_601
+DROP VIEW IF EXISTS view_3_tab4_601 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2868,13 +2868,13 @@ SELECT pk FROM tab0 WHERE col0 IN (SELECT col3 FROM tab0 WHERE col0 >= 795) OR c
 42 values hashing to 1a5c5ea02f9c7bb1e940e0d19bc8f819
 
 statement ok
-DROP VIEW view_1_tab0_602
+DROP VIEW IF EXISTS view_1_tab0_602 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_602
+DROP VIEW IF EXISTS view_2_tab0_602 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_602
+DROP VIEW IF EXISTS view_3_tab0_602 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2965,13 +2965,13 @@ SELECT pk FROM tab1 WHERE col0 IN (SELECT col3 FROM tab1 WHERE col0 >= 795) OR c
 42 values hashing to 1a5c5ea02f9c7bb1e940e0d19bc8f819
 
 statement ok
-DROP VIEW view_1_tab1_602
+DROP VIEW IF EXISTS view_1_tab1_602 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_602
+DROP VIEW IF EXISTS view_2_tab1_602 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_602
+DROP VIEW IF EXISTS view_3_tab1_602 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3062,13 +3062,13 @@ SELECT pk FROM tab2 WHERE col0 IN (SELECT col3 FROM tab2 WHERE col0 >= 795) OR c
 42 values hashing to 1a5c5ea02f9c7bb1e940e0d19bc8f819
 
 statement ok
-DROP VIEW view_1_tab2_602
+DROP VIEW IF EXISTS view_1_tab2_602 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_602
+DROP VIEW IF EXISTS view_2_tab2_602 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_602
+DROP VIEW IF EXISTS view_3_tab2_602 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3159,13 +3159,13 @@ SELECT pk FROM tab3 WHERE col0 IN (SELECT col3 FROM tab3 WHERE col0 >= 795) OR c
 42 values hashing to 1a5c5ea02f9c7bb1e940e0d19bc8f819
 
 statement ok
-DROP VIEW view_1_tab3_602
+DROP VIEW IF EXISTS view_1_tab3_602 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_602
+DROP VIEW IF EXISTS view_2_tab3_602 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_602
+DROP VIEW IF EXISTS view_3_tab3_602 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3256,13 +3256,13 @@ SELECT pk FROM tab4 WHERE col0 IN (SELECT col3 FROM tab4 WHERE col0 >= 795) OR c
 42 values hashing to 1a5c5ea02f9c7bb1e940e0d19bc8f819
 
 statement ok
-DROP VIEW view_1_tab4_602
+DROP VIEW IF EXISTS view_1_tab4_602 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_602
+DROP VIEW IF EXISTS view_2_tab4_602 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_602
+DROP VIEW IF EXISTS view_3_tab4_602 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3353,13 +3353,13 @@ SELECT pk FROM tab0 WHERE col0 >= 344 AND col4 >= 598.61 AND col1 < 670.29
 18 values hashing to 65bd203ff1e552adc3ee01f0ffd3e7df
 
 statement ok
-DROP VIEW view_1_tab0_603
+DROP VIEW IF EXISTS view_1_tab0_603 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_603
+DROP VIEW IF EXISTS view_2_tab0_603 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_603
+DROP VIEW IF EXISTS view_3_tab0_603 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3450,13 +3450,13 @@ SELECT pk FROM tab1 WHERE col0 >= 344 AND col4 >= 598.61 AND col1 < 670.29
 18 values hashing to 65bd203ff1e552adc3ee01f0ffd3e7df
 
 statement ok
-DROP VIEW view_1_tab1_603
+DROP VIEW IF EXISTS view_1_tab1_603 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_603
+DROP VIEW IF EXISTS view_2_tab1_603 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_603
+DROP VIEW IF EXISTS view_3_tab1_603 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3547,13 +3547,13 @@ SELECT pk FROM tab2 WHERE col0 >= 344 AND col4 >= 598.61 AND col1 < 670.29
 18 values hashing to 65bd203ff1e552adc3ee01f0ffd3e7df
 
 statement ok
-DROP VIEW view_1_tab2_603
+DROP VIEW IF EXISTS view_1_tab2_603 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_603
+DROP VIEW IF EXISTS view_2_tab2_603 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_603
+DROP VIEW IF EXISTS view_3_tab2_603 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3644,13 +3644,13 @@ SELECT pk FROM tab3 WHERE col0 >= 344 AND col4 >= 598.61 AND col1 < 670.29
 18 values hashing to 65bd203ff1e552adc3ee01f0ffd3e7df
 
 statement ok
-DROP VIEW view_1_tab3_603
+DROP VIEW IF EXISTS view_1_tab3_603 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_603
+DROP VIEW IF EXISTS view_2_tab3_603 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_603
+DROP VIEW IF EXISTS view_3_tab3_603 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3741,13 +3741,13 @@ SELECT pk FROM tab4 WHERE col0 >= 344 AND col4 >= 598.61 AND col1 < 670.29
 18 values hashing to 65bd203ff1e552adc3ee01f0ffd3e7df
 
 statement ok
-DROP VIEW view_1_tab4_603
+DROP VIEW IF EXISTS view_1_tab4_603 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_603
+DROP VIEW IF EXISTS view_2_tab4_603 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_603
+DROP VIEW IF EXISTS view_3_tab4_603 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3838,13 +3838,13 @@ SELECT pk FROM tab0 WHERE col0 > 429
 57 values hashing to a1ae08b42bb8a06ffda5b6fab318f193
 
 statement ok
-DROP VIEW view_1_tab0_604
+DROP VIEW IF EXISTS view_1_tab0_604 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_604
+DROP VIEW IF EXISTS view_2_tab0_604 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_604
+DROP VIEW IF EXISTS view_3_tab0_604 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3935,13 +3935,13 @@ SELECT pk FROM tab1 WHERE col0 > 429
 57 values hashing to a1ae08b42bb8a06ffda5b6fab318f193
 
 statement ok
-DROP VIEW view_1_tab1_604
+DROP VIEW IF EXISTS view_1_tab1_604 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_604
+DROP VIEW IF EXISTS view_2_tab1_604 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_604
+DROP VIEW IF EXISTS view_3_tab1_604 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4032,13 +4032,13 @@ SELECT pk FROM tab2 WHERE col0 > 429
 57 values hashing to a1ae08b42bb8a06ffda5b6fab318f193
 
 statement ok
-DROP VIEW view_1_tab2_604
+DROP VIEW IF EXISTS view_1_tab2_604 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_604
+DROP VIEW IF EXISTS view_2_tab2_604 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_604
+DROP VIEW IF EXISTS view_3_tab2_604 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4129,13 +4129,13 @@ SELECT pk FROM tab3 WHERE col0 > 429
 57 values hashing to a1ae08b42bb8a06ffda5b6fab318f193
 
 statement ok
-DROP VIEW view_1_tab3_604
+DROP VIEW IF EXISTS view_1_tab3_604 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_604
+DROP VIEW IF EXISTS view_2_tab3_604 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_604
+DROP VIEW IF EXISTS view_3_tab3_604 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4226,13 +4226,13 @@ SELECT pk FROM tab4 WHERE col0 > 429
 57 values hashing to a1ae08b42bb8a06ffda5b6fab318f193
 
 statement ok
-DROP VIEW view_1_tab4_604
+DROP VIEW IF EXISTS view_1_tab4_604 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_604
+DROP VIEW IF EXISTS view_2_tab4_604 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_604
+DROP VIEW IF EXISTS view_3_tab4_604 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4323,13 +4323,13 @@ SELECT pk FROM tab0 WHERE col3 > 786
 15 values hashing to 7468f5aeea43e031afee943d222e772a
 
 statement ok
-DROP VIEW view_1_tab0_605
+DROP VIEW IF EXISTS view_1_tab0_605 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_605
+DROP VIEW IF EXISTS view_2_tab0_605 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_605
+DROP VIEW IF EXISTS view_3_tab0_605 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4420,13 +4420,13 @@ SELECT pk FROM tab1 WHERE col3 > 786
 15 values hashing to 7468f5aeea43e031afee943d222e772a
 
 statement ok
-DROP VIEW view_1_tab1_605
+DROP VIEW IF EXISTS view_1_tab1_605 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_605
+DROP VIEW IF EXISTS view_2_tab1_605 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_605
+DROP VIEW IF EXISTS view_3_tab1_605 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4517,13 +4517,13 @@ SELECT pk FROM tab2 WHERE col3 > 786
 15 values hashing to 7468f5aeea43e031afee943d222e772a
 
 statement ok
-DROP VIEW view_1_tab2_605
+DROP VIEW IF EXISTS view_1_tab2_605 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_605
+DROP VIEW IF EXISTS view_2_tab2_605 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_605
+DROP VIEW IF EXISTS view_3_tab2_605 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4614,13 +4614,13 @@ SELECT pk FROM tab3 WHERE col3 > 786
 15 values hashing to 7468f5aeea43e031afee943d222e772a
 
 statement ok
-DROP VIEW view_1_tab3_605
+DROP VIEW IF EXISTS view_1_tab3_605 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_605
+DROP VIEW IF EXISTS view_2_tab3_605 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_605
+DROP VIEW IF EXISTS view_3_tab3_605 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4711,13 +4711,13 @@ SELECT pk FROM tab4 WHERE col3 > 786
 15 values hashing to 7468f5aeea43e031afee943d222e772a
 
 statement ok
-DROP VIEW view_1_tab4_605
+DROP VIEW IF EXISTS view_1_tab4_605 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_605
+DROP VIEW IF EXISTS view_2_tab4_605 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_605
+DROP VIEW IF EXISTS view_3_tab4_605 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4808,13 +4808,13 @@ SELECT pk FROM tab0 WHERE (col3 > 274 AND col0 >= 182)
 47 values hashing to 7a3f888d612cd16115db8160b0ad5016
 
 statement ok
-DROP VIEW view_1_tab0_606
+DROP VIEW IF EXISTS view_1_tab0_606 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_606
+DROP VIEW IF EXISTS view_2_tab0_606 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_606
+DROP VIEW IF EXISTS view_3_tab0_606 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4905,13 +4905,13 @@ SELECT pk FROM tab1 WHERE (col3 > 274 AND col0 >= 182)
 47 values hashing to 7a3f888d612cd16115db8160b0ad5016
 
 statement ok
-DROP VIEW view_1_tab1_606
+DROP VIEW IF EXISTS view_1_tab1_606 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_606
+DROP VIEW IF EXISTS view_2_tab1_606 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_606
+DROP VIEW IF EXISTS view_3_tab1_606 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5002,13 +5002,13 @@ SELECT pk FROM tab2 WHERE (col3 > 274 AND col0 >= 182)
 47 values hashing to 7a3f888d612cd16115db8160b0ad5016
 
 statement ok
-DROP VIEW view_1_tab2_606
+DROP VIEW IF EXISTS view_1_tab2_606 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_606
+DROP VIEW IF EXISTS view_2_tab2_606 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_606
+DROP VIEW IF EXISTS view_3_tab2_606 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5099,13 +5099,13 @@ SELECT pk FROM tab3 WHERE (col3 > 274 AND col0 >= 182)
 47 values hashing to 7a3f888d612cd16115db8160b0ad5016
 
 statement ok
-DROP VIEW view_1_tab3_606
+DROP VIEW IF EXISTS view_1_tab3_606 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_606
+DROP VIEW IF EXISTS view_2_tab3_606 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_606
+DROP VIEW IF EXISTS view_3_tab3_606 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5196,13 +5196,13 @@ SELECT pk FROM tab4 WHERE (col3 > 274 AND col0 >= 182)
 47 values hashing to 7a3f888d612cd16115db8160b0ad5016
 
 statement ok
-DROP VIEW view_1_tab4_606
+DROP VIEW IF EXISTS view_1_tab4_606 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_606
+DROP VIEW IF EXISTS view_2_tab4_606 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_606
+DROP VIEW IF EXISTS view_3_tab4_606 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5293,13 +5293,13 @@ SELECT pk FROM tab0 WHERE ((col3 > 992) OR col0 <= 373)
 40 values hashing to 3b1e18d0c56fc30d567e412c4c82229b
 
 statement ok
-DROP VIEW view_1_tab0_607
+DROP VIEW IF EXISTS view_1_tab0_607 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_607
+DROP VIEW IF EXISTS view_2_tab0_607 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_607
+DROP VIEW IF EXISTS view_3_tab0_607 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5390,13 +5390,13 @@ SELECT pk FROM tab1 WHERE ((col3 > 992) OR col0 <= 373)
 40 values hashing to 3b1e18d0c56fc30d567e412c4c82229b
 
 statement ok
-DROP VIEW view_1_tab1_607
+DROP VIEW IF EXISTS view_1_tab1_607 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_607
+DROP VIEW IF EXISTS view_2_tab1_607 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_607
+DROP VIEW IF EXISTS view_3_tab1_607 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5487,13 +5487,13 @@ SELECT pk FROM tab2 WHERE ((col3 > 992) OR col0 <= 373)
 40 values hashing to 3b1e18d0c56fc30d567e412c4c82229b
 
 statement ok
-DROP VIEW view_1_tab2_607
+DROP VIEW IF EXISTS view_1_tab2_607 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_607
+DROP VIEW IF EXISTS view_2_tab2_607 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_607
+DROP VIEW IF EXISTS view_3_tab2_607 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5584,13 +5584,13 @@ SELECT pk FROM tab3 WHERE ((col3 > 992) OR col0 <= 373)
 40 values hashing to 3b1e18d0c56fc30d567e412c4c82229b
 
 statement ok
-DROP VIEW view_1_tab3_607
+DROP VIEW IF EXISTS view_1_tab3_607 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_607
+DROP VIEW IF EXISTS view_2_tab3_607 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_607
+DROP VIEW IF EXISTS view_3_tab3_607 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5681,13 +5681,13 @@ SELECT pk FROM tab4 WHERE ((col3 > 992) OR col0 <= 373)
 40 values hashing to 3b1e18d0c56fc30d567e412c4c82229b
 
 statement ok
-DROP VIEW view_1_tab4_607
+DROP VIEW IF EXISTS view_1_tab4_607 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_607
+DROP VIEW IF EXISTS view_2_tab4_607 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_607
+DROP VIEW IF EXISTS view_3_tab4_607 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5778,13 +5778,13 @@ SELECT pk FROM tab0 WHERE col0 <= 627
 62 values hashing to 66d743753f010a83a3d0f2a51d63876e
 
 statement ok
-DROP VIEW view_1_tab0_608
+DROP VIEW IF EXISTS view_1_tab0_608 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_608
+DROP VIEW IF EXISTS view_2_tab0_608 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_608
+DROP VIEW IF EXISTS view_3_tab0_608 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5875,13 +5875,13 @@ SELECT pk FROM tab1 WHERE col0 <= 627
 62 values hashing to 66d743753f010a83a3d0f2a51d63876e
 
 statement ok
-DROP VIEW view_1_tab1_608
+DROP VIEW IF EXISTS view_1_tab1_608 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_608
+DROP VIEW IF EXISTS view_2_tab1_608 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_608
+DROP VIEW IF EXISTS view_3_tab1_608 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5972,13 +5972,13 @@ SELECT pk FROM tab2 WHERE col0 <= 627
 62 values hashing to 66d743753f010a83a3d0f2a51d63876e
 
 statement ok
-DROP VIEW view_1_tab2_608
+DROP VIEW IF EXISTS view_1_tab2_608 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_608
+DROP VIEW IF EXISTS view_2_tab2_608 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_608
+DROP VIEW IF EXISTS view_3_tab2_608 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6069,13 +6069,13 @@ SELECT pk FROM tab3 WHERE col0 <= 627
 62 values hashing to 66d743753f010a83a3d0f2a51d63876e
 
 statement ok
-DROP VIEW view_1_tab3_608
+DROP VIEW IF EXISTS view_1_tab3_608 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_608
+DROP VIEW IF EXISTS view_2_tab3_608 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_608
+DROP VIEW IF EXISTS view_3_tab3_608 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6166,13 +6166,13 @@ SELECT pk FROM tab4 WHERE col0 <= 627
 62 values hashing to 66d743753f010a83a3d0f2a51d63876e
 
 statement ok
-DROP VIEW view_1_tab4_608
+DROP VIEW IF EXISTS view_1_tab4_608 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_608
+DROP VIEW IF EXISTS view_2_tab4_608 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_608
+DROP VIEW IF EXISTS view_3_tab4_608 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6258,13 +6258,13 @@ SELECT pk FROM tab0 WHERE col1 IN (273.6)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_609
+DROP VIEW IF EXISTS view_1_tab0_609 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_609
+DROP VIEW IF EXISTS view_2_tab0_609 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_609
+DROP VIEW IF EXISTS view_3_tab0_609 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6350,13 +6350,13 @@ SELECT pk FROM tab1 WHERE col1 IN (273.6)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_609
+DROP VIEW IF EXISTS view_1_tab1_609 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_609
+DROP VIEW IF EXISTS view_2_tab1_609 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_609
+DROP VIEW IF EXISTS view_3_tab1_609 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6442,13 +6442,13 @@ SELECT pk FROM tab2 WHERE col1 IN (273.6)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_609
+DROP VIEW IF EXISTS view_1_tab2_609 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_609
+DROP VIEW IF EXISTS view_2_tab2_609 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_609
+DROP VIEW IF EXISTS view_3_tab2_609 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6534,13 +6534,13 @@ SELECT pk FROM tab3 WHERE col1 IN (273.6)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_609
+DROP VIEW IF EXISTS view_1_tab3_609 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_609
+DROP VIEW IF EXISTS view_2_tab3_609 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_609
+DROP VIEW IF EXISTS view_3_tab3_609 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6626,13 +6626,13 @@ SELECT pk FROM tab4 WHERE col1 IN (273.6)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_609
+DROP VIEW IF EXISTS view_1_tab4_609 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_609
+DROP VIEW IF EXISTS view_2_tab4_609 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_609
+DROP VIEW IF EXISTS view_3_tab4_609 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6723,13 +6723,13 @@ SELECT pk FROM tab0 WHERE col3 < 955
 94 values hashing to fdc318f00544da5864f1bc66efb6e125
 
 statement ok
-DROP VIEW view_1_tab0_610
+DROP VIEW IF EXISTS view_1_tab0_610 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_610
+DROP VIEW IF EXISTS view_2_tab0_610 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_610
+DROP VIEW IF EXISTS view_3_tab0_610 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6820,13 +6820,13 @@ SELECT pk FROM tab1 WHERE col3 < 955
 94 values hashing to fdc318f00544da5864f1bc66efb6e125
 
 statement ok
-DROP VIEW view_1_tab1_610
+DROP VIEW IF EXISTS view_1_tab1_610 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_610
+DROP VIEW IF EXISTS view_2_tab1_610 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_610
+DROP VIEW IF EXISTS view_3_tab1_610 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6917,13 +6917,13 @@ SELECT pk FROM tab2 WHERE col3 < 955
 94 values hashing to fdc318f00544da5864f1bc66efb6e125
 
 statement ok
-DROP VIEW view_1_tab2_610
+DROP VIEW IF EXISTS view_1_tab2_610 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_610
+DROP VIEW IF EXISTS view_2_tab2_610 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_610
+DROP VIEW IF EXISTS view_3_tab2_610 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7014,13 +7014,13 @@ SELECT pk FROM tab3 WHERE col3 < 955
 94 values hashing to fdc318f00544da5864f1bc66efb6e125
 
 statement ok
-DROP VIEW view_1_tab3_610
+DROP VIEW IF EXISTS view_1_tab3_610 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_610
+DROP VIEW IF EXISTS view_2_tab3_610 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_610
+DROP VIEW IF EXISTS view_3_tab3_610 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7111,13 +7111,13 @@ SELECT pk FROM tab4 WHERE col3 < 955
 94 values hashing to fdc318f00544da5864f1bc66efb6e125
 
 statement ok
-DROP VIEW view_1_tab4_610
+DROP VIEW IF EXISTS view_1_tab4_610 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_610
+DROP VIEW IF EXISTS view_2_tab4_610 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_610
+DROP VIEW IF EXISTS view_3_tab4_610 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7208,13 +7208,13 @@ SELECT pk FROM tab0 WHERE col0 > 873
 12 values hashing to a022a4af1f904a42b195f1c174cced90
 
 statement ok
-DROP VIEW view_1_tab0_611
+DROP VIEW IF EXISTS view_1_tab0_611 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_611
+DROP VIEW IF EXISTS view_2_tab0_611 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_611
+DROP VIEW IF EXISTS view_3_tab0_611 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7305,13 +7305,13 @@ SELECT pk FROM tab1 WHERE col0 > 873
 12 values hashing to a022a4af1f904a42b195f1c174cced90
 
 statement ok
-DROP VIEW view_1_tab1_611
+DROP VIEW IF EXISTS view_1_tab1_611 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_611
+DROP VIEW IF EXISTS view_2_tab1_611 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_611
+DROP VIEW IF EXISTS view_3_tab1_611 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7402,13 +7402,13 @@ SELECT pk FROM tab2 WHERE col0 > 873
 12 values hashing to a022a4af1f904a42b195f1c174cced90
 
 statement ok
-DROP VIEW view_1_tab2_611
+DROP VIEW IF EXISTS view_1_tab2_611 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_611
+DROP VIEW IF EXISTS view_2_tab2_611 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_611
+DROP VIEW IF EXISTS view_3_tab2_611 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7499,13 +7499,13 @@ SELECT pk FROM tab3 WHERE col0 > 873
 12 values hashing to a022a4af1f904a42b195f1c174cced90
 
 statement ok
-DROP VIEW view_1_tab3_611
+DROP VIEW IF EXISTS view_1_tab3_611 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_611
+DROP VIEW IF EXISTS view_2_tab3_611 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_611
+DROP VIEW IF EXISTS view_3_tab3_611 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7596,13 +7596,13 @@ SELECT pk FROM tab4 WHERE col0 > 873
 12 values hashing to a022a4af1f904a42b195f1c174cced90
 
 statement ok
-DROP VIEW view_1_tab4_611
+DROP VIEW IF EXISTS view_1_tab4_611 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_611
+DROP VIEW IF EXISTS view_2_tab4_611 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_611
+DROP VIEW IF EXISTS view_3_tab4_611 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7688,13 +7688,13 @@ SELECT pk FROM tab0 WHERE (col3 = 840)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_612
+DROP VIEW IF EXISTS view_1_tab0_612 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_612
+DROP VIEW IF EXISTS view_2_tab0_612 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_612
+DROP VIEW IF EXISTS view_3_tab0_612 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7780,13 +7780,13 @@ SELECT pk FROM tab1 WHERE (col3 = 840)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_612
+DROP VIEW IF EXISTS view_1_tab1_612 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_612
+DROP VIEW IF EXISTS view_2_tab1_612 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_612
+DROP VIEW IF EXISTS view_3_tab1_612 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7872,13 +7872,13 @@ SELECT pk FROM tab2 WHERE (col3 = 840)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_612
+DROP VIEW IF EXISTS view_1_tab2_612 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_612
+DROP VIEW IF EXISTS view_2_tab2_612 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_612
+DROP VIEW IF EXISTS view_3_tab2_612 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7964,13 +7964,13 @@ SELECT pk FROM tab3 WHERE (col3 = 840)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_612
+DROP VIEW IF EXISTS view_1_tab3_612 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_612
+DROP VIEW IF EXISTS view_2_tab3_612 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_612
+DROP VIEW IF EXISTS view_3_tab3_612 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8056,13 +8056,13 @@ SELECT pk FROM tab4 WHERE (col3 = 840)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_612
+DROP VIEW IF EXISTS view_1_tab4_612 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_612
+DROP VIEW IF EXISTS view_2_tab4_612 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_612
+DROP VIEW IF EXISTS view_3_tab4_612 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8153,13 +8153,13 @@ SELECT pk FROM tab0 WHERE (col3 > 677 AND (col3 < 952) OR col0 = 444 AND col0 >=
 29 values hashing to 8216f7e4c76fd951786e286239a8736a
 
 statement ok
-DROP VIEW view_1_tab0_613
+DROP VIEW IF EXISTS view_1_tab0_613 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_613
+DROP VIEW IF EXISTS view_2_tab0_613 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_613
+DROP VIEW IF EXISTS view_3_tab0_613 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8250,13 +8250,13 @@ SELECT pk FROM tab1 WHERE (col3 > 677 AND (col3 < 952) OR col0 = 444 AND col0 >=
 29 values hashing to 8216f7e4c76fd951786e286239a8736a
 
 statement ok
-DROP VIEW view_1_tab1_613
+DROP VIEW IF EXISTS view_1_tab1_613 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_613
+DROP VIEW IF EXISTS view_2_tab1_613 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_613
+DROP VIEW IF EXISTS view_3_tab1_613 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8347,13 +8347,13 @@ SELECT pk FROM tab2 WHERE (col3 > 677 AND (col3 < 952) OR col0 = 444 AND col0 >=
 29 values hashing to 8216f7e4c76fd951786e286239a8736a
 
 statement ok
-DROP VIEW view_1_tab2_613
+DROP VIEW IF EXISTS view_1_tab2_613 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_613
+DROP VIEW IF EXISTS view_2_tab2_613 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_613
+DROP VIEW IF EXISTS view_3_tab2_613 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8444,13 +8444,13 @@ SELECT pk FROM tab3 WHERE (col3 > 677 AND (col3 < 952) OR col0 = 444 AND col0 >=
 29 values hashing to 8216f7e4c76fd951786e286239a8736a
 
 statement ok
-DROP VIEW view_1_tab3_613
+DROP VIEW IF EXISTS view_1_tab3_613 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_613
+DROP VIEW IF EXISTS view_2_tab3_613 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_613
+DROP VIEW IF EXISTS view_3_tab3_613 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8541,13 +8541,13 @@ SELECT pk FROM tab4 WHERE (col3 > 677 AND (col3 < 952) OR col0 = 444 AND col0 >=
 29 values hashing to 8216f7e4c76fd951786e286239a8736a
 
 statement ok
-DROP VIEW view_1_tab4_613
+DROP VIEW IF EXISTS view_1_tab4_613 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_613
+DROP VIEW IF EXISTS view_2_tab4_613 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_613
+DROP VIEW IF EXISTS view_3_tab4_613 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8633,13 +8633,13 @@ SELECT pk FROM tab0 WHERE col4 IS NULL AND (col0 IS NULL OR col3 = 271) AND col0
 ----
 
 statement ok
-DROP VIEW view_1_tab0_614
+DROP VIEW IF EXISTS view_1_tab0_614 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_614
+DROP VIEW IF EXISTS view_2_tab0_614 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_614
+DROP VIEW IF EXISTS view_3_tab0_614 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8725,13 +8725,13 @@ SELECT pk FROM tab1 WHERE col4 IS NULL AND (col0 IS NULL OR col3 = 271) AND col0
 ----
 
 statement ok
-DROP VIEW view_1_tab1_614
+DROP VIEW IF EXISTS view_1_tab1_614 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_614
+DROP VIEW IF EXISTS view_2_tab1_614 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_614
+DROP VIEW IF EXISTS view_3_tab1_614 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8817,13 +8817,13 @@ SELECT pk FROM tab2 WHERE col4 IS NULL AND (col0 IS NULL OR col3 = 271) AND col0
 ----
 
 statement ok
-DROP VIEW view_1_tab2_614
+DROP VIEW IF EXISTS view_1_tab2_614 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_614
+DROP VIEW IF EXISTS view_2_tab2_614 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_614
+DROP VIEW IF EXISTS view_3_tab2_614 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8909,13 +8909,13 @@ SELECT pk FROM tab3 WHERE col4 IS NULL AND (col0 IS NULL OR col3 = 271) AND col0
 ----
 
 statement ok
-DROP VIEW view_1_tab3_614
+DROP VIEW IF EXISTS view_1_tab3_614 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_614
+DROP VIEW IF EXISTS view_2_tab3_614 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_614
+DROP VIEW IF EXISTS view_3_tab3_614 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9001,13 +9001,13 @@ SELECT pk FROM tab4 WHERE col4 IS NULL AND (col0 IS NULL OR col3 = 271) AND col0
 ----
 
 statement ok
-DROP VIEW view_1_tab4_614
+DROP VIEW IF EXISTS view_1_tab4_614 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_614
+DROP VIEW IF EXISTS view_2_tab4_614 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_614
+DROP VIEW IF EXISTS view_3_tab4_614 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9098,13 +9098,13 @@ SELECT pk FROM tab0 WHERE col0 > 186
 77 values hashing to 06d54a6df2d6563364c89b53594728ac
 
 statement ok
-DROP VIEW view_1_tab0_615
+DROP VIEW IF EXISTS view_1_tab0_615 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_615
+DROP VIEW IF EXISTS view_2_tab0_615 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_615
+DROP VIEW IF EXISTS view_3_tab0_615 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9195,13 +9195,13 @@ SELECT pk FROM tab1 WHERE col0 > 186
 77 values hashing to 06d54a6df2d6563364c89b53594728ac
 
 statement ok
-DROP VIEW view_1_tab1_615
+DROP VIEW IF EXISTS view_1_tab1_615 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_615
+DROP VIEW IF EXISTS view_2_tab1_615 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_615
+DROP VIEW IF EXISTS view_3_tab1_615 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9292,13 +9292,13 @@ SELECT pk FROM tab2 WHERE col0 > 186
 77 values hashing to 06d54a6df2d6563364c89b53594728ac
 
 statement ok
-DROP VIEW view_1_tab2_615
+DROP VIEW IF EXISTS view_1_tab2_615 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_615
+DROP VIEW IF EXISTS view_2_tab2_615 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_615
+DROP VIEW IF EXISTS view_3_tab2_615 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9389,13 +9389,13 @@ SELECT pk FROM tab3 WHERE col0 > 186
 77 values hashing to 06d54a6df2d6563364c89b53594728ac
 
 statement ok
-DROP VIEW view_1_tab3_615
+DROP VIEW IF EXISTS view_1_tab3_615 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_615
+DROP VIEW IF EXISTS view_2_tab3_615 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_615
+DROP VIEW IF EXISTS view_3_tab3_615 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9486,13 +9486,13 @@ SELECT pk FROM tab4 WHERE col0 > 186
 77 values hashing to 06d54a6df2d6563364c89b53594728ac
 
 statement ok
-DROP VIEW view_1_tab4_615
+DROP VIEW IF EXISTS view_1_tab4_615 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_615
+DROP VIEW IF EXISTS view_2_tab4_615 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_615
+DROP VIEW IF EXISTS view_3_tab4_615 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9578,13 +9578,13 @@ SELECT pk FROM tab0 WHERE col3 >= 620 AND (col0 > 318 OR ((col1 >= 2.92 AND col0
 ----
 
 statement ok
-DROP VIEW view_1_tab0_616
+DROP VIEW IF EXISTS view_1_tab0_616 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_616
+DROP VIEW IF EXISTS view_2_tab0_616 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_616
+DROP VIEW IF EXISTS view_3_tab0_616 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9670,13 +9670,13 @@ SELECT pk FROM tab1 WHERE col3 >= 620 AND (col0 > 318 OR ((col1 >= 2.92 AND col0
 ----
 
 statement ok
-DROP VIEW view_1_tab1_616
+DROP VIEW IF EXISTS view_1_tab1_616 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_616
+DROP VIEW IF EXISTS view_2_tab1_616 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_616
+DROP VIEW IF EXISTS view_3_tab1_616 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9762,13 +9762,13 @@ SELECT pk FROM tab2 WHERE col3 >= 620 AND (col0 > 318 OR ((col1 >= 2.92 AND col0
 ----
 
 statement ok
-DROP VIEW view_1_tab2_616
+DROP VIEW IF EXISTS view_1_tab2_616 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_616
+DROP VIEW IF EXISTS view_2_tab2_616 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_616
+DROP VIEW IF EXISTS view_3_tab2_616 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9854,13 +9854,13 @@ SELECT pk FROM tab3 WHERE col3 >= 620 AND (col0 > 318 OR ((col1 >= 2.92 AND col0
 ----
 
 statement ok
-DROP VIEW view_1_tab3_616
+DROP VIEW IF EXISTS view_1_tab3_616 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_616
+DROP VIEW IF EXISTS view_2_tab3_616 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_616
+DROP VIEW IF EXISTS view_3_tab3_616 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9946,13 +9946,13 @@ SELECT pk FROM tab4 WHERE col3 >= 620 AND (col0 > 318 OR ((col1 >= 2.92 AND col0
 ----
 
 statement ok
-DROP VIEW view_1_tab4_616
+DROP VIEW IF EXISTS view_1_tab4_616 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_616
+DROP VIEW IF EXISTS view_2_tab4_616 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_616
+DROP VIEW IF EXISTS view_3_tab4_616 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10043,13 +10043,13 @@ SELECT pk FROM tab0 WHERE (col0 < 525 AND (col4 <= 908.4 AND col4 < 957.20 AND c
 48 values hashing to e5dfebfd6b7ef5f4a7a15529ab7ed36f
 
 statement ok
-DROP VIEW view_1_tab0_617
+DROP VIEW IF EXISTS view_1_tab0_617 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_617
+DROP VIEW IF EXISTS view_2_tab0_617 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_617
+DROP VIEW IF EXISTS view_3_tab0_617 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10140,13 +10140,13 @@ SELECT pk FROM tab1 WHERE (col0 < 525 AND (col4 <= 908.4 AND col4 < 957.20 AND c
 48 values hashing to e5dfebfd6b7ef5f4a7a15529ab7ed36f
 
 statement ok
-DROP VIEW view_1_tab1_617
+DROP VIEW IF EXISTS view_1_tab1_617 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_617
+DROP VIEW IF EXISTS view_2_tab1_617 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_617
+DROP VIEW IF EXISTS view_3_tab1_617 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10237,13 +10237,13 @@ SELECT pk FROM tab2 WHERE (col0 < 525 AND (col4 <= 908.4 AND col4 < 957.20 AND c
 48 values hashing to e5dfebfd6b7ef5f4a7a15529ab7ed36f
 
 statement ok
-DROP VIEW view_1_tab2_617
+DROP VIEW IF EXISTS view_1_tab2_617 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_617
+DROP VIEW IF EXISTS view_2_tab2_617 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_617
+DROP VIEW IF EXISTS view_3_tab2_617 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10334,13 +10334,13 @@ SELECT pk FROM tab3 WHERE (col0 < 525 AND (col4 <= 908.4 AND col4 < 957.20 AND c
 48 values hashing to e5dfebfd6b7ef5f4a7a15529ab7ed36f
 
 statement ok
-DROP VIEW view_1_tab3_617
+DROP VIEW IF EXISTS view_1_tab3_617 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_617
+DROP VIEW IF EXISTS view_2_tab3_617 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_617
+DROP VIEW IF EXISTS view_3_tab3_617 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10431,13 +10431,13 @@ SELECT pk FROM tab4 WHERE (col0 < 525 AND (col4 <= 908.4 AND col4 < 957.20 AND c
 48 values hashing to e5dfebfd6b7ef5f4a7a15529ab7ed36f
 
 statement ok
-DROP VIEW view_1_tab4_617
+DROP VIEW IF EXISTS view_1_tab4_617 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_617
+DROP VIEW IF EXISTS view_2_tab4_617 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_617
+DROP VIEW IF EXISTS view_3_tab4_617 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10528,13 +10528,13 @@ SELECT pk FROM tab0 WHERE col0 < 883
 88 values hashing to 684d9d9f2e4dfc4368dcc0d07416fc4c
 
 statement ok
-DROP VIEW view_1_tab0_618
+DROP VIEW IF EXISTS view_1_tab0_618 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_618
+DROP VIEW IF EXISTS view_2_tab0_618 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_618
+DROP VIEW IF EXISTS view_3_tab0_618 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10625,13 +10625,13 @@ SELECT pk FROM tab1 WHERE col0 < 883
 88 values hashing to 684d9d9f2e4dfc4368dcc0d07416fc4c
 
 statement ok
-DROP VIEW view_1_tab1_618
+DROP VIEW IF EXISTS view_1_tab1_618 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_618
+DROP VIEW IF EXISTS view_2_tab1_618 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_618
+DROP VIEW IF EXISTS view_3_tab1_618 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10722,13 +10722,13 @@ SELECT pk FROM tab2 WHERE col0 < 883
 88 values hashing to 684d9d9f2e4dfc4368dcc0d07416fc4c
 
 statement ok
-DROP VIEW view_1_tab2_618
+DROP VIEW IF EXISTS view_1_tab2_618 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_618
+DROP VIEW IF EXISTS view_2_tab2_618 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_618
+DROP VIEW IF EXISTS view_3_tab2_618 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10819,13 +10819,13 @@ SELECT pk FROM tab3 WHERE col0 < 883
 88 values hashing to 684d9d9f2e4dfc4368dcc0d07416fc4c
 
 statement ok
-DROP VIEW view_1_tab3_618
+DROP VIEW IF EXISTS view_1_tab3_618 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_618
+DROP VIEW IF EXISTS view_2_tab3_618 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_618
+DROP VIEW IF EXISTS view_3_tab3_618 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10916,13 +10916,13 @@ SELECT pk FROM tab4 WHERE col0 < 883
 88 values hashing to 684d9d9f2e4dfc4368dcc0d07416fc4c
 
 statement ok
-DROP VIEW view_1_tab4_618
+DROP VIEW IF EXISTS view_1_tab4_618 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_618
+DROP VIEW IF EXISTS view_2_tab4_618 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_618
+DROP VIEW IF EXISTS view_3_tab4_618 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11013,13 +11013,13 @@ SELECT pk FROM tab0 WHERE (col1 > 218.76)
 78 values hashing to 302082b93d47a7735e6c35c90ee28711
 
 statement ok
-DROP VIEW view_1_tab0_619
+DROP VIEW IF EXISTS view_1_tab0_619 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_619
+DROP VIEW IF EXISTS view_2_tab0_619 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_619
+DROP VIEW IF EXISTS view_3_tab0_619 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11110,13 +11110,13 @@ SELECT pk FROM tab1 WHERE (col1 > 218.76)
 78 values hashing to 302082b93d47a7735e6c35c90ee28711
 
 statement ok
-DROP VIEW view_1_tab1_619
+DROP VIEW IF EXISTS view_1_tab1_619 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_619
+DROP VIEW IF EXISTS view_2_tab1_619 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_619
+DROP VIEW IF EXISTS view_3_tab1_619 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11207,13 +11207,13 @@ SELECT pk FROM tab2 WHERE (col1 > 218.76)
 78 values hashing to 302082b93d47a7735e6c35c90ee28711
 
 statement ok
-DROP VIEW view_1_tab2_619
+DROP VIEW IF EXISTS view_1_tab2_619 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_619
+DROP VIEW IF EXISTS view_2_tab2_619 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_619
+DROP VIEW IF EXISTS view_3_tab2_619 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11304,13 +11304,13 @@ SELECT pk FROM tab3 WHERE (col1 > 218.76)
 78 values hashing to 302082b93d47a7735e6c35c90ee28711
 
 statement ok
-DROP VIEW view_1_tab3_619
+DROP VIEW IF EXISTS view_1_tab3_619 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_619
+DROP VIEW IF EXISTS view_2_tab3_619 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_619
+DROP VIEW IF EXISTS view_3_tab3_619 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11401,13 +11401,13 @@ SELECT pk FROM tab4 WHERE (col1 > 218.76)
 78 values hashing to 302082b93d47a7735e6c35c90ee28711
 
 statement ok
-DROP VIEW view_1_tab4_619
+DROP VIEW IF EXISTS view_1_tab4_619 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_619
+DROP VIEW IF EXISTS view_2_tab4_619 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_619
+DROP VIEW IF EXISTS view_3_tab4_619 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11498,13 +11498,13 @@ SELECT pk FROM tab0 WHERE (col0 <= 196) OR col4 >= 611.16
 55 values hashing to 3d6393ef56506c281a37d929d9dcb451
 
 statement ok
-DROP VIEW view_1_tab0_620
+DROP VIEW IF EXISTS view_1_tab0_620 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_620
+DROP VIEW IF EXISTS view_2_tab0_620 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_620
+DROP VIEW IF EXISTS view_3_tab0_620 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11595,13 +11595,13 @@ SELECT pk FROM tab1 WHERE (col0 <= 196) OR col4 >= 611.16
 55 values hashing to 3d6393ef56506c281a37d929d9dcb451
 
 statement ok
-DROP VIEW view_1_tab1_620
+DROP VIEW IF EXISTS view_1_tab1_620 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_620
+DROP VIEW IF EXISTS view_2_tab1_620 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_620
+DROP VIEW IF EXISTS view_3_tab1_620 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11692,13 +11692,13 @@ SELECT pk FROM tab2 WHERE (col0 <= 196) OR col4 >= 611.16
 55 values hashing to 3d6393ef56506c281a37d929d9dcb451
 
 statement ok
-DROP VIEW view_1_tab2_620
+DROP VIEW IF EXISTS view_1_tab2_620 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_620
+DROP VIEW IF EXISTS view_2_tab2_620 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_620
+DROP VIEW IF EXISTS view_3_tab2_620 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11789,13 +11789,13 @@ SELECT pk FROM tab3 WHERE (col0 <= 196) OR col4 >= 611.16
 55 values hashing to 3d6393ef56506c281a37d929d9dcb451
 
 statement ok
-DROP VIEW view_1_tab3_620
+DROP VIEW IF EXISTS view_1_tab3_620 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_620
+DROP VIEW IF EXISTS view_2_tab3_620 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_620
+DROP VIEW IF EXISTS view_3_tab3_620 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11886,13 +11886,13 @@ SELECT pk FROM tab4 WHERE (col0 <= 196) OR col4 >= 611.16
 55 values hashing to 3d6393ef56506c281a37d929d9dcb451
 
 statement ok
-DROP VIEW view_1_tab4_620
+DROP VIEW IF EXISTS view_1_tab4_620 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_620
+DROP VIEW IF EXISTS view_2_tab4_620 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_620
+DROP VIEW IF EXISTS view_3_tab4_620 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11992,13 +11992,13 @@ SELECT pk FROM tab0 WHERE col0 >= 960
 69
 
 statement ok
-DROP VIEW view_1_tab0_621
+DROP VIEW IF EXISTS view_1_tab0_621 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_621
+DROP VIEW IF EXISTS view_2_tab0_621 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_621
+DROP VIEW IF EXISTS view_3_tab0_621 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12098,13 +12098,13 @@ SELECT pk FROM tab1 WHERE col0 >= 960
 69
 
 statement ok
-DROP VIEW view_1_tab1_621
+DROP VIEW IF EXISTS view_1_tab1_621 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_621
+DROP VIEW IF EXISTS view_2_tab1_621 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_621
+DROP VIEW IF EXISTS view_3_tab1_621 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12204,13 +12204,13 @@ SELECT pk FROM tab2 WHERE col0 >= 960
 69
 
 statement ok
-DROP VIEW view_1_tab2_621
+DROP VIEW IF EXISTS view_1_tab2_621 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_621
+DROP VIEW IF EXISTS view_2_tab2_621 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_621
+DROP VIEW IF EXISTS view_3_tab2_621 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12310,13 +12310,13 @@ SELECT pk FROM tab3 WHERE col0 >= 960
 69
 
 statement ok
-DROP VIEW view_1_tab3_621
+DROP VIEW IF EXISTS view_1_tab3_621 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_621
+DROP VIEW IF EXISTS view_2_tab3_621 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_621
+DROP VIEW IF EXISTS view_3_tab3_621 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12416,13 +12416,13 @@ SELECT pk FROM tab4 WHERE col0 >= 960
 69
 
 statement ok
-DROP VIEW view_1_tab4_621
+DROP VIEW IF EXISTS view_1_tab4_621 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_621
+DROP VIEW IF EXISTS view_2_tab4_621 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_621
+DROP VIEW IF EXISTS view_3_tab4_621 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12513,13 +12513,13 @@ SELECT pk FROM tab0 WHERE col3 <= 206
 28 values hashing to 97405bd1f31e93ce927cb8f7f8b70802
 
 statement ok
-DROP VIEW view_1_tab0_622
+DROP VIEW IF EXISTS view_1_tab0_622 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_622
+DROP VIEW IF EXISTS view_2_tab0_622 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_622
+DROP VIEW IF EXISTS view_3_tab0_622 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12610,13 +12610,13 @@ SELECT pk FROM tab1 WHERE col3 <= 206
 28 values hashing to 97405bd1f31e93ce927cb8f7f8b70802
 
 statement ok
-DROP VIEW view_1_tab1_622
+DROP VIEW IF EXISTS view_1_tab1_622 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_622
+DROP VIEW IF EXISTS view_2_tab1_622 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_622
+DROP VIEW IF EXISTS view_3_tab1_622 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12707,13 +12707,13 @@ SELECT pk FROM tab2 WHERE col3 <= 206
 28 values hashing to 97405bd1f31e93ce927cb8f7f8b70802
 
 statement ok
-DROP VIEW view_1_tab2_622
+DROP VIEW IF EXISTS view_1_tab2_622 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_622
+DROP VIEW IF EXISTS view_2_tab2_622 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_622
+DROP VIEW IF EXISTS view_3_tab2_622 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12804,13 +12804,13 @@ SELECT pk FROM tab3 WHERE col3 <= 206
 28 values hashing to 97405bd1f31e93ce927cb8f7f8b70802
 
 statement ok
-DROP VIEW view_1_tab3_622
+DROP VIEW IF EXISTS view_1_tab3_622 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_622
+DROP VIEW IF EXISTS view_2_tab3_622 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_622
+DROP VIEW IF EXISTS view_3_tab3_622 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12901,13 +12901,13 @@ SELECT pk FROM tab4 WHERE col3 <= 206
 28 values hashing to 97405bd1f31e93ce927cb8f7f8b70802
 
 statement ok
-DROP VIEW view_1_tab4_622
+DROP VIEW IF EXISTS view_1_tab4_622 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_622
+DROP VIEW IF EXISTS view_2_tab4_622 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_622
+DROP VIEW IF EXISTS view_3_tab4_622 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12993,13 +12993,13 @@ SELECT pk FROM tab0 WHERE col0 <= 920 AND col3 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab0_623
+DROP VIEW IF EXISTS view_1_tab0_623 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_623
+DROP VIEW IF EXISTS view_2_tab0_623 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_623
+DROP VIEW IF EXISTS view_3_tab0_623 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13085,13 +13085,13 @@ SELECT pk FROM tab1 WHERE col0 <= 920 AND col3 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab1_623
+DROP VIEW IF EXISTS view_1_tab1_623 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_623
+DROP VIEW IF EXISTS view_2_tab1_623 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_623
+DROP VIEW IF EXISTS view_3_tab1_623 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13177,13 +13177,13 @@ SELECT pk FROM tab2 WHERE col0 <= 920 AND col3 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab2_623
+DROP VIEW IF EXISTS view_1_tab2_623 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_623
+DROP VIEW IF EXISTS view_2_tab2_623 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_623
+DROP VIEW IF EXISTS view_3_tab2_623 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13269,13 +13269,13 @@ SELECT pk FROM tab3 WHERE col0 <= 920 AND col3 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab3_623
+DROP VIEW IF EXISTS view_1_tab3_623 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_623
+DROP VIEW IF EXISTS view_2_tab3_623 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_623
+DROP VIEW IF EXISTS view_3_tab3_623 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13361,13 +13361,13 @@ SELECT pk FROM tab4 WHERE col0 <= 920 AND col3 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab4_623
+DROP VIEW IF EXISTS view_1_tab4_623 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_623
+DROP VIEW IF EXISTS view_2_tab4_623 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_623
+DROP VIEW IF EXISTS view_3_tab4_623 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13472,13 +13472,13 @@ SELECT pk FROM tab0 WHERE (col1 < 913.71)
 96 values hashing to 85754c1236b9a681305cdf66156e76fe
 
 statement ok
-DROP VIEW view_1_tab0_624
+DROP VIEW IF EXISTS view_1_tab0_624 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_624
+DROP VIEW IF EXISTS view_2_tab0_624 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_624
+DROP VIEW IF EXISTS view_3_tab0_624 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13583,13 +13583,13 @@ SELECT pk FROM tab1 WHERE (col1 < 913.71)
 96 values hashing to 85754c1236b9a681305cdf66156e76fe
 
 statement ok
-DROP VIEW view_1_tab1_624
+DROP VIEW IF EXISTS view_1_tab1_624 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_624
+DROP VIEW IF EXISTS view_2_tab1_624 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_624
+DROP VIEW IF EXISTS view_3_tab1_624 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13694,13 +13694,13 @@ SELECT pk FROM tab2 WHERE (col1 < 913.71)
 96 values hashing to 85754c1236b9a681305cdf66156e76fe
 
 statement ok
-DROP VIEW view_1_tab2_624
+DROP VIEW IF EXISTS view_1_tab2_624 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_624
+DROP VIEW IF EXISTS view_2_tab2_624 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_624
+DROP VIEW IF EXISTS view_3_tab2_624 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13805,13 +13805,13 @@ SELECT pk FROM tab3 WHERE (col1 < 913.71)
 96 values hashing to 85754c1236b9a681305cdf66156e76fe
 
 statement ok
-DROP VIEW view_1_tab3_624
+DROP VIEW IF EXISTS view_1_tab3_624 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_624
+DROP VIEW IF EXISTS view_2_tab3_624 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_624
+DROP VIEW IF EXISTS view_3_tab3_624 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13916,13 +13916,13 @@ SELECT pk FROM tab4 WHERE (col1 < 913.71)
 96 values hashing to 85754c1236b9a681305cdf66156e76fe
 
 statement ok
-DROP VIEW view_1_tab4_624
+DROP VIEW IF EXISTS view_1_tab4_624 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_624
+DROP VIEW IF EXISTS view_2_tab4_624 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_624
+DROP VIEW IF EXISTS view_3_tab4_624 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14008,13 +14008,13 @@ SELECT pk FROM tab0 WHERE col1 = 954.53
 ----
 
 statement ok
-DROP VIEW view_1_tab0_625
+DROP VIEW IF EXISTS view_1_tab0_625 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_625
+DROP VIEW IF EXISTS view_2_tab0_625 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_625
+DROP VIEW IF EXISTS view_3_tab0_625 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14100,13 +14100,13 @@ SELECT pk FROM tab1 WHERE col1 = 954.53
 ----
 
 statement ok
-DROP VIEW view_1_tab1_625
+DROP VIEW IF EXISTS view_1_tab1_625 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_625
+DROP VIEW IF EXISTS view_2_tab1_625 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_625
+DROP VIEW IF EXISTS view_3_tab1_625 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14192,13 +14192,13 @@ SELECT pk FROM tab2 WHERE col1 = 954.53
 ----
 
 statement ok
-DROP VIEW view_1_tab2_625
+DROP VIEW IF EXISTS view_1_tab2_625 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_625
+DROP VIEW IF EXISTS view_2_tab2_625 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_625
+DROP VIEW IF EXISTS view_3_tab2_625 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14284,13 +14284,13 @@ SELECT pk FROM tab3 WHERE col1 = 954.53
 ----
 
 statement ok
-DROP VIEW view_1_tab3_625
+DROP VIEW IF EXISTS view_1_tab3_625 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_625
+DROP VIEW IF EXISTS view_2_tab3_625 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_625
+DROP VIEW IF EXISTS view_3_tab3_625 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14376,13 +14376,13 @@ SELECT pk FROM tab4 WHERE col1 = 954.53
 ----
 
 statement ok
-DROP VIEW view_1_tab4_625
+DROP VIEW IF EXISTS view_1_tab4_625 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_625
+DROP VIEW IF EXISTS view_2_tab4_625 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_625
+DROP VIEW IF EXISTS view_3_tab4_625 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14473,13 +14473,13 @@ SELECT pk FROM tab0 WHERE (col0 > 811)
 20 values hashing to 14b782b7a3e95a04f9eafeb15714855b
 
 statement ok
-DROP VIEW view_1_tab0_626
+DROP VIEW IF EXISTS view_1_tab0_626 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_626
+DROP VIEW IF EXISTS view_2_tab0_626 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_626
+DROP VIEW IF EXISTS view_3_tab0_626 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14570,13 +14570,13 @@ SELECT pk FROM tab1 WHERE (col0 > 811)
 20 values hashing to 14b782b7a3e95a04f9eafeb15714855b
 
 statement ok
-DROP VIEW view_1_tab1_626
+DROP VIEW IF EXISTS view_1_tab1_626 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_626
+DROP VIEW IF EXISTS view_2_tab1_626 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_626
+DROP VIEW IF EXISTS view_3_tab1_626 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14667,13 +14667,13 @@ SELECT pk FROM tab2 WHERE (col0 > 811)
 20 values hashing to 14b782b7a3e95a04f9eafeb15714855b
 
 statement ok
-DROP VIEW view_1_tab2_626
+DROP VIEW IF EXISTS view_1_tab2_626 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_626
+DROP VIEW IF EXISTS view_2_tab2_626 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_626
+DROP VIEW IF EXISTS view_3_tab2_626 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14764,13 +14764,13 @@ SELECT pk FROM tab3 WHERE (col0 > 811)
 20 values hashing to 14b782b7a3e95a04f9eafeb15714855b
 
 statement ok
-DROP VIEW view_1_tab3_626
+DROP VIEW IF EXISTS view_1_tab3_626 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_626
+DROP VIEW IF EXISTS view_2_tab3_626 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_626
+DROP VIEW IF EXISTS view_3_tab3_626 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14861,13 +14861,13 @@ SELECT pk FROM tab4 WHERE (col0 > 811)
 20 values hashing to 14b782b7a3e95a04f9eafeb15714855b
 
 statement ok
-DROP VIEW view_1_tab4_626
+DROP VIEW IF EXISTS view_1_tab4_626 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_626
+DROP VIEW IF EXISTS view_2_tab4_626 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_626
+DROP VIEW IF EXISTS view_3_tab4_626 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14967,13 +14967,13 @@ SELECT pk FROM tab0 WHERE (col3 >= 136) AND (col0 > 690 OR col3 IN (784,454,994,
 74
 
 statement ok
-DROP VIEW view_1_tab0_627
+DROP VIEW IF EXISTS view_1_tab0_627 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_627
+DROP VIEW IF EXISTS view_2_tab0_627 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_627
+DROP VIEW IF EXISTS view_3_tab0_627 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15073,13 +15073,13 @@ SELECT pk FROM tab1 WHERE (col3 >= 136) AND (col0 > 690 OR col3 IN (784,454,994,
 74
 
 statement ok
-DROP VIEW view_1_tab1_627
+DROP VIEW IF EXISTS view_1_tab1_627 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_627
+DROP VIEW IF EXISTS view_2_tab1_627 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_627
+DROP VIEW IF EXISTS view_3_tab1_627 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15179,13 +15179,13 @@ SELECT pk FROM tab2 WHERE (col3 >= 136) AND (col0 > 690 OR col3 IN (784,454,994,
 74
 
 statement ok
-DROP VIEW view_1_tab2_627
+DROP VIEW IF EXISTS view_1_tab2_627 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_627
+DROP VIEW IF EXISTS view_2_tab2_627 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_627
+DROP VIEW IF EXISTS view_3_tab2_627 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15285,13 +15285,13 @@ SELECT pk FROM tab3 WHERE (col3 >= 136) AND (col0 > 690 OR col3 IN (784,454,994,
 74
 
 statement ok
-DROP VIEW view_1_tab3_627
+DROP VIEW IF EXISTS view_1_tab3_627 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_627
+DROP VIEW IF EXISTS view_2_tab3_627 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_627
+DROP VIEW IF EXISTS view_3_tab3_627 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15391,13 +15391,13 @@ SELECT pk FROM tab4 WHERE (col3 >= 136) AND (col0 > 690 OR col3 IN (784,454,994,
 74
 
 statement ok
-DROP VIEW view_1_tab4_627
+DROP VIEW IF EXISTS view_1_tab4_627 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_627
+DROP VIEW IF EXISTS view_2_tab4_627 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_627
+DROP VIEW IF EXISTS view_3_tab4_627 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15483,13 +15483,13 @@ SELECT pk FROM tab0 WHERE col0 >= 745 AND (col1 IS NULL AND ((col3 < 784)) AND c
 ----
 
 statement ok
-DROP VIEW view_1_tab0_628
+DROP VIEW IF EXISTS view_1_tab0_628 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_628
+DROP VIEW IF EXISTS view_2_tab0_628 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_628
+DROP VIEW IF EXISTS view_3_tab0_628 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15575,13 +15575,13 @@ SELECT pk FROM tab1 WHERE col0 >= 745 AND (col1 IS NULL AND ((col3 < 784)) AND c
 ----
 
 statement ok
-DROP VIEW view_1_tab1_628
+DROP VIEW IF EXISTS view_1_tab1_628 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_628
+DROP VIEW IF EXISTS view_2_tab1_628 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_628
+DROP VIEW IF EXISTS view_3_tab1_628 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15667,13 +15667,13 @@ SELECT pk FROM tab2 WHERE col0 >= 745 AND (col1 IS NULL AND ((col3 < 784)) AND c
 ----
 
 statement ok
-DROP VIEW view_1_tab2_628
+DROP VIEW IF EXISTS view_1_tab2_628 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_628
+DROP VIEW IF EXISTS view_2_tab2_628 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_628
+DROP VIEW IF EXISTS view_3_tab2_628 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15759,13 +15759,13 @@ SELECT pk FROM tab3 WHERE col0 >= 745 AND (col1 IS NULL AND ((col3 < 784)) AND c
 ----
 
 statement ok
-DROP VIEW view_1_tab3_628
+DROP VIEW IF EXISTS view_1_tab3_628 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_628
+DROP VIEW IF EXISTS view_2_tab3_628 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_628
+DROP VIEW IF EXISTS view_3_tab3_628 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15851,13 +15851,13 @@ SELECT pk FROM tab4 WHERE col0 >= 745 AND (col1 IS NULL AND ((col3 < 784)) AND c
 ----
 
 statement ok
-DROP VIEW view_1_tab4_628
+DROP VIEW IF EXISTS view_1_tab4_628 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_628
+DROP VIEW IF EXISTS view_2_tab4_628 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_628
+DROP VIEW IF EXISTS view_3_tab4_628 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15943,13 +15943,13 @@ SELECT pk FROM tab0 WHERE (col4 BETWEEN 408.57 AND 368.80 AND col4 IS NULL AND c
 ----
 
 statement ok
-DROP VIEW view_1_tab0_629
+DROP VIEW IF EXISTS view_1_tab0_629 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_629
+DROP VIEW IF EXISTS view_2_tab0_629 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_629
+DROP VIEW IF EXISTS view_3_tab0_629 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16035,13 +16035,13 @@ SELECT pk FROM tab1 WHERE (col4 BETWEEN 408.57 AND 368.80 AND col4 IS NULL AND c
 ----
 
 statement ok
-DROP VIEW view_1_tab1_629
+DROP VIEW IF EXISTS view_1_tab1_629 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_629
+DROP VIEW IF EXISTS view_2_tab1_629 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_629
+DROP VIEW IF EXISTS view_3_tab1_629 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16127,13 +16127,13 @@ SELECT pk FROM tab2 WHERE (col4 BETWEEN 408.57 AND 368.80 AND col4 IS NULL AND c
 ----
 
 statement ok
-DROP VIEW view_1_tab2_629
+DROP VIEW IF EXISTS view_1_tab2_629 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_629
+DROP VIEW IF EXISTS view_2_tab2_629 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_629
+DROP VIEW IF EXISTS view_3_tab2_629 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16219,13 +16219,13 @@ SELECT pk FROM tab3 WHERE (col4 BETWEEN 408.57 AND 368.80 AND col4 IS NULL AND c
 ----
 
 statement ok
-DROP VIEW view_1_tab3_629
+DROP VIEW IF EXISTS view_1_tab3_629 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_629
+DROP VIEW IF EXISTS view_2_tab3_629 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_629
+DROP VIEW IF EXISTS view_3_tab3_629 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16311,13 +16311,13 @@ SELECT pk FROM tab4 WHERE (col4 BETWEEN 408.57 AND 368.80 AND col4 IS NULL AND c
 ----
 
 statement ok
-DROP VIEW view_1_tab4_629
+DROP VIEW IF EXISTS view_1_tab4_629 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_629
+DROP VIEW IF EXISTS view_2_tab4_629 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_629
+DROP VIEW IF EXISTS view_3_tab4_629 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16408,13 +16408,13 @@ SELECT pk FROM tab0 WHERE col0 <= 161 AND ((col3 > 572)) OR col1 > 635.39
 40 values hashing to b694a583e1fc0b1911799484890e8c21
 
 statement ok
-DROP VIEW view_1_tab0_630
+DROP VIEW IF EXISTS view_1_tab0_630 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_630
+DROP VIEW IF EXISTS view_2_tab0_630 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_630
+DROP VIEW IF EXISTS view_3_tab0_630 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16505,13 +16505,13 @@ SELECT pk FROM tab1 WHERE col0 <= 161 AND ((col3 > 572)) OR col1 > 635.39
 40 values hashing to b694a583e1fc0b1911799484890e8c21
 
 statement ok
-DROP VIEW view_1_tab1_630
+DROP VIEW IF EXISTS view_1_tab1_630 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_630
+DROP VIEW IF EXISTS view_2_tab1_630 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_630
+DROP VIEW IF EXISTS view_3_tab1_630 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16602,13 +16602,13 @@ SELECT pk FROM tab2 WHERE col0 <= 161 AND ((col3 > 572)) OR col1 > 635.39
 40 values hashing to b694a583e1fc0b1911799484890e8c21
 
 statement ok
-DROP VIEW view_1_tab2_630
+DROP VIEW IF EXISTS view_1_tab2_630 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_630
+DROP VIEW IF EXISTS view_2_tab2_630 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_630
+DROP VIEW IF EXISTS view_3_tab2_630 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16699,13 +16699,13 @@ SELECT pk FROM tab3 WHERE col0 <= 161 AND ((col3 > 572)) OR col1 > 635.39
 40 values hashing to b694a583e1fc0b1911799484890e8c21
 
 statement ok
-DROP VIEW view_1_tab3_630
+DROP VIEW IF EXISTS view_1_tab3_630 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_630
+DROP VIEW IF EXISTS view_2_tab3_630 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_630
+DROP VIEW IF EXISTS view_3_tab3_630 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16796,13 +16796,13 @@ SELECT pk FROM tab4 WHERE col0 <= 161 AND ((col3 > 572)) OR col1 > 635.39
 40 values hashing to b694a583e1fc0b1911799484890e8c21
 
 statement ok
-DROP VIEW view_1_tab4_630
+DROP VIEW IF EXISTS view_1_tab4_630 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_630
+DROP VIEW IF EXISTS view_2_tab4_630 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_630
+DROP VIEW IF EXISTS view_3_tab4_630 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16893,13 +16893,13 @@ SELECT pk FROM tab0 WHERE col3 >= 301 OR col0 = 429 OR col3 BETWEEN 876 AND 759
 64 values hashing to ee203217c66e05d8720780de81b329da
 
 statement ok
-DROP VIEW view_1_tab0_631
+DROP VIEW IF EXISTS view_1_tab0_631 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_631
+DROP VIEW IF EXISTS view_2_tab0_631 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_631
+DROP VIEW IF EXISTS view_3_tab0_631 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16990,13 +16990,13 @@ SELECT pk FROM tab1 WHERE col3 >= 301 OR col0 = 429 OR col3 BETWEEN 876 AND 759
 64 values hashing to ee203217c66e05d8720780de81b329da
 
 statement ok
-DROP VIEW view_1_tab1_631
+DROP VIEW IF EXISTS view_1_tab1_631 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_631
+DROP VIEW IF EXISTS view_2_tab1_631 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_631
+DROP VIEW IF EXISTS view_3_tab1_631 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17087,13 +17087,13 @@ SELECT pk FROM tab2 WHERE col3 >= 301 OR col0 = 429 OR col3 BETWEEN 876 AND 759
 64 values hashing to ee203217c66e05d8720780de81b329da
 
 statement ok
-DROP VIEW view_1_tab2_631
+DROP VIEW IF EXISTS view_1_tab2_631 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_631
+DROP VIEW IF EXISTS view_2_tab2_631 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_631
+DROP VIEW IF EXISTS view_3_tab2_631 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17184,13 +17184,13 @@ SELECT pk FROM tab3 WHERE col3 >= 301 OR col0 = 429 OR col3 BETWEEN 876 AND 759
 64 values hashing to ee203217c66e05d8720780de81b329da
 
 statement ok
-DROP VIEW view_1_tab3_631
+DROP VIEW IF EXISTS view_1_tab3_631 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_631
+DROP VIEW IF EXISTS view_2_tab3_631 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_631
+DROP VIEW IF EXISTS view_3_tab3_631 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17281,13 +17281,13 @@ SELECT pk FROM tab4 WHERE col3 >= 301 OR col0 = 429 OR col3 BETWEEN 876 AND 759
 64 values hashing to ee203217c66e05d8720780de81b329da
 
 statement ok
-DROP VIEW view_1_tab4_631
+DROP VIEW IF EXISTS view_1_tab4_631 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_631
+DROP VIEW IF EXISTS view_2_tab4_631 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_631
+DROP VIEW IF EXISTS view_3_tab4_631 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17378,13 +17378,13 @@ SELECT pk FROM tab0 WHERE (col3 >= 597 OR col0 >= 537 AND col3 <= 759 AND (((col
 69 values hashing to 38d3d85b3bff5a5fb75e6a60da24887d
 
 statement ok
-DROP VIEW view_1_tab0_632
+DROP VIEW IF EXISTS view_1_tab0_632 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_632
+DROP VIEW IF EXISTS view_2_tab0_632 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_632
+DROP VIEW IF EXISTS view_3_tab0_632 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17475,13 +17475,13 @@ SELECT pk FROM tab1 WHERE (col3 >= 597 OR col0 >= 537 AND col3 <= 759 AND (((col
 69 values hashing to 38d3d85b3bff5a5fb75e6a60da24887d
 
 statement ok
-DROP VIEW view_1_tab1_632
+DROP VIEW IF EXISTS view_1_tab1_632 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_632
+DROP VIEW IF EXISTS view_2_tab1_632 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_632
+DROP VIEW IF EXISTS view_3_tab1_632 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17572,13 +17572,13 @@ SELECT pk FROM tab2 WHERE (col3 >= 597 OR col0 >= 537 AND col3 <= 759 AND (((col
 69 values hashing to 38d3d85b3bff5a5fb75e6a60da24887d
 
 statement ok
-DROP VIEW view_1_tab2_632
+DROP VIEW IF EXISTS view_1_tab2_632 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_632
+DROP VIEW IF EXISTS view_2_tab2_632 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_632
+DROP VIEW IF EXISTS view_3_tab2_632 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17669,13 +17669,13 @@ SELECT pk FROM tab3 WHERE (col3 >= 597 OR col0 >= 537 AND col3 <= 759 AND (((col
 69 values hashing to 38d3d85b3bff5a5fb75e6a60da24887d
 
 statement ok
-DROP VIEW view_1_tab3_632
+DROP VIEW IF EXISTS view_1_tab3_632 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_632
+DROP VIEW IF EXISTS view_2_tab3_632 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_632
+DROP VIEW IF EXISTS view_3_tab3_632 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17766,13 +17766,13 @@ SELECT pk FROM tab4 WHERE (col3 >= 597 OR col0 >= 537 AND col3 <= 759 AND (((col
 69 values hashing to 38d3d85b3bff5a5fb75e6a60da24887d
 
 statement ok
-DROP VIEW view_1_tab4_632
+DROP VIEW IF EXISTS view_1_tab4_632 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_632
+DROP VIEW IF EXISTS view_2_tab4_632 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_632
+DROP VIEW IF EXISTS view_3_tab4_632 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17863,13 +17863,13 @@ SELECT pk FROM tab0 WHERE col1 <= 108.74 OR ((col0 <= 34)) OR col0 >= 844
 23 values hashing to 639c5584abd6fa415762c3b8d2d6225b
 
 statement ok
-DROP VIEW view_1_tab0_633
+DROP VIEW IF EXISTS view_1_tab0_633 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_633
+DROP VIEW IF EXISTS view_2_tab0_633 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_633
+DROP VIEW IF EXISTS view_3_tab0_633 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17960,13 +17960,13 @@ SELECT pk FROM tab1 WHERE col1 <= 108.74 OR ((col0 <= 34)) OR col0 >= 844
 23 values hashing to 639c5584abd6fa415762c3b8d2d6225b
 
 statement ok
-DROP VIEW view_1_tab1_633
+DROP VIEW IF EXISTS view_1_tab1_633 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_633
+DROP VIEW IF EXISTS view_2_tab1_633 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_633
+DROP VIEW IF EXISTS view_3_tab1_633 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18057,13 +18057,13 @@ SELECT pk FROM tab2 WHERE col1 <= 108.74 OR ((col0 <= 34)) OR col0 >= 844
 23 values hashing to 639c5584abd6fa415762c3b8d2d6225b
 
 statement ok
-DROP VIEW view_1_tab2_633
+DROP VIEW IF EXISTS view_1_tab2_633 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_633
+DROP VIEW IF EXISTS view_2_tab2_633 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_633
+DROP VIEW IF EXISTS view_3_tab2_633 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18154,13 +18154,13 @@ SELECT pk FROM tab3 WHERE col1 <= 108.74 OR ((col0 <= 34)) OR col0 >= 844
 23 values hashing to 639c5584abd6fa415762c3b8d2d6225b
 
 statement ok
-DROP VIEW view_1_tab3_633
+DROP VIEW IF EXISTS view_1_tab3_633 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_633
+DROP VIEW IF EXISTS view_2_tab3_633 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_633
+DROP VIEW IF EXISTS view_3_tab3_633 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18251,13 +18251,13 @@ SELECT pk FROM tab4 WHERE col1 <= 108.74 OR ((col0 <= 34)) OR col0 >= 844
 23 values hashing to 639c5584abd6fa415762c3b8d2d6225b
 
 statement ok
-DROP VIEW view_1_tab4_633
+DROP VIEW IF EXISTS view_1_tab4_633 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_633
+DROP VIEW IF EXISTS view_2_tab4_633 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_633
+DROP VIEW IF EXISTS view_3_tab4_633 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18348,13 +18348,13 @@ SELECT pk FROM tab0 WHERE col3 < 934 AND col4 < 836.19 AND ((col3 > 574)) AND co
 69 values hashing to 6dc1b417afed563e50b2c47ba8f26528
 
 statement ok
-DROP VIEW view_1_tab0_634
+DROP VIEW IF EXISTS view_1_tab0_634 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_634
+DROP VIEW IF EXISTS view_2_tab0_634 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_634
+DROP VIEW IF EXISTS view_3_tab0_634 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18445,13 +18445,13 @@ SELECT pk FROM tab1 WHERE col3 < 934 AND col4 < 836.19 AND ((col3 > 574)) AND co
 69 values hashing to 6dc1b417afed563e50b2c47ba8f26528
 
 statement ok
-DROP VIEW view_1_tab1_634
+DROP VIEW IF EXISTS view_1_tab1_634 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_634
+DROP VIEW IF EXISTS view_2_tab1_634 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_634
+DROP VIEW IF EXISTS view_3_tab1_634 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18542,13 +18542,13 @@ SELECT pk FROM tab2 WHERE col3 < 934 AND col4 < 836.19 AND ((col3 > 574)) AND co
 69 values hashing to 6dc1b417afed563e50b2c47ba8f26528
 
 statement ok
-DROP VIEW view_1_tab2_634
+DROP VIEW IF EXISTS view_1_tab2_634 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_634
+DROP VIEW IF EXISTS view_2_tab2_634 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_634
+DROP VIEW IF EXISTS view_3_tab2_634 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18639,13 +18639,13 @@ SELECT pk FROM tab3 WHERE col3 < 934 AND col4 < 836.19 AND ((col3 > 574)) AND co
 69 values hashing to 6dc1b417afed563e50b2c47ba8f26528
 
 statement ok
-DROP VIEW view_1_tab3_634
+DROP VIEW IF EXISTS view_1_tab3_634 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_634
+DROP VIEW IF EXISTS view_2_tab3_634 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_634
+DROP VIEW IF EXISTS view_3_tab3_634 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18736,13 +18736,13 @@ SELECT pk FROM tab4 WHERE col3 < 934 AND col4 < 836.19 AND ((col3 > 574)) AND co
 69 values hashing to 6dc1b417afed563e50b2c47ba8f26528
 
 statement ok
-DROP VIEW view_1_tab4_634
+DROP VIEW IF EXISTS view_1_tab4_634 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_634
+DROP VIEW IF EXISTS view_2_tab4_634 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_634
+DROP VIEW IF EXISTS view_3_tab4_634 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18833,13 +18833,13 @@ SELECT pk FROM tab0 WHERE col1 < 273.10
 29 values hashing to 1406005fef04005ab5cc63728dc80243
 
 statement ok
-DROP VIEW view_1_tab0_635
+DROP VIEW IF EXISTS view_1_tab0_635 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_635
+DROP VIEW IF EXISTS view_2_tab0_635 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_635
+DROP VIEW IF EXISTS view_3_tab0_635 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18930,13 +18930,13 @@ SELECT pk FROM tab1 WHERE col1 < 273.10
 29 values hashing to 1406005fef04005ab5cc63728dc80243
 
 statement ok
-DROP VIEW view_1_tab1_635
+DROP VIEW IF EXISTS view_1_tab1_635 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_635
+DROP VIEW IF EXISTS view_2_tab1_635 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_635
+DROP VIEW IF EXISTS view_3_tab1_635 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19027,13 +19027,13 @@ SELECT pk FROM tab2 WHERE col1 < 273.10
 29 values hashing to 1406005fef04005ab5cc63728dc80243
 
 statement ok
-DROP VIEW view_1_tab2_635
+DROP VIEW IF EXISTS view_1_tab2_635 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_635
+DROP VIEW IF EXISTS view_2_tab2_635 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_635
+DROP VIEW IF EXISTS view_3_tab2_635 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19124,13 +19124,13 @@ SELECT pk FROM tab3 WHERE col1 < 273.10
 29 values hashing to 1406005fef04005ab5cc63728dc80243
 
 statement ok
-DROP VIEW view_1_tab3_635
+DROP VIEW IF EXISTS view_1_tab3_635 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_635
+DROP VIEW IF EXISTS view_2_tab3_635 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_635
+DROP VIEW IF EXISTS view_3_tab3_635 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19221,13 +19221,13 @@ SELECT pk FROM tab4 WHERE col1 < 273.10
 29 values hashing to 1406005fef04005ab5cc63728dc80243
 
 statement ok
-DROP VIEW view_1_tab4_635
+DROP VIEW IF EXISTS view_1_tab4_635 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_635
+DROP VIEW IF EXISTS view_2_tab4_635 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_635
+DROP VIEW IF EXISTS view_3_tab4_635 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19318,13 +19318,13 @@ SELECT pk FROM tab0 WHERE col4 >= 838.84 OR col0 > 864
 27 values hashing to 7e644fc9784fa8010b1a5cae8c8b2341
 
 statement ok
-DROP VIEW view_1_tab0_636
+DROP VIEW IF EXISTS view_1_tab0_636 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_636
+DROP VIEW IF EXISTS view_2_tab0_636 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_636
+DROP VIEW IF EXISTS view_3_tab0_636 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19415,13 +19415,13 @@ SELECT pk FROM tab1 WHERE col4 >= 838.84 OR col0 > 864
 27 values hashing to 7e644fc9784fa8010b1a5cae8c8b2341
 
 statement ok
-DROP VIEW view_1_tab1_636
+DROP VIEW IF EXISTS view_1_tab1_636 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_636
+DROP VIEW IF EXISTS view_2_tab1_636 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_636
+DROP VIEW IF EXISTS view_3_tab1_636 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19512,13 +19512,13 @@ SELECT pk FROM tab2 WHERE col4 >= 838.84 OR col0 > 864
 27 values hashing to 7e644fc9784fa8010b1a5cae8c8b2341
 
 statement ok
-DROP VIEW view_1_tab2_636
+DROP VIEW IF EXISTS view_1_tab2_636 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_636
+DROP VIEW IF EXISTS view_2_tab2_636 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_636
+DROP VIEW IF EXISTS view_3_tab2_636 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19609,13 +19609,13 @@ SELECT pk FROM tab3 WHERE col4 >= 838.84 OR col0 > 864
 27 values hashing to 7e644fc9784fa8010b1a5cae8c8b2341
 
 statement ok
-DROP VIEW view_1_tab3_636
+DROP VIEW IF EXISTS view_1_tab3_636 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_636
+DROP VIEW IF EXISTS view_2_tab3_636 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_636
+DROP VIEW IF EXISTS view_3_tab3_636 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19706,13 +19706,13 @@ SELECT pk FROM tab4 WHERE col4 >= 838.84 OR col0 > 864
 27 values hashing to 7e644fc9784fa8010b1a5cae8c8b2341
 
 statement ok
-DROP VIEW view_1_tab4_636
+DROP VIEW IF EXISTS view_1_tab4_636 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_636
+DROP VIEW IF EXISTS view_2_tab4_636 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_636
+DROP VIEW IF EXISTS view_3_tab4_636 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19803,13 +19803,13 @@ SELECT pk FROM tab0 WHERE (((col0 <= 308)))
 31 values hashing to 9375ed8fe31219b00478a1b5c566434b
 
 statement ok
-DROP VIEW view_1_tab0_637
+DROP VIEW IF EXISTS view_1_tab0_637 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_637
+DROP VIEW IF EXISTS view_2_tab0_637 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_637
+DROP VIEW IF EXISTS view_3_tab0_637 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19900,13 +19900,13 @@ SELECT pk FROM tab1 WHERE (((col0 <= 308)))
 31 values hashing to 9375ed8fe31219b00478a1b5c566434b
 
 statement ok
-DROP VIEW view_1_tab1_637
+DROP VIEW IF EXISTS view_1_tab1_637 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_637
+DROP VIEW IF EXISTS view_2_tab1_637 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_637
+DROP VIEW IF EXISTS view_3_tab1_637 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19997,13 +19997,13 @@ SELECT pk FROM tab2 WHERE (((col0 <= 308)))
 31 values hashing to 9375ed8fe31219b00478a1b5c566434b
 
 statement ok
-DROP VIEW view_1_tab2_637
+DROP VIEW IF EXISTS view_1_tab2_637 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_637
+DROP VIEW IF EXISTS view_2_tab2_637 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_637
+DROP VIEW IF EXISTS view_3_tab2_637 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20094,13 +20094,13 @@ SELECT pk FROM tab3 WHERE (((col0 <= 308)))
 31 values hashing to 9375ed8fe31219b00478a1b5c566434b
 
 statement ok
-DROP VIEW view_1_tab3_637
+DROP VIEW IF EXISTS view_1_tab3_637 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_637
+DROP VIEW IF EXISTS view_2_tab3_637 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_637
+DROP VIEW IF EXISTS view_3_tab3_637 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20191,13 +20191,13 @@ SELECT pk FROM tab4 WHERE (((col0 <= 308)))
 31 values hashing to 9375ed8fe31219b00478a1b5c566434b
 
 statement ok
-DROP VIEW view_1_tab4_637
+DROP VIEW IF EXISTS view_1_tab4_637 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_637
+DROP VIEW IF EXISTS view_2_tab4_637 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_637
+DROP VIEW IF EXISTS view_3_tab4_637 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20283,13 +20283,13 @@ SELECT pk FROM tab0 WHERE col0 <= 632 AND (col0 > 947) AND col0 < 824 AND ((col3
 ----
 
 statement ok
-DROP VIEW view_1_tab0_638
+DROP VIEW IF EXISTS view_1_tab0_638 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_638
+DROP VIEW IF EXISTS view_2_tab0_638 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_638
+DROP VIEW IF EXISTS view_3_tab0_638 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20375,13 +20375,13 @@ SELECT pk FROM tab1 WHERE col0 <= 632 AND (col0 > 947) AND col0 < 824 AND ((col3
 ----
 
 statement ok
-DROP VIEW view_1_tab1_638
+DROP VIEW IF EXISTS view_1_tab1_638 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_638
+DROP VIEW IF EXISTS view_2_tab1_638 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_638
+DROP VIEW IF EXISTS view_3_tab1_638 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20467,13 +20467,13 @@ SELECT pk FROM tab2 WHERE col0 <= 632 AND (col0 > 947) AND col0 < 824 AND ((col3
 ----
 
 statement ok
-DROP VIEW view_1_tab2_638
+DROP VIEW IF EXISTS view_1_tab2_638 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_638
+DROP VIEW IF EXISTS view_2_tab2_638 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_638
+DROP VIEW IF EXISTS view_3_tab2_638 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20559,13 +20559,13 @@ SELECT pk FROM tab3 WHERE col0 <= 632 AND (col0 > 947) AND col0 < 824 AND ((col3
 ----
 
 statement ok
-DROP VIEW view_1_tab3_638
+DROP VIEW IF EXISTS view_1_tab3_638 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_638
+DROP VIEW IF EXISTS view_2_tab3_638 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_638
+DROP VIEW IF EXISTS view_3_tab3_638 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20651,13 +20651,13 @@ SELECT pk FROM tab4 WHERE col0 <= 632 AND (col0 > 947) AND col0 < 824 AND ((col3
 ----
 
 statement ok
-DROP VIEW view_1_tab4_638
+DROP VIEW IF EXISTS view_1_tab4_638 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_638
+DROP VIEW IF EXISTS view_2_tab4_638 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_638
+DROP VIEW IF EXISTS view_3_tab4_638 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20748,13 +20748,13 @@ SELECT pk FROM tab0 WHERE (col3 > 53)
 95 values hashing to fc050f03ae4cde40d79b00065d4b0125
 
 statement ok
-DROP VIEW view_1_tab0_639
+DROP VIEW IF EXISTS view_1_tab0_639 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_639
+DROP VIEW IF EXISTS view_2_tab0_639 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_639
+DROP VIEW IF EXISTS view_3_tab0_639 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20845,13 +20845,13 @@ SELECT pk FROM tab1 WHERE (col3 > 53)
 95 values hashing to fc050f03ae4cde40d79b00065d4b0125
 
 statement ok
-DROP VIEW view_1_tab1_639
+DROP VIEW IF EXISTS view_1_tab1_639 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_639
+DROP VIEW IF EXISTS view_2_tab1_639 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_639
+DROP VIEW IF EXISTS view_3_tab1_639 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20942,13 +20942,13 @@ SELECT pk FROM tab2 WHERE (col3 > 53)
 95 values hashing to fc050f03ae4cde40d79b00065d4b0125
 
 statement ok
-DROP VIEW view_1_tab2_639
+DROP VIEW IF EXISTS view_1_tab2_639 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_639
+DROP VIEW IF EXISTS view_2_tab2_639 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_639
+DROP VIEW IF EXISTS view_3_tab2_639 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21039,13 +21039,13 @@ SELECT pk FROM tab3 WHERE (col3 > 53)
 95 values hashing to fc050f03ae4cde40d79b00065d4b0125
 
 statement ok
-DROP VIEW view_1_tab3_639
+DROP VIEW IF EXISTS view_1_tab3_639 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_639
+DROP VIEW IF EXISTS view_2_tab3_639 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_639
+DROP VIEW IF EXISTS view_3_tab3_639 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21136,13 +21136,13 @@ SELECT pk FROM tab4 WHERE (col3 > 53)
 95 values hashing to fc050f03ae4cde40d79b00065d4b0125
 
 statement ok
-DROP VIEW view_1_tab4_639
+DROP VIEW IF EXISTS view_1_tab4_639 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_639
+DROP VIEW IF EXISTS view_2_tab4_639 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_639
+DROP VIEW IF EXISTS view_3_tab4_639 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21233,13 +21233,13 @@ SELECT pk FROM tab0 WHERE col0 < 555 AND col0 >= 88
 40 values hashing to a4c36d978797cfb924718f92b228af58
 
 statement ok
-DROP VIEW view_1_tab0_641
+DROP VIEW IF EXISTS view_1_tab0_641 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_641
+DROP VIEW IF EXISTS view_2_tab0_641 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_641
+DROP VIEW IF EXISTS view_3_tab0_641 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21330,13 +21330,13 @@ SELECT pk FROM tab1 WHERE col0 < 555 AND col0 >= 88
 40 values hashing to a4c36d978797cfb924718f92b228af58
 
 statement ok
-DROP VIEW view_1_tab1_641
+DROP VIEW IF EXISTS view_1_tab1_641 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_641
+DROP VIEW IF EXISTS view_2_tab1_641 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_641
+DROP VIEW IF EXISTS view_3_tab1_641 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21427,13 +21427,13 @@ SELECT pk FROM tab2 WHERE col0 < 555 AND col0 >= 88
 40 values hashing to a4c36d978797cfb924718f92b228af58
 
 statement ok
-DROP VIEW view_1_tab2_641
+DROP VIEW IF EXISTS view_1_tab2_641 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_641
+DROP VIEW IF EXISTS view_2_tab2_641 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_641
+DROP VIEW IF EXISTS view_3_tab2_641 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21524,13 +21524,13 @@ SELECT pk FROM tab3 WHERE col0 < 555 AND col0 >= 88
 40 values hashing to a4c36d978797cfb924718f92b228af58
 
 statement ok
-DROP VIEW view_1_tab3_641
+DROP VIEW IF EXISTS view_1_tab3_641 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_641
+DROP VIEW IF EXISTS view_2_tab3_641 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_641
+DROP VIEW IF EXISTS view_3_tab3_641 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21621,13 +21621,13 @@ SELECT pk FROM tab4 WHERE col0 < 555 AND col0 >= 88
 40 values hashing to a4c36d978797cfb924718f92b228af58
 
 statement ok
-DROP VIEW view_1_tab4_641
+DROP VIEW IF EXISTS view_1_tab4_641 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_641
+DROP VIEW IF EXISTS view_2_tab4_641 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_641
+DROP VIEW IF EXISTS view_3_tab4_641 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21718,13 +21718,13 @@ SELECT pk FROM tab0 WHERE col0 <= 213
 24 values hashing to 50c8c9b225e92585c43981b40b6b0a9c
 
 statement ok
-DROP VIEW view_1_tab0_642
+DROP VIEW IF EXISTS view_1_tab0_642 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_642
+DROP VIEW IF EXISTS view_2_tab0_642 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_642
+DROP VIEW IF EXISTS view_3_tab0_642 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21815,13 +21815,13 @@ SELECT pk FROM tab1 WHERE col0 <= 213
 24 values hashing to 50c8c9b225e92585c43981b40b6b0a9c
 
 statement ok
-DROP VIEW view_1_tab1_642
+DROP VIEW IF EXISTS view_1_tab1_642 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_642
+DROP VIEW IF EXISTS view_2_tab1_642 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_642
+DROP VIEW IF EXISTS view_3_tab1_642 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21912,13 +21912,13 @@ SELECT pk FROM tab2 WHERE col0 <= 213
 24 values hashing to 50c8c9b225e92585c43981b40b6b0a9c
 
 statement ok
-DROP VIEW view_1_tab2_642
+DROP VIEW IF EXISTS view_1_tab2_642 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_642
+DROP VIEW IF EXISTS view_2_tab2_642 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_642
+DROP VIEW IF EXISTS view_3_tab2_642 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22009,13 +22009,13 @@ SELECT pk FROM tab3 WHERE col0 <= 213
 24 values hashing to 50c8c9b225e92585c43981b40b6b0a9c
 
 statement ok
-DROP VIEW view_1_tab3_642
+DROP VIEW IF EXISTS view_1_tab3_642 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_642
+DROP VIEW IF EXISTS view_2_tab3_642 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_642
+DROP VIEW IF EXISTS view_3_tab3_642 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22106,13 +22106,13 @@ SELECT pk FROM tab4 WHERE col0 <= 213
 24 values hashing to 50c8c9b225e92585c43981b40b6b0a9c
 
 statement ok
-DROP VIEW view_1_tab4_642
+DROP VIEW IF EXISTS view_1_tab4_642 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_642
+DROP VIEW IF EXISTS view_2_tab4_642 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_642
+DROP VIEW IF EXISTS view_3_tab4_642 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22203,13 +22203,13 @@ SELECT pk FROM tab0 WHERE col0 > 687
 30 values hashing to b3f1ddfddb20f2acadba9061190de845
 
 statement ok
-DROP VIEW view_1_tab0_643
+DROP VIEW IF EXISTS view_1_tab0_643 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_643
+DROP VIEW IF EXISTS view_2_tab0_643 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_643
+DROP VIEW IF EXISTS view_3_tab0_643 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22300,13 +22300,13 @@ SELECT pk FROM tab1 WHERE col0 > 687
 30 values hashing to b3f1ddfddb20f2acadba9061190de845
 
 statement ok
-DROP VIEW view_1_tab1_643
+DROP VIEW IF EXISTS view_1_tab1_643 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_643
+DROP VIEW IF EXISTS view_2_tab1_643 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_643
+DROP VIEW IF EXISTS view_3_tab1_643 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22397,13 +22397,13 @@ SELECT pk FROM tab2 WHERE col0 > 687
 30 values hashing to b3f1ddfddb20f2acadba9061190de845
 
 statement ok
-DROP VIEW view_1_tab2_643
+DROP VIEW IF EXISTS view_1_tab2_643 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_643
+DROP VIEW IF EXISTS view_2_tab2_643 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_643
+DROP VIEW IF EXISTS view_3_tab2_643 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22494,13 +22494,13 @@ SELECT pk FROM tab3 WHERE col0 > 687
 30 values hashing to b3f1ddfddb20f2acadba9061190de845
 
 statement ok
-DROP VIEW view_1_tab3_643
+DROP VIEW IF EXISTS view_1_tab3_643 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_643
+DROP VIEW IF EXISTS view_2_tab3_643 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_643
+DROP VIEW IF EXISTS view_3_tab3_643 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22591,13 +22591,13 @@ SELECT pk FROM tab4 WHERE col0 > 687
 30 values hashing to b3f1ddfddb20f2acadba9061190de845
 
 statement ok
-DROP VIEW view_1_tab4_643
+DROP VIEW IF EXISTS view_1_tab4_643 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_643
+DROP VIEW IF EXISTS view_2_tab4_643 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_643
+DROP VIEW IF EXISTS view_3_tab4_643 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22683,13 +22683,13 @@ SELECT pk FROM tab0 WHERE col0 = 246 AND col0 > 842 AND (col0 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_644
+DROP VIEW IF EXISTS view_1_tab0_644 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_644
+DROP VIEW IF EXISTS view_2_tab0_644 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_644
+DROP VIEW IF EXISTS view_3_tab0_644 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22775,13 +22775,13 @@ SELECT pk FROM tab1 WHERE col0 = 246 AND col0 > 842 AND (col0 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_644
+DROP VIEW IF EXISTS view_1_tab1_644 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_644
+DROP VIEW IF EXISTS view_2_tab1_644 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_644
+DROP VIEW IF EXISTS view_3_tab1_644 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22867,13 +22867,13 @@ SELECT pk FROM tab2 WHERE col0 = 246 AND col0 > 842 AND (col0 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_644
+DROP VIEW IF EXISTS view_1_tab2_644 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_644
+DROP VIEW IF EXISTS view_2_tab2_644 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_644
+DROP VIEW IF EXISTS view_3_tab2_644 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22959,13 +22959,13 @@ SELECT pk FROM tab3 WHERE col0 = 246 AND col0 > 842 AND (col0 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_644
+DROP VIEW IF EXISTS view_1_tab3_644 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_644
+DROP VIEW IF EXISTS view_2_tab3_644 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_644
+DROP VIEW IF EXISTS view_3_tab3_644 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23051,13 +23051,13 @@ SELECT pk FROM tab4 WHERE col0 = 246 AND col0 > 842 AND (col0 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_644
+DROP VIEW IF EXISTS view_1_tab4_644 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_644
+DROP VIEW IF EXISTS view_2_tab4_644 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_644
+DROP VIEW IF EXISTS view_3_tab4_644 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23150,13 +23150,13 @@ SELECT pk FROM tab0 WHERE col0 = 840 OR col3 > 6
 99 values hashing to bc756eaad898aee727318756048c0ae2
 
 statement ok
-DROP VIEW view_1_tab0_645
+DROP VIEW IF EXISTS view_1_tab0_645 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_645
+DROP VIEW IF EXISTS view_2_tab0_645 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_645
+DROP VIEW IF EXISTS view_3_tab0_645 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23249,13 +23249,13 @@ SELECT pk FROM tab1 WHERE col0 = 840 OR col3 > 6
 99 values hashing to bc756eaad898aee727318756048c0ae2
 
 statement ok
-DROP VIEW view_1_tab1_645
+DROP VIEW IF EXISTS view_1_tab1_645 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_645
+DROP VIEW IF EXISTS view_2_tab1_645 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_645
+DROP VIEW IF EXISTS view_3_tab1_645 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23348,13 +23348,13 @@ SELECT pk FROM tab2 WHERE col0 = 840 OR col3 > 6
 99 values hashing to bc756eaad898aee727318756048c0ae2
 
 statement ok
-DROP VIEW view_1_tab2_645
+DROP VIEW IF EXISTS view_1_tab2_645 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_645
+DROP VIEW IF EXISTS view_2_tab2_645 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_645
+DROP VIEW IF EXISTS view_3_tab2_645 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23447,13 +23447,13 @@ SELECT pk FROM tab3 WHERE col0 = 840 OR col3 > 6
 99 values hashing to bc756eaad898aee727318756048c0ae2
 
 statement ok
-DROP VIEW view_1_tab3_645
+DROP VIEW IF EXISTS view_1_tab3_645 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_645
+DROP VIEW IF EXISTS view_2_tab3_645 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_645
+DROP VIEW IF EXISTS view_3_tab3_645 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23546,13 +23546,13 @@ SELECT pk FROM tab4 WHERE col0 = 840 OR col3 > 6
 99 values hashing to bc756eaad898aee727318756048c0ae2
 
 statement ok
-DROP VIEW view_1_tab4_645
+DROP VIEW IF EXISTS view_1_tab4_645 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_645
+DROP VIEW IF EXISTS view_2_tab4_645 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_645
+DROP VIEW IF EXISTS view_3_tab4_645 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23638,13 +23638,13 @@ SELECT pk FROM tab0 WHERE ((col3 > 748 OR (col0 >= 346) AND col4 < 104.89 OR (co
 ----
 
 statement ok
-DROP VIEW view_1_tab0_646
+DROP VIEW IF EXISTS view_1_tab0_646 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_646
+DROP VIEW IF EXISTS view_2_tab0_646 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_646
+DROP VIEW IF EXISTS view_3_tab0_646 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23730,13 +23730,13 @@ SELECT pk FROM tab1 WHERE ((col3 > 748 OR (col0 >= 346) AND col4 < 104.89 OR (co
 ----
 
 statement ok
-DROP VIEW view_1_tab1_646
+DROP VIEW IF EXISTS view_1_tab1_646 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_646
+DROP VIEW IF EXISTS view_2_tab1_646 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_646
+DROP VIEW IF EXISTS view_3_tab1_646 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23822,13 +23822,13 @@ SELECT pk FROM tab2 WHERE ((col3 > 748 OR (col0 >= 346) AND col4 < 104.89 OR (co
 ----
 
 statement ok
-DROP VIEW view_1_tab2_646
+DROP VIEW IF EXISTS view_1_tab2_646 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_646
+DROP VIEW IF EXISTS view_2_tab2_646 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_646
+DROP VIEW IF EXISTS view_3_tab2_646 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23914,13 +23914,13 @@ SELECT pk FROM tab3 WHERE ((col3 > 748 OR (col0 >= 346) AND col4 < 104.89 OR (co
 ----
 
 statement ok
-DROP VIEW view_1_tab3_646
+DROP VIEW IF EXISTS view_1_tab3_646 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_646
+DROP VIEW IF EXISTS view_2_tab3_646 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_646
+DROP VIEW IF EXISTS view_3_tab3_646 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24006,13 +24006,13 @@ SELECT pk FROM tab4 WHERE ((col3 > 748 OR (col0 >= 346) AND col4 < 104.89 OR (co
 ----
 
 statement ok
-DROP VIEW view_1_tab4_646
+DROP VIEW IF EXISTS view_1_tab4_646 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_646
+DROP VIEW IF EXISTS view_2_tab4_646 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_646
+DROP VIEW IF EXISTS view_3_tab4_646 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24103,13 +24103,13 @@ SELECT pk FROM tab0 WHERE col3 < 407
 49 values hashing to 73403bb74e8462eae58bc1305a0890da
 
 statement ok
-DROP VIEW view_1_tab0_647
+DROP VIEW IF EXISTS view_1_tab0_647 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_647
+DROP VIEW IF EXISTS view_2_tab0_647 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_647
+DROP VIEW IF EXISTS view_3_tab0_647 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24200,13 +24200,13 @@ SELECT pk FROM tab1 WHERE col3 < 407
 49 values hashing to 73403bb74e8462eae58bc1305a0890da
 
 statement ok
-DROP VIEW view_1_tab1_647
+DROP VIEW IF EXISTS view_1_tab1_647 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_647
+DROP VIEW IF EXISTS view_2_tab1_647 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_647
+DROP VIEW IF EXISTS view_3_tab1_647 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24297,13 +24297,13 @@ SELECT pk FROM tab2 WHERE col3 < 407
 49 values hashing to 73403bb74e8462eae58bc1305a0890da
 
 statement ok
-DROP VIEW view_1_tab2_647
+DROP VIEW IF EXISTS view_1_tab2_647 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_647
+DROP VIEW IF EXISTS view_2_tab2_647 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_647
+DROP VIEW IF EXISTS view_3_tab2_647 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24394,13 +24394,13 @@ SELECT pk FROM tab3 WHERE col3 < 407
 49 values hashing to 73403bb74e8462eae58bc1305a0890da
 
 statement ok
-DROP VIEW view_1_tab3_647
+DROP VIEW IF EXISTS view_1_tab3_647 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_647
+DROP VIEW IF EXISTS view_2_tab3_647 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_647
+DROP VIEW IF EXISTS view_3_tab3_647 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24491,13 +24491,13 @@ SELECT pk FROM tab4 WHERE col3 < 407
 49 values hashing to 73403bb74e8462eae58bc1305a0890da
 
 statement ok
-DROP VIEW view_1_tab4_647
+DROP VIEW IF EXISTS view_1_tab4_647 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_647
+DROP VIEW IF EXISTS view_2_tab4_647 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_647
+DROP VIEW IF EXISTS view_3_tab4_647 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24588,13 +24588,13 @@ SELECT pk FROM tab0 WHERE (col0 < 317) OR (col3 > 940)
 39 values hashing to 291b958582867896d917374351bef51a
 
 statement ok
-DROP VIEW view_1_tab0_648
+DROP VIEW IF EXISTS view_1_tab0_648 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_648
+DROP VIEW IF EXISTS view_2_tab0_648 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_648
+DROP VIEW IF EXISTS view_3_tab0_648 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24685,13 +24685,13 @@ SELECT pk FROM tab1 WHERE (col0 < 317) OR (col3 > 940)
 39 values hashing to 291b958582867896d917374351bef51a
 
 statement ok
-DROP VIEW view_1_tab1_648
+DROP VIEW IF EXISTS view_1_tab1_648 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_648
+DROP VIEW IF EXISTS view_2_tab1_648 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_648
+DROP VIEW IF EXISTS view_3_tab1_648 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24782,13 +24782,13 @@ SELECT pk FROM tab2 WHERE (col0 < 317) OR (col3 > 940)
 39 values hashing to 291b958582867896d917374351bef51a
 
 statement ok
-DROP VIEW view_1_tab2_648
+DROP VIEW IF EXISTS view_1_tab2_648 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_648
+DROP VIEW IF EXISTS view_2_tab2_648 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_648
+DROP VIEW IF EXISTS view_3_tab2_648 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24879,13 +24879,13 @@ SELECT pk FROM tab3 WHERE (col0 < 317) OR (col3 > 940)
 39 values hashing to 291b958582867896d917374351bef51a
 
 statement ok
-DROP VIEW view_1_tab3_648
+DROP VIEW IF EXISTS view_1_tab3_648 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_648
+DROP VIEW IF EXISTS view_2_tab3_648 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_648
+DROP VIEW IF EXISTS view_3_tab3_648 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24976,13 +24976,13 @@ SELECT pk FROM tab4 WHERE (col0 < 317) OR (col3 > 940)
 39 values hashing to 291b958582867896d917374351bef51a
 
 statement ok
-DROP VIEW view_1_tab4_648
+DROP VIEW IF EXISTS view_1_tab4_648 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_648
+DROP VIEW IF EXISTS view_2_tab4_648 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_648
+DROP VIEW IF EXISTS view_3_tab4_648 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25083,13 +25083,13 @@ SELECT pk FROM tab0 WHERE col3 >= 766 OR col1 < 348.94 AND ((((col4 IN (307.68,2
 97 values hashing to 2ce647298726de968583c5befcabf6b0
 
 statement ok
-DROP VIEW view_1_tab0_649
+DROP VIEW IF EXISTS view_1_tab0_649 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_649
+DROP VIEW IF EXISTS view_2_tab0_649 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_649
+DROP VIEW IF EXISTS view_3_tab0_649 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25190,13 +25190,13 @@ SELECT pk FROM tab1 WHERE col3 >= 766 OR col1 < 348.94 AND ((((col4 IN (307.68,2
 97 values hashing to 2ce647298726de968583c5befcabf6b0
 
 statement ok
-DROP VIEW view_1_tab1_649
+DROP VIEW IF EXISTS view_1_tab1_649 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_649
+DROP VIEW IF EXISTS view_2_tab1_649 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_649
+DROP VIEW IF EXISTS view_3_tab1_649 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25297,13 +25297,13 @@ SELECT pk FROM tab2 WHERE col3 >= 766 OR col1 < 348.94 AND ((((col4 IN (307.68,2
 97 values hashing to 2ce647298726de968583c5befcabf6b0
 
 statement ok
-DROP VIEW view_1_tab2_649
+DROP VIEW IF EXISTS view_1_tab2_649 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_649
+DROP VIEW IF EXISTS view_2_tab2_649 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_649
+DROP VIEW IF EXISTS view_3_tab2_649 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25404,13 +25404,13 @@ SELECT pk FROM tab3 WHERE col3 >= 766 OR col1 < 348.94 AND ((((col4 IN (307.68,2
 97 values hashing to 2ce647298726de968583c5befcabf6b0
 
 statement ok
-DROP VIEW view_1_tab3_649
+DROP VIEW IF EXISTS view_1_tab3_649 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_649
+DROP VIEW IF EXISTS view_2_tab3_649 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_649
+DROP VIEW IF EXISTS view_3_tab3_649 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25511,13 +25511,13 @@ SELECT pk FROM tab4 WHERE col3 >= 766 OR col1 < 348.94 AND ((((col4 IN (307.68,2
 97 values hashing to 2ce647298726de968583c5befcabf6b0
 
 statement ok
-DROP VIEW view_1_tab4_649
+DROP VIEW IF EXISTS view_1_tab4_649 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_649
+DROP VIEW IF EXISTS view_2_tab4_649 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_649
+DROP VIEW IF EXISTS view_3_tab4_649 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25608,13 +25608,13 @@ SELECT pk FROM tab0 WHERE col0 <= 807 AND col0 > 131
 66 values hashing to d45f9df347eb37037587423516558cc5
 
 statement ok
-DROP VIEW view_1_tab0_650
+DROP VIEW IF EXISTS view_1_tab0_650 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_650
+DROP VIEW IF EXISTS view_2_tab0_650 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_650
+DROP VIEW IF EXISTS view_3_tab0_650 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25705,13 +25705,13 @@ SELECT pk FROM tab1 WHERE col0 <= 807 AND col0 > 131
 66 values hashing to d45f9df347eb37037587423516558cc5
 
 statement ok
-DROP VIEW view_1_tab1_650
+DROP VIEW IF EXISTS view_1_tab1_650 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_650
+DROP VIEW IF EXISTS view_2_tab1_650 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_650
+DROP VIEW IF EXISTS view_3_tab1_650 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25802,13 +25802,13 @@ SELECT pk FROM tab2 WHERE col0 <= 807 AND col0 > 131
 66 values hashing to d45f9df347eb37037587423516558cc5
 
 statement ok
-DROP VIEW view_1_tab2_650
+DROP VIEW IF EXISTS view_1_tab2_650 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_650
+DROP VIEW IF EXISTS view_2_tab2_650 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_650
+DROP VIEW IF EXISTS view_3_tab2_650 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25899,13 +25899,13 @@ SELECT pk FROM tab3 WHERE col0 <= 807 AND col0 > 131
 66 values hashing to d45f9df347eb37037587423516558cc5
 
 statement ok
-DROP VIEW view_1_tab3_650
+DROP VIEW IF EXISTS view_1_tab3_650 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_650
+DROP VIEW IF EXISTS view_2_tab3_650 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_650
+DROP VIEW IF EXISTS view_3_tab3_650 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25996,13 +25996,13 @@ SELECT pk FROM tab4 WHERE col0 <= 807 AND col0 > 131
 66 values hashing to d45f9df347eb37037587423516558cc5
 
 statement ok
-DROP VIEW view_1_tab4_650
+DROP VIEW IF EXISTS view_1_tab4_650 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_650
+DROP VIEW IF EXISTS view_2_tab4_650 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_650
+DROP VIEW IF EXISTS view_3_tab4_650 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26093,13 +26093,13 @@ SELECT pk FROM tab0 WHERE (col0 < 245)
 27 values hashing to bedaee6a3732f1adb58c96676f9977e9
 
 statement ok
-DROP VIEW view_1_tab0_651
+DROP VIEW IF EXISTS view_1_tab0_651 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_651
+DROP VIEW IF EXISTS view_2_tab0_651 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_651
+DROP VIEW IF EXISTS view_3_tab0_651 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26190,13 +26190,13 @@ SELECT pk FROM tab1 WHERE (col0 < 245)
 27 values hashing to bedaee6a3732f1adb58c96676f9977e9
 
 statement ok
-DROP VIEW view_1_tab1_651
+DROP VIEW IF EXISTS view_1_tab1_651 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_651
+DROP VIEW IF EXISTS view_2_tab1_651 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_651
+DROP VIEW IF EXISTS view_3_tab1_651 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26287,13 +26287,13 @@ SELECT pk FROM tab2 WHERE (col0 < 245)
 27 values hashing to bedaee6a3732f1adb58c96676f9977e9
 
 statement ok
-DROP VIEW view_1_tab2_651
+DROP VIEW IF EXISTS view_1_tab2_651 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_651
+DROP VIEW IF EXISTS view_2_tab2_651 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_651
+DROP VIEW IF EXISTS view_3_tab2_651 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26384,13 +26384,13 @@ SELECT pk FROM tab3 WHERE (col0 < 245)
 27 values hashing to bedaee6a3732f1adb58c96676f9977e9
 
 statement ok
-DROP VIEW view_1_tab3_651
+DROP VIEW IF EXISTS view_1_tab3_651 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_651
+DROP VIEW IF EXISTS view_2_tab3_651 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_651
+DROP VIEW IF EXISTS view_3_tab3_651 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26481,13 +26481,13 @@ SELECT pk FROM tab4 WHERE (col0 < 245)
 27 values hashing to bedaee6a3732f1adb58c96676f9977e9
 
 statement ok
-DROP VIEW view_1_tab4_651
+DROP VIEW IF EXISTS view_1_tab4_651 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_651
+DROP VIEW IF EXISTS view_2_tab4_651 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_651
+DROP VIEW IF EXISTS view_3_tab4_651 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26573,13 +26573,13 @@ SELECT pk FROM tab0 WHERE (((col1 IN (102.83,510.38,216.62))))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_652
+DROP VIEW IF EXISTS view_1_tab0_652 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_652
+DROP VIEW IF EXISTS view_2_tab0_652 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_652
+DROP VIEW IF EXISTS view_3_tab0_652 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26665,13 +26665,13 @@ SELECT pk FROM tab1 WHERE (((col1 IN (102.83,510.38,216.62))))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_652
+DROP VIEW IF EXISTS view_1_tab1_652 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_652
+DROP VIEW IF EXISTS view_2_tab1_652 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_652
+DROP VIEW IF EXISTS view_3_tab1_652 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26757,13 +26757,13 @@ SELECT pk FROM tab2 WHERE (((col1 IN (102.83,510.38,216.62))))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_652
+DROP VIEW IF EXISTS view_1_tab2_652 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_652
+DROP VIEW IF EXISTS view_2_tab2_652 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_652
+DROP VIEW IF EXISTS view_3_tab2_652 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26849,13 +26849,13 @@ SELECT pk FROM tab3 WHERE (((col1 IN (102.83,510.38,216.62))))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_652
+DROP VIEW IF EXISTS view_1_tab3_652 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_652
+DROP VIEW IF EXISTS view_2_tab3_652 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_652
+DROP VIEW IF EXISTS view_3_tab3_652 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26941,13 +26941,13 @@ SELECT pk FROM tab4 WHERE (((col1 IN (102.83,510.38,216.62))))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_652
+DROP VIEW IF EXISTS view_1_tab4_652 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_652
+DROP VIEW IF EXISTS view_2_tab4_652 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_652
+DROP VIEW IF EXISTS view_3_tab4_652 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27038,13 +27038,13 @@ SELECT pk FROM tab0 WHERE col0 >= 576
 48 values hashing to fa012b0ee1da64a93a91455c2c254990
 
 statement ok
-DROP VIEW view_1_tab0_653
+DROP VIEW IF EXISTS view_1_tab0_653 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_653
+DROP VIEW IF EXISTS view_2_tab0_653 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_653
+DROP VIEW IF EXISTS view_3_tab0_653 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27135,13 +27135,13 @@ SELECT pk FROM tab1 WHERE col0 >= 576
 48 values hashing to fa012b0ee1da64a93a91455c2c254990
 
 statement ok
-DROP VIEW view_1_tab1_653
+DROP VIEW IF EXISTS view_1_tab1_653 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_653
+DROP VIEW IF EXISTS view_2_tab1_653 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_653
+DROP VIEW IF EXISTS view_3_tab1_653 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27232,13 +27232,13 @@ SELECT pk FROM tab2 WHERE col0 >= 576
 48 values hashing to fa012b0ee1da64a93a91455c2c254990
 
 statement ok
-DROP VIEW view_1_tab2_653
+DROP VIEW IF EXISTS view_1_tab2_653 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_653
+DROP VIEW IF EXISTS view_2_tab2_653 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_653
+DROP VIEW IF EXISTS view_3_tab2_653 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27329,13 +27329,13 @@ SELECT pk FROM tab3 WHERE col0 >= 576
 48 values hashing to fa012b0ee1da64a93a91455c2c254990
 
 statement ok
-DROP VIEW view_1_tab3_653
+DROP VIEW IF EXISTS view_1_tab3_653 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_653
+DROP VIEW IF EXISTS view_2_tab3_653 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_653
+DROP VIEW IF EXISTS view_3_tab3_653 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27426,13 +27426,13 @@ SELECT pk FROM tab4 WHERE col0 >= 576
 48 values hashing to fa012b0ee1da64a93a91455c2c254990
 
 statement ok
-DROP VIEW view_1_tab4_653
+DROP VIEW IF EXISTS view_1_tab4_653 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_653
+DROP VIEW IF EXISTS view_2_tab4_653 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_653
+DROP VIEW IF EXISTS view_3_tab4_653 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27521,13 +27521,13 @@ SELECT pk FROM tab0 WHERE col3 < 766 OR col4 >= 95.44
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab0_654
+DROP VIEW IF EXISTS view_1_tab0_654 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_654
+DROP VIEW IF EXISTS view_2_tab0_654 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_654
+DROP VIEW IF EXISTS view_3_tab0_654 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27616,13 +27616,13 @@ SELECT pk FROM tab1 WHERE col3 < 766 OR col4 >= 95.44
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab1_654
+DROP VIEW IF EXISTS view_1_tab1_654 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_654
+DROP VIEW IF EXISTS view_2_tab1_654 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_654
+DROP VIEW IF EXISTS view_3_tab1_654 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27711,13 +27711,13 @@ SELECT pk FROM tab2 WHERE col3 < 766 OR col4 >= 95.44
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab2_654
+DROP VIEW IF EXISTS view_1_tab2_654 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_654
+DROP VIEW IF EXISTS view_2_tab2_654 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_654
+DROP VIEW IF EXISTS view_3_tab2_654 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27806,13 +27806,13 @@ SELECT pk FROM tab3 WHERE col3 < 766 OR col4 >= 95.44
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab3_654
+DROP VIEW IF EXISTS view_1_tab3_654 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_654
+DROP VIEW IF EXISTS view_2_tab3_654 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_654
+DROP VIEW IF EXISTS view_3_tab3_654 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27901,13 +27901,13 @@ SELECT pk FROM tab4 WHERE col3 < 766 OR col4 >= 95.44
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab4_654
+DROP VIEW IF EXISTS view_1_tab4_654 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_654
+DROP VIEW IF EXISTS view_2_tab4_654 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_654
+DROP VIEW IF EXISTS view_3_tab4_654 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27998,13 +27998,13 @@ SELECT pk FROM tab0 WHERE col0 > 298
 70 values hashing to 6d270095773d8228b1aafe8e94c61df3
 
 statement ok
-DROP VIEW view_1_tab0_655
+DROP VIEW IF EXISTS view_1_tab0_655 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_655
+DROP VIEW IF EXISTS view_2_tab0_655 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_655
+DROP VIEW IF EXISTS view_3_tab0_655 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28095,13 +28095,13 @@ SELECT pk FROM tab1 WHERE col0 > 298
 70 values hashing to 6d270095773d8228b1aafe8e94c61df3
 
 statement ok
-DROP VIEW view_1_tab1_655
+DROP VIEW IF EXISTS view_1_tab1_655 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_655
+DROP VIEW IF EXISTS view_2_tab1_655 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_655
+DROP VIEW IF EXISTS view_3_tab1_655 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28192,13 +28192,13 @@ SELECT pk FROM tab2 WHERE col0 > 298
 70 values hashing to 6d270095773d8228b1aafe8e94c61df3
 
 statement ok
-DROP VIEW view_1_tab2_655
+DROP VIEW IF EXISTS view_1_tab2_655 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_655
+DROP VIEW IF EXISTS view_2_tab2_655 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_655
+DROP VIEW IF EXISTS view_3_tab2_655 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28289,13 +28289,13 @@ SELECT pk FROM tab3 WHERE col0 > 298
 70 values hashing to 6d270095773d8228b1aafe8e94c61df3
 
 statement ok
-DROP VIEW view_1_tab3_655
+DROP VIEW IF EXISTS view_1_tab3_655 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_655
+DROP VIEW IF EXISTS view_2_tab3_655 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_655
+DROP VIEW IF EXISTS view_3_tab3_655 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28386,13 +28386,13 @@ SELECT pk FROM tab4 WHERE col0 > 298
 70 values hashing to 6d270095773d8228b1aafe8e94c61df3
 
 statement ok
-DROP VIEW view_1_tab4_655
+DROP VIEW IF EXISTS view_1_tab4_655 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_655
+DROP VIEW IF EXISTS view_2_tab4_655 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_655
+DROP VIEW IF EXISTS view_3_tab4_655 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28483,13 +28483,13 @@ SELECT pk FROM tab0 WHERE col3 >= 210
 72 values hashing to f65119d4d79ec4245a7873330ff2e41f
 
 statement ok
-DROP VIEW view_1_tab0_656
+DROP VIEW IF EXISTS view_1_tab0_656 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_656
+DROP VIEW IF EXISTS view_2_tab0_656 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_656
+DROP VIEW IF EXISTS view_3_tab0_656 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28580,13 +28580,13 @@ SELECT pk FROM tab1 WHERE col3 >= 210
 72 values hashing to f65119d4d79ec4245a7873330ff2e41f
 
 statement ok
-DROP VIEW view_1_tab1_656
+DROP VIEW IF EXISTS view_1_tab1_656 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_656
+DROP VIEW IF EXISTS view_2_tab1_656 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_656
+DROP VIEW IF EXISTS view_3_tab1_656 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28677,13 +28677,13 @@ SELECT pk FROM tab2 WHERE col3 >= 210
 72 values hashing to f65119d4d79ec4245a7873330ff2e41f
 
 statement ok
-DROP VIEW view_1_tab2_656
+DROP VIEW IF EXISTS view_1_tab2_656 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_656
+DROP VIEW IF EXISTS view_2_tab2_656 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_656
+DROP VIEW IF EXISTS view_3_tab2_656 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28774,13 +28774,13 @@ SELECT pk FROM tab3 WHERE col3 >= 210
 72 values hashing to f65119d4d79ec4245a7873330ff2e41f
 
 statement ok
-DROP VIEW view_1_tab3_656
+DROP VIEW IF EXISTS view_1_tab3_656 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_656
+DROP VIEW IF EXISTS view_2_tab3_656 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_656
+DROP VIEW IF EXISTS view_3_tab3_656 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28871,13 +28871,13 @@ SELECT pk FROM tab4 WHERE col3 >= 210
 72 values hashing to f65119d4d79ec4245a7873330ff2e41f
 
 statement ok
-DROP VIEW view_1_tab4_656
+DROP VIEW IF EXISTS view_1_tab4_656 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_656
+DROP VIEW IF EXISTS view_2_tab4_656 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_656
+DROP VIEW IF EXISTS view_3_tab4_656 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28963,13 +28963,13 @@ SELECT pk FROM tab0 WHERE col0 = 157
 ----
 
 statement ok
-DROP VIEW view_1_tab0_657
+DROP VIEW IF EXISTS view_1_tab0_657 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_657
+DROP VIEW IF EXISTS view_2_tab0_657 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_657
+DROP VIEW IF EXISTS view_3_tab0_657 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29055,13 +29055,13 @@ SELECT pk FROM tab1 WHERE col0 = 157
 ----
 
 statement ok
-DROP VIEW view_1_tab1_657
+DROP VIEW IF EXISTS view_1_tab1_657 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_657
+DROP VIEW IF EXISTS view_2_tab1_657 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_657
+DROP VIEW IF EXISTS view_3_tab1_657 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29147,13 +29147,13 @@ SELECT pk FROM tab2 WHERE col0 = 157
 ----
 
 statement ok
-DROP VIEW view_1_tab2_657
+DROP VIEW IF EXISTS view_1_tab2_657 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_657
+DROP VIEW IF EXISTS view_2_tab2_657 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_657
+DROP VIEW IF EXISTS view_3_tab2_657 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29239,13 +29239,13 @@ SELECT pk FROM tab3 WHERE col0 = 157
 ----
 
 statement ok
-DROP VIEW view_1_tab3_657
+DROP VIEW IF EXISTS view_1_tab3_657 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_657
+DROP VIEW IF EXISTS view_2_tab3_657 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_657
+DROP VIEW IF EXISTS view_3_tab3_657 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29331,13 +29331,13 @@ SELECT pk FROM tab4 WHERE col0 = 157
 ----
 
 statement ok
-DROP VIEW view_1_tab4_657
+DROP VIEW IF EXISTS view_1_tab4_657 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_657
+DROP VIEW IF EXISTS view_2_tab4_657 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_657
+DROP VIEW IF EXISTS view_3_tab4_657 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29443,13 +29443,13 @@ SELECT pk FROM tab0 WHERE col3 > 930
 82
 
 statement ok
-DROP VIEW view_1_tab0_658
+DROP VIEW IF EXISTS view_1_tab0_658 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_658
+DROP VIEW IF EXISTS view_2_tab0_658 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_658
+DROP VIEW IF EXISTS view_3_tab0_658 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29555,13 +29555,13 @@ SELECT pk FROM tab1 WHERE col3 > 930
 82
 
 statement ok
-DROP VIEW view_1_tab1_658
+DROP VIEW IF EXISTS view_1_tab1_658 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_658
+DROP VIEW IF EXISTS view_2_tab1_658 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_658
+DROP VIEW IF EXISTS view_3_tab1_658 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29667,13 +29667,13 @@ SELECT pk FROM tab2 WHERE col3 > 930
 82
 
 statement ok
-DROP VIEW view_1_tab2_658
+DROP VIEW IF EXISTS view_1_tab2_658 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_658
+DROP VIEW IF EXISTS view_2_tab2_658 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_658
+DROP VIEW IF EXISTS view_3_tab2_658 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29779,13 +29779,13 @@ SELECT pk FROM tab3 WHERE col3 > 930
 82
 
 statement ok
-DROP VIEW view_1_tab3_658
+DROP VIEW IF EXISTS view_1_tab3_658 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_658
+DROP VIEW IF EXISTS view_2_tab3_658 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_658
+DROP VIEW IF EXISTS view_3_tab3_658 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29891,13 +29891,13 @@ SELECT pk FROM tab4 WHERE col3 > 930
 82
 
 statement ok
-DROP VIEW view_1_tab4_658
+DROP VIEW IF EXISTS view_1_tab4_658 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_658
+DROP VIEW IF EXISTS view_2_tab4_658 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_658
+DROP VIEW IF EXISTS view_3_tab4_658 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29988,13 +29988,13 @@ SELECT pk FROM tab0 WHERE ((col0 >= 575))
 49 values hashing to ccb6d190efd8c9d5e521ae496417a451
 
 statement ok
-DROP VIEW view_1_tab0_659
+DROP VIEW IF EXISTS view_1_tab0_659 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_659
+DROP VIEW IF EXISTS view_2_tab0_659 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_659
+DROP VIEW IF EXISTS view_3_tab0_659 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30085,13 +30085,13 @@ SELECT pk FROM tab1 WHERE ((col0 >= 575))
 49 values hashing to ccb6d190efd8c9d5e521ae496417a451
 
 statement ok
-DROP VIEW view_1_tab1_659
+DROP VIEW IF EXISTS view_1_tab1_659 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_659
+DROP VIEW IF EXISTS view_2_tab1_659 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_659
+DROP VIEW IF EXISTS view_3_tab1_659 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30182,13 +30182,13 @@ SELECT pk FROM tab2 WHERE ((col0 >= 575))
 49 values hashing to ccb6d190efd8c9d5e521ae496417a451
 
 statement ok
-DROP VIEW view_1_tab2_659
+DROP VIEW IF EXISTS view_1_tab2_659 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_659
+DROP VIEW IF EXISTS view_2_tab2_659 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_659
+DROP VIEW IF EXISTS view_3_tab2_659 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30279,13 +30279,13 @@ SELECT pk FROM tab3 WHERE ((col0 >= 575))
 49 values hashing to ccb6d190efd8c9d5e521ae496417a451
 
 statement ok
-DROP VIEW view_1_tab3_659
+DROP VIEW IF EXISTS view_1_tab3_659 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_659
+DROP VIEW IF EXISTS view_2_tab3_659 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_659
+DROP VIEW IF EXISTS view_3_tab3_659 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30376,11 +30376,11 @@ SELECT pk FROM tab4 WHERE ((col0 >= 575))
 49 values hashing to ccb6d190efd8c9d5e521ae496417a451
 
 statement ok
-DROP VIEW view_1_tab4_659
+DROP VIEW IF EXISTS view_1_tab4_659 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_659
+DROP VIEW IF EXISTS view_2_tab4_659 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_659
+DROP VIEW IF EXISTS view_3_tab4_659 CASCADE
 

--- a/test/index/view/100/slt_good_4.test
+++ b/test/index/view/100/slt_good_4.test
@@ -456,13 +456,13 @@ SELECT pk FROM tab0 WHERE (col0 = 888)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_798
+DROP VIEW IF EXISTS view_1_tab0_798 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_798
+DROP VIEW IF EXISTS view_2_tab0_798 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_798
+DROP VIEW IF EXISTS view_3_tab0_798 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -548,13 +548,13 @@ SELECT pk FROM tab1 WHERE (col0 = 888)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_798
+DROP VIEW IF EXISTS view_1_tab1_798 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_798
+DROP VIEW IF EXISTS view_2_tab1_798 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_798
+DROP VIEW IF EXISTS view_3_tab1_798 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -640,13 +640,13 @@ SELECT pk FROM tab2 WHERE (col0 = 888)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_798
+DROP VIEW IF EXISTS view_1_tab2_798 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_798
+DROP VIEW IF EXISTS view_2_tab2_798 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_798
+DROP VIEW IF EXISTS view_3_tab2_798 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -732,13 +732,13 @@ SELECT pk FROM tab3 WHERE (col0 = 888)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_798
+DROP VIEW IF EXISTS view_1_tab3_798 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_798
+DROP VIEW IF EXISTS view_2_tab3_798 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_798
+DROP VIEW IF EXISTS view_3_tab3_798 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -824,13 +824,13 @@ SELECT pk FROM tab4 WHERE (col0 = 888)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_798
+DROP VIEW IF EXISTS view_1_tab4_798 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_798
+DROP VIEW IF EXISTS view_2_tab4_798 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_798
+DROP VIEW IF EXISTS view_3_tab4_798 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -921,13 +921,13 @@ SELECT pk FROM tab0 WHERE col3 IS NULL OR (col3 >= 422 OR (col3 > 734 AND (col3 
 82 values hashing to 9970a5136345a5c90ecf1209a35af03a
 
 statement ok
-DROP VIEW view_1_tab0_799
+DROP VIEW IF EXISTS view_1_tab0_799 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_799
+DROP VIEW IF EXISTS view_2_tab0_799 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_799
+DROP VIEW IF EXISTS view_3_tab0_799 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1018,13 +1018,13 @@ SELECT pk FROM tab1 WHERE col3 IS NULL OR (col3 >= 422 OR (col3 > 734 AND (col3 
 82 values hashing to 9970a5136345a5c90ecf1209a35af03a
 
 statement ok
-DROP VIEW view_1_tab1_799
+DROP VIEW IF EXISTS view_1_tab1_799 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_799
+DROP VIEW IF EXISTS view_2_tab1_799 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_799
+DROP VIEW IF EXISTS view_3_tab1_799 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1115,13 +1115,13 @@ SELECT pk FROM tab2 WHERE col3 IS NULL OR (col3 >= 422 OR (col3 > 734 AND (col3 
 82 values hashing to 9970a5136345a5c90ecf1209a35af03a
 
 statement ok
-DROP VIEW view_1_tab2_799
+DROP VIEW IF EXISTS view_1_tab2_799 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_799
+DROP VIEW IF EXISTS view_2_tab2_799 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_799
+DROP VIEW IF EXISTS view_3_tab2_799 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1212,13 +1212,13 @@ SELECT pk FROM tab3 WHERE col3 IS NULL OR (col3 >= 422 OR (col3 > 734 AND (col3 
 82 values hashing to 9970a5136345a5c90ecf1209a35af03a
 
 statement ok
-DROP VIEW view_1_tab3_799
+DROP VIEW IF EXISTS view_1_tab3_799 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_799
+DROP VIEW IF EXISTS view_2_tab3_799 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_799
+DROP VIEW IF EXISTS view_3_tab3_799 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1309,13 +1309,13 @@ SELECT pk FROM tab4 WHERE col3 IS NULL OR (col3 >= 422 OR (col3 > 734 AND (col3 
 82 values hashing to 9970a5136345a5c90ecf1209a35af03a
 
 statement ok
-DROP VIEW view_1_tab4_799
+DROP VIEW IF EXISTS view_1_tab4_799 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_799
+DROP VIEW IF EXISTS view_2_tab4_799 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_799
+DROP VIEW IF EXISTS view_3_tab4_799 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1406,13 +1406,13 @@ SELECT pk FROM tab0 WHERE col0 > 844
 22 values hashing to 96fe476686da148b25392d0260781739
 
 statement ok
-DROP VIEW view_1_tab0_800
+DROP VIEW IF EXISTS view_1_tab0_800 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_800
+DROP VIEW IF EXISTS view_2_tab0_800 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_800
+DROP VIEW IF EXISTS view_3_tab0_800 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1503,13 +1503,13 @@ SELECT pk FROM tab1 WHERE col0 > 844
 22 values hashing to 96fe476686da148b25392d0260781739
 
 statement ok
-DROP VIEW view_1_tab1_800
+DROP VIEW IF EXISTS view_1_tab1_800 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_800
+DROP VIEW IF EXISTS view_2_tab1_800 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_800
+DROP VIEW IF EXISTS view_3_tab1_800 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1600,13 +1600,13 @@ SELECT pk FROM tab2 WHERE col0 > 844
 22 values hashing to 96fe476686da148b25392d0260781739
 
 statement ok
-DROP VIEW view_1_tab2_800
+DROP VIEW IF EXISTS view_1_tab2_800 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_800
+DROP VIEW IF EXISTS view_2_tab2_800 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_800
+DROP VIEW IF EXISTS view_3_tab2_800 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1697,13 +1697,13 @@ SELECT pk FROM tab3 WHERE col0 > 844
 22 values hashing to 96fe476686da148b25392d0260781739
 
 statement ok
-DROP VIEW view_1_tab3_800
+DROP VIEW IF EXISTS view_1_tab3_800 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_800
+DROP VIEW IF EXISTS view_2_tab3_800 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_800
+DROP VIEW IF EXISTS view_3_tab3_800 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1794,13 +1794,13 @@ SELECT pk FROM tab4 WHERE col0 > 844
 22 values hashing to 96fe476686da148b25392d0260781739
 
 statement ok
-DROP VIEW view_1_tab4_800
+DROP VIEW IF EXISTS view_1_tab4_800 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_800
+DROP VIEW IF EXISTS view_2_tab4_800 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_800
+DROP VIEW IF EXISTS view_3_tab4_800 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1891,13 +1891,13 @@ SELECT pk FROM tab0 WHERE ((col4 >= 485.68 OR col1 <= 935.75 AND col0 = 836))
 50 values hashing to fa9c48c9e9bbf736e6c36f41b507c573
 
 statement ok
-DROP VIEW view_1_tab0_801
+DROP VIEW IF EXISTS view_1_tab0_801 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_801
+DROP VIEW IF EXISTS view_2_tab0_801 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_801
+DROP VIEW IF EXISTS view_3_tab0_801 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1988,13 +1988,13 @@ SELECT pk FROM tab1 WHERE ((col4 >= 485.68 OR col1 <= 935.75 AND col0 = 836))
 50 values hashing to fa9c48c9e9bbf736e6c36f41b507c573
 
 statement ok
-DROP VIEW view_1_tab1_801
+DROP VIEW IF EXISTS view_1_tab1_801 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_801
+DROP VIEW IF EXISTS view_2_tab1_801 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_801
+DROP VIEW IF EXISTS view_3_tab1_801 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2085,13 +2085,13 @@ SELECT pk FROM tab2 WHERE ((col4 >= 485.68 OR col1 <= 935.75 AND col0 = 836))
 50 values hashing to fa9c48c9e9bbf736e6c36f41b507c573
 
 statement ok
-DROP VIEW view_1_tab2_801
+DROP VIEW IF EXISTS view_1_tab2_801 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_801
+DROP VIEW IF EXISTS view_2_tab2_801 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_801
+DROP VIEW IF EXISTS view_3_tab2_801 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2182,13 +2182,13 @@ SELECT pk FROM tab3 WHERE ((col4 >= 485.68 OR col1 <= 935.75 AND col0 = 836))
 50 values hashing to fa9c48c9e9bbf736e6c36f41b507c573
 
 statement ok
-DROP VIEW view_1_tab3_801
+DROP VIEW IF EXISTS view_1_tab3_801 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_801
+DROP VIEW IF EXISTS view_2_tab3_801 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_801
+DROP VIEW IF EXISTS view_3_tab3_801 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2279,13 +2279,13 @@ SELECT pk FROM tab4 WHERE ((col4 >= 485.68 OR col1 <= 935.75 AND col0 = 836))
 50 values hashing to fa9c48c9e9bbf736e6c36f41b507c573
 
 statement ok
-DROP VIEW view_1_tab4_801
+DROP VIEW IF EXISTS view_1_tab4_801 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_801
+DROP VIEW IF EXISTS view_2_tab4_801 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_801
+DROP VIEW IF EXISTS view_3_tab4_801 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2376,13 +2376,13 @@ SELECT pk FROM tab0 WHERE (col4 < 468.15 AND col3 > 163 OR (col0 = 676) AND col0
 56 values hashing to 9c7f84a4ba735af34bdfb30201d6bf09
 
 statement ok
-DROP VIEW view_1_tab0_802
+DROP VIEW IF EXISTS view_1_tab0_802 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_802
+DROP VIEW IF EXISTS view_2_tab0_802 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_802
+DROP VIEW IF EXISTS view_3_tab0_802 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2473,13 +2473,13 @@ SELECT pk FROM tab1 WHERE (col4 < 468.15 AND col3 > 163 OR (col0 = 676) AND col0
 56 values hashing to 9c7f84a4ba735af34bdfb30201d6bf09
 
 statement ok
-DROP VIEW view_1_tab1_802
+DROP VIEW IF EXISTS view_1_tab1_802 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_802
+DROP VIEW IF EXISTS view_2_tab1_802 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_802
+DROP VIEW IF EXISTS view_3_tab1_802 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2570,13 +2570,13 @@ SELECT pk FROM tab2 WHERE (col4 < 468.15 AND col3 > 163 OR (col0 = 676) AND col0
 56 values hashing to 9c7f84a4ba735af34bdfb30201d6bf09
 
 statement ok
-DROP VIEW view_1_tab2_802
+DROP VIEW IF EXISTS view_1_tab2_802 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_802
+DROP VIEW IF EXISTS view_2_tab2_802 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_802
+DROP VIEW IF EXISTS view_3_tab2_802 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2667,13 +2667,13 @@ SELECT pk FROM tab3 WHERE (col4 < 468.15 AND col3 > 163 OR (col0 = 676) AND col0
 56 values hashing to 9c7f84a4ba735af34bdfb30201d6bf09
 
 statement ok
-DROP VIEW view_1_tab3_802
+DROP VIEW IF EXISTS view_1_tab3_802 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_802
+DROP VIEW IF EXISTS view_2_tab3_802 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_802
+DROP VIEW IF EXISTS view_3_tab3_802 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2764,13 +2764,13 @@ SELECT pk FROM tab4 WHERE (col4 < 468.15 AND col3 > 163 OR (col0 = 676) AND col0
 56 values hashing to 9c7f84a4ba735af34bdfb30201d6bf09
 
 statement ok
-DROP VIEW view_1_tab4_802
+DROP VIEW IF EXISTS view_1_tab4_802 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_802
+DROP VIEW IF EXISTS view_2_tab4_802 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_802
+DROP VIEW IF EXISTS view_3_tab4_802 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2856,13 +2856,13 @@ SELECT pk FROM tab0 WHERE col0 = 307 AND col0 > 413 OR col3 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab0_803
+DROP VIEW IF EXISTS view_1_tab0_803 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_803
+DROP VIEW IF EXISTS view_2_tab0_803 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_803
+DROP VIEW IF EXISTS view_3_tab0_803 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2948,13 +2948,13 @@ SELECT pk FROM tab1 WHERE col0 = 307 AND col0 > 413 OR col3 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab1_803
+DROP VIEW IF EXISTS view_1_tab1_803 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_803
+DROP VIEW IF EXISTS view_2_tab1_803 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_803
+DROP VIEW IF EXISTS view_3_tab1_803 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3040,13 +3040,13 @@ SELECT pk FROM tab2 WHERE col0 = 307 AND col0 > 413 OR col3 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab2_803
+DROP VIEW IF EXISTS view_1_tab2_803 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_803
+DROP VIEW IF EXISTS view_2_tab2_803 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_803
+DROP VIEW IF EXISTS view_3_tab2_803 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3132,13 +3132,13 @@ SELECT pk FROM tab3 WHERE col0 = 307 AND col0 > 413 OR col3 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab3_803
+DROP VIEW IF EXISTS view_1_tab3_803 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_803
+DROP VIEW IF EXISTS view_2_tab3_803 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_803
+DROP VIEW IF EXISTS view_3_tab3_803 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3224,13 +3224,13 @@ SELECT pk FROM tab4 WHERE col0 = 307 AND col0 > 413 OR col3 IS NULL
 ----
 
 statement ok
-DROP VIEW view_1_tab4_803
+DROP VIEW IF EXISTS view_1_tab4_803 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_803
+DROP VIEW IF EXISTS view_2_tab4_803 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_803
+DROP VIEW IF EXISTS view_3_tab4_803 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3330,13 +3330,13 @@ SELECT pk FROM tab0 WHERE col4 > 627.65 AND col3 < 323 AND ((col1 <= 267.93)) AN
 47
 
 statement ok
-DROP VIEW view_1_tab0_804
+DROP VIEW IF EXISTS view_1_tab0_804 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_804
+DROP VIEW IF EXISTS view_2_tab0_804 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_804
+DROP VIEW IF EXISTS view_3_tab0_804 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3436,13 +3436,13 @@ SELECT pk FROM tab1 WHERE col4 > 627.65 AND col3 < 323 AND ((col1 <= 267.93)) AN
 47
 
 statement ok
-DROP VIEW view_1_tab1_804
+DROP VIEW IF EXISTS view_1_tab1_804 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_804
+DROP VIEW IF EXISTS view_2_tab1_804 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_804
+DROP VIEW IF EXISTS view_3_tab1_804 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3542,13 +3542,13 @@ SELECT pk FROM tab2 WHERE col4 > 627.65 AND col3 < 323 AND ((col1 <= 267.93)) AN
 47
 
 statement ok
-DROP VIEW view_1_tab2_804
+DROP VIEW IF EXISTS view_1_tab2_804 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_804
+DROP VIEW IF EXISTS view_2_tab2_804 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_804
+DROP VIEW IF EXISTS view_3_tab2_804 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3648,13 +3648,13 @@ SELECT pk FROM tab3 WHERE col4 > 627.65 AND col3 < 323 AND ((col1 <= 267.93)) AN
 47
 
 statement ok
-DROP VIEW view_1_tab3_804
+DROP VIEW IF EXISTS view_1_tab3_804 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_804
+DROP VIEW IF EXISTS view_2_tab3_804 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_804
+DROP VIEW IF EXISTS view_3_tab3_804 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3754,13 +3754,13 @@ SELECT pk FROM tab4 WHERE col4 > 627.65 AND col3 < 323 AND ((col1 <= 267.93)) AN
 47
 
 statement ok
-DROP VIEW view_1_tab4_804
+DROP VIEW IF EXISTS view_1_tab4_804 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_804
+DROP VIEW IF EXISTS view_2_tab4_804 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_804
+DROP VIEW IF EXISTS view_3_tab4_804 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3851,13 +3851,13 @@ SELECT pk FROM tab0 WHERE col3 >= 454
 62 values hashing to fc4c22afadb1a3ea4ba5c17164de8b68
 
 statement ok
-DROP VIEW view_1_tab0_805
+DROP VIEW IF EXISTS view_1_tab0_805 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_805
+DROP VIEW IF EXISTS view_2_tab0_805 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_805
+DROP VIEW IF EXISTS view_3_tab0_805 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3948,13 +3948,13 @@ SELECT pk FROM tab1 WHERE col3 >= 454
 62 values hashing to fc4c22afadb1a3ea4ba5c17164de8b68
 
 statement ok
-DROP VIEW view_1_tab1_805
+DROP VIEW IF EXISTS view_1_tab1_805 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_805
+DROP VIEW IF EXISTS view_2_tab1_805 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_805
+DROP VIEW IF EXISTS view_3_tab1_805 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4045,13 +4045,13 @@ SELECT pk FROM tab2 WHERE col3 >= 454
 62 values hashing to fc4c22afadb1a3ea4ba5c17164de8b68
 
 statement ok
-DROP VIEW view_1_tab2_805
+DROP VIEW IF EXISTS view_1_tab2_805 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_805
+DROP VIEW IF EXISTS view_2_tab2_805 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_805
+DROP VIEW IF EXISTS view_3_tab2_805 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4142,13 +4142,13 @@ SELECT pk FROM tab3 WHERE col3 >= 454
 62 values hashing to fc4c22afadb1a3ea4ba5c17164de8b68
 
 statement ok
-DROP VIEW view_1_tab3_805
+DROP VIEW IF EXISTS view_1_tab3_805 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_805
+DROP VIEW IF EXISTS view_2_tab3_805 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_805
+DROP VIEW IF EXISTS view_3_tab3_805 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4239,13 +4239,13 @@ SELECT pk FROM tab4 WHERE col3 >= 454
 62 values hashing to fc4c22afadb1a3ea4ba5c17164de8b68
 
 statement ok
-DROP VIEW view_1_tab4_805
+DROP VIEW IF EXISTS view_1_tab4_805 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_805
+DROP VIEW IF EXISTS view_2_tab4_805 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_805
+DROP VIEW IF EXISTS view_3_tab4_805 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4338,13 +4338,13 @@ SELECT pk FROM tab0 WHERE ((col0 >= 9))
 99 values hashing to bac6cf5ee2072074c6851542bb2a5c96
 
 statement ok
-DROP VIEW view_1_tab0_806
+DROP VIEW IF EXISTS view_1_tab0_806 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_806
+DROP VIEW IF EXISTS view_2_tab0_806 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_806
+DROP VIEW IF EXISTS view_3_tab0_806 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4437,13 +4437,13 @@ SELECT pk FROM tab1 WHERE ((col0 >= 9))
 99 values hashing to bac6cf5ee2072074c6851542bb2a5c96
 
 statement ok
-DROP VIEW view_1_tab1_806
+DROP VIEW IF EXISTS view_1_tab1_806 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_806
+DROP VIEW IF EXISTS view_2_tab1_806 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_806
+DROP VIEW IF EXISTS view_3_tab1_806 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4536,13 +4536,13 @@ SELECT pk FROM tab2 WHERE ((col0 >= 9))
 99 values hashing to bac6cf5ee2072074c6851542bb2a5c96
 
 statement ok
-DROP VIEW view_1_tab2_806
+DROP VIEW IF EXISTS view_1_tab2_806 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_806
+DROP VIEW IF EXISTS view_2_tab2_806 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_806
+DROP VIEW IF EXISTS view_3_tab2_806 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4635,13 +4635,13 @@ SELECT pk FROM tab3 WHERE ((col0 >= 9))
 99 values hashing to bac6cf5ee2072074c6851542bb2a5c96
 
 statement ok
-DROP VIEW view_1_tab3_806
+DROP VIEW IF EXISTS view_1_tab3_806 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_806
+DROP VIEW IF EXISTS view_2_tab3_806 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_806
+DROP VIEW IF EXISTS view_3_tab3_806 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4734,13 +4734,13 @@ SELECT pk FROM tab4 WHERE ((col0 >= 9))
 99 values hashing to bac6cf5ee2072074c6851542bb2a5c96
 
 statement ok
-DROP VIEW view_1_tab4_806
+DROP VIEW IF EXISTS view_1_tab4_806 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_806
+DROP VIEW IF EXISTS view_2_tab4_806 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_806
+DROP VIEW IF EXISTS view_3_tab4_806 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4826,13 +4826,13 @@ SELECT pk FROM tab0 WHERE col4 <= 330.87 AND (col1 IN (407.60,346.33,55.94,650.6
 ----
 
 statement ok
-DROP VIEW view_1_tab0_807
+DROP VIEW IF EXISTS view_1_tab0_807 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_807
+DROP VIEW IF EXISTS view_2_tab0_807 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_807
+DROP VIEW IF EXISTS view_3_tab0_807 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4918,13 +4918,13 @@ SELECT pk FROM tab1 WHERE col4 <= 330.87 AND (col1 IN (407.60,346.33,55.94,650.6
 ----
 
 statement ok
-DROP VIEW view_1_tab1_807
+DROP VIEW IF EXISTS view_1_tab1_807 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_807
+DROP VIEW IF EXISTS view_2_tab1_807 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_807
+DROP VIEW IF EXISTS view_3_tab1_807 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5010,13 +5010,13 @@ SELECT pk FROM tab2 WHERE col4 <= 330.87 AND (col1 IN (407.60,346.33,55.94,650.6
 ----
 
 statement ok
-DROP VIEW view_1_tab2_807
+DROP VIEW IF EXISTS view_1_tab2_807 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_807
+DROP VIEW IF EXISTS view_2_tab2_807 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_807
+DROP VIEW IF EXISTS view_3_tab2_807 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5102,13 +5102,13 @@ SELECT pk FROM tab3 WHERE col4 <= 330.87 AND (col1 IN (407.60,346.33,55.94,650.6
 ----
 
 statement ok
-DROP VIEW view_1_tab3_807
+DROP VIEW IF EXISTS view_1_tab3_807 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_807
+DROP VIEW IF EXISTS view_2_tab3_807 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_807
+DROP VIEW IF EXISTS view_3_tab3_807 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5194,13 +5194,13 @@ SELECT pk FROM tab4 WHERE col4 <= 330.87 AND (col1 IN (407.60,346.33,55.94,650.6
 ----
 
 statement ok
-DROP VIEW view_1_tab4_807
+DROP VIEW IF EXISTS view_1_tab4_807 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_807
+DROP VIEW IF EXISTS view_2_tab4_807 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_807
+DROP VIEW IF EXISTS view_3_tab4_807 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5291,13 +5291,13 @@ SELECT pk FROM tab0 WHERE col4 > 360.72
 62 values hashing to fd82df81677c15289fe0e5650e601d27
 
 statement ok
-DROP VIEW view_1_tab0_808
+DROP VIEW IF EXISTS view_1_tab0_808 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_808
+DROP VIEW IF EXISTS view_2_tab0_808 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_808
+DROP VIEW IF EXISTS view_3_tab0_808 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5388,13 +5388,13 @@ SELECT pk FROM tab1 WHERE col4 > 360.72
 62 values hashing to fd82df81677c15289fe0e5650e601d27
 
 statement ok
-DROP VIEW view_1_tab1_808
+DROP VIEW IF EXISTS view_1_tab1_808 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_808
+DROP VIEW IF EXISTS view_2_tab1_808 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_808
+DROP VIEW IF EXISTS view_3_tab1_808 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5485,13 +5485,13 @@ SELECT pk FROM tab2 WHERE col4 > 360.72
 62 values hashing to fd82df81677c15289fe0e5650e601d27
 
 statement ok
-DROP VIEW view_1_tab2_808
+DROP VIEW IF EXISTS view_1_tab2_808 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_808
+DROP VIEW IF EXISTS view_2_tab2_808 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_808
+DROP VIEW IF EXISTS view_3_tab2_808 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5582,13 +5582,13 @@ SELECT pk FROM tab3 WHERE col4 > 360.72
 62 values hashing to fd82df81677c15289fe0e5650e601d27
 
 statement ok
-DROP VIEW view_1_tab3_808
+DROP VIEW IF EXISTS view_1_tab3_808 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_808
+DROP VIEW IF EXISTS view_2_tab3_808 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_808
+DROP VIEW IF EXISTS view_3_tab3_808 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5679,13 +5679,13 @@ SELECT pk FROM tab4 WHERE col4 > 360.72
 62 values hashing to fd82df81677c15289fe0e5650e601d27
 
 statement ok
-DROP VIEW view_1_tab4_808
+DROP VIEW IF EXISTS view_1_tab4_808 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_808
+DROP VIEW IF EXISTS view_2_tab4_808 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_808
+DROP VIEW IF EXISTS view_3_tab4_808 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5776,13 +5776,13 @@ SELECT pk FROM tab0 WHERE ((col3 < 745 AND col1 >= 529.81 OR col1 > 630.95 OR (c
 67 values hashing to 36f5eec3dad572ec8f6275c28e26024e
 
 statement ok
-DROP VIEW view_1_tab0_810
+DROP VIEW IF EXISTS view_1_tab0_810 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_810
+DROP VIEW IF EXISTS view_2_tab0_810 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_810
+DROP VIEW IF EXISTS view_3_tab0_810 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5873,13 +5873,13 @@ SELECT pk FROM tab1 WHERE ((col3 < 745 AND col1 >= 529.81 OR col1 > 630.95 OR (c
 67 values hashing to 36f5eec3dad572ec8f6275c28e26024e
 
 statement ok
-DROP VIEW view_1_tab1_810
+DROP VIEW IF EXISTS view_1_tab1_810 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_810
+DROP VIEW IF EXISTS view_2_tab1_810 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_810
+DROP VIEW IF EXISTS view_3_tab1_810 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5970,13 +5970,13 @@ SELECT pk FROM tab2 WHERE ((col3 < 745 AND col1 >= 529.81 OR col1 > 630.95 OR (c
 67 values hashing to 36f5eec3dad572ec8f6275c28e26024e
 
 statement ok
-DROP VIEW view_1_tab2_810
+DROP VIEW IF EXISTS view_1_tab2_810 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_810
+DROP VIEW IF EXISTS view_2_tab2_810 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_810
+DROP VIEW IF EXISTS view_3_tab2_810 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6067,13 +6067,13 @@ SELECT pk FROM tab3 WHERE ((col3 < 745 AND col1 >= 529.81 OR col1 > 630.95 OR (c
 67 values hashing to 36f5eec3dad572ec8f6275c28e26024e
 
 statement ok
-DROP VIEW view_1_tab3_810
+DROP VIEW IF EXISTS view_1_tab3_810 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_810
+DROP VIEW IF EXISTS view_2_tab3_810 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_810
+DROP VIEW IF EXISTS view_3_tab3_810 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6164,13 +6164,13 @@ SELECT pk FROM tab4 WHERE ((col3 < 745 AND col1 >= 529.81 OR col1 > 630.95 OR (c
 67 values hashing to 36f5eec3dad572ec8f6275c28e26024e
 
 statement ok
-DROP VIEW view_1_tab4_810
+DROP VIEW IF EXISTS view_1_tab4_810 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_810
+DROP VIEW IF EXISTS view_2_tab4_810 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_810
+DROP VIEW IF EXISTS view_3_tab4_810 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6263,13 +6263,13 @@ SELECT pk FROM tab0 WHERE (col3 <= 515 AND (((col3 IN (25,177,820,947,826,625) O
 99 values hashing to c9d09709e576f181d867541892fc042a
 
 statement ok
-DROP VIEW view_1_tab0_811
+DROP VIEW IF EXISTS view_1_tab0_811 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_811
+DROP VIEW IF EXISTS view_2_tab0_811 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_811
+DROP VIEW IF EXISTS view_3_tab0_811 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6362,13 +6362,13 @@ SELECT pk FROM tab1 WHERE (col3 <= 515 AND (((col3 IN (25,177,820,947,826,625) O
 99 values hashing to c9d09709e576f181d867541892fc042a
 
 statement ok
-DROP VIEW view_1_tab1_811
+DROP VIEW IF EXISTS view_1_tab1_811 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_811
+DROP VIEW IF EXISTS view_2_tab1_811 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_811
+DROP VIEW IF EXISTS view_3_tab1_811 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6461,13 +6461,13 @@ SELECT pk FROM tab2 WHERE (col3 <= 515 AND (((col3 IN (25,177,820,947,826,625) O
 99 values hashing to c9d09709e576f181d867541892fc042a
 
 statement ok
-DROP VIEW view_1_tab2_811
+DROP VIEW IF EXISTS view_1_tab2_811 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_811
+DROP VIEW IF EXISTS view_2_tab2_811 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_811
+DROP VIEW IF EXISTS view_3_tab2_811 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6560,13 +6560,13 @@ SELECT pk FROM tab3 WHERE (col3 <= 515 AND (((col3 IN (25,177,820,947,826,625) O
 99 values hashing to c9d09709e576f181d867541892fc042a
 
 statement ok
-DROP VIEW view_1_tab3_811
+DROP VIEW IF EXISTS view_1_tab3_811 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_811
+DROP VIEW IF EXISTS view_2_tab3_811 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_811
+DROP VIEW IF EXISTS view_3_tab3_811 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6659,13 +6659,13 @@ SELECT pk FROM tab4 WHERE (col3 <= 515 AND (((col3 IN (25,177,820,947,826,625) O
 99 values hashing to c9d09709e576f181d867541892fc042a
 
 statement ok
-DROP VIEW view_1_tab4_811
+DROP VIEW IF EXISTS view_1_tab4_811 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_811
+DROP VIEW IF EXISTS view_2_tab4_811 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_811
+DROP VIEW IF EXISTS view_3_tab4_811 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6758,13 +6758,13 @@ SELECT pk FROM tab0 WHERE col0 IN (752,49,495,682)
 49
 
 statement ok
-DROP VIEW view_1_tab0_813
+DROP VIEW IF EXISTS view_1_tab0_813 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_813
+DROP VIEW IF EXISTS view_2_tab0_813 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_813
+DROP VIEW IF EXISTS view_3_tab0_813 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6857,13 +6857,13 @@ SELECT pk FROM tab1 WHERE col0 IN (752,49,495,682)
 49
 
 statement ok
-DROP VIEW view_1_tab1_813
+DROP VIEW IF EXISTS view_1_tab1_813 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_813
+DROP VIEW IF EXISTS view_2_tab1_813 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_813
+DROP VIEW IF EXISTS view_3_tab1_813 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6956,13 +6956,13 @@ SELECT pk FROM tab2 WHERE col0 IN (752,49,495,682)
 49
 
 statement ok
-DROP VIEW view_1_tab2_813
+DROP VIEW IF EXISTS view_1_tab2_813 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_813
+DROP VIEW IF EXISTS view_2_tab2_813 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_813
+DROP VIEW IF EXISTS view_3_tab2_813 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7055,13 +7055,13 @@ SELECT pk FROM tab3 WHERE col0 IN (752,49,495,682)
 49
 
 statement ok
-DROP VIEW view_1_tab3_813
+DROP VIEW IF EXISTS view_1_tab3_813 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_813
+DROP VIEW IF EXISTS view_2_tab3_813 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_813
+DROP VIEW IF EXISTS view_3_tab3_813 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7154,13 +7154,13 @@ SELECT pk FROM tab4 WHERE col0 IN (752,49,495,682)
 49
 
 statement ok
-DROP VIEW view_1_tab4_813
+DROP VIEW IF EXISTS view_1_tab4_813 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_813
+DROP VIEW IF EXISTS view_2_tab4_813 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_813
+DROP VIEW IF EXISTS view_3_tab4_813 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7246,13 +7246,13 @@ SELECT pk FROM tab0 WHERE (col1 = 156.80 AND col0 < 589)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_814
+DROP VIEW IF EXISTS view_1_tab0_814 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_814
+DROP VIEW IF EXISTS view_2_tab0_814 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_814
+DROP VIEW IF EXISTS view_3_tab0_814 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7338,13 +7338,13 @@ SELECT pk FROM tab1 WHERE (col1 = 156.80 AND col0 < 589)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_814
+DROP VIEW IF EXISTS view_1_tab1_814 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_814
+DROP VIEW IF EXISTS view_2_tab1_814 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_814
+DROP VIEW IF EXISTS view_3_tab1_814 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7430,13 +7430,13 @@ SELECT pk FROM tab2 WHERE (col1 = 156.80 AND col0 < 589)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_814
+DROP VIEW IF EXISTS view_1_tab2_814 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_814
+DROP VIEW IF EXISTS view_2_tab2_814 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_814
+DROP VIEW IF EXISTS view_3_tab2_814 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7522,13 +7522,13 @@ SELECT pk FROM tab3 WHERE (col1 = 156.80 AND col0 < 589)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_814
+DROP VIEW IF EXISTS view_1_tab3_814 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_814
+DROP VIEW IF EXISTS view_2_tab3_814 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_814
+DROP VIEW IF EXISTS view_3_tab3_814 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7614,13 +7614,13 @@ SELECT pk FROM tab4 WHERE (col1 = 156.80 AND col0 < 589)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_814
+DROP VIEW IF EXISTS view_1_tab4_814 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_814
+DROP VIEW IF EXISTS view_2_tab4_814 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_814
+DROP VIEW IF EXISTS view_3_tab4_814 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7706,13 +7706,13 @@ SELECT pk FROM tab0 WHERE col4 >= 54.81 AND (col0 < 14) AND (col3 IS NULL OR (co
 ----
 
 statement ok
-DROP VIEW view_1_tab0_815
+DROP VIEW IF EXISTS view_1_tab0_815 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_815
+DROP VIEW IF EXISTS view_2_tab0_815 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_815
+DROP VIEW IF EXISTS view_3_tab0_815 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7798,13 +7798,13 @@ SELECT pk FROM tab1 WHERE col4 >= 54.81 AND (col0 < 14) AND (col3 IS NULL OR (co
 ----
 
 statement ok
-DROP VIEW view_1_tab1_815
+DROP VIEW IF EXISTS view_1_tab1_815 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_815
+DROP VIEW IF EXISTS view_2_tab1_815 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_815
+DROP VIEW IF EXISTS view_3_tab1_815 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7890,13 +7890,13 @@ SELECT pk FROM tab2 WHERE col4 >= 54.81 AND (col0 < 14) AND (col3 IS NULL OR (co
 ----
 
 statement ok
-DROP VIEW view_1_tab2_815
+DROP VIEW IF EXISTS view_1_tab2_815 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_815
+DROP VIEW IF EXISTS view_2_tab2_815 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_815
+DROP VIEW IF EXISTS view_3_tab2_815 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7982,13 +7982,13 @@ SELECT pk FROM tab3 WHERE col4 >= 54.81 AND (col0 < 14) AND (col3 IS NULL OR (co
 ----
 
 statement ok
-DROP VIEW view_1_tab3_815
+DROP VIEW IF EXISTS view_1_tab3_815 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_815
+DROP VIEW IF EXISTS view_2_tab3_815 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_815
+DROP VIEW IF EXISTS view_3_tab3_815 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8074,13 +8074,13 @@ SELECT pk FROM tab4 WHERE col4 >= 54.81 AND (col0 < 14) AND (col3 IS NULL OR (co
 ----
 
 statement ok
-DROP VIEW view_1_tab4_815
+DROP VIEW IF EXISTS view_1_tab4_815 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_815
+DROP VIEW IF EXISTS view_2_tab4_815 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_815
+DROP VIEW IF EXISTS view_3_tab4_815 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8166,13 +8166,13 @@ SELECT pk FROM tab0 WHERE col0 BETWEEN 404 AND 372
 ----
 
 statement ok
-DROP VIEW view_1_tab0_816
+DROP VIEW IF EXISTS view_1_tab0_816 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_816
+DROP VIEW IF EXISTS view_2_tab0_816 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_816
+DROP VIEW IF EXISTS view_3_tab0_816 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8258,13 +8258,13 @@ SELECT pk FROM tab1 WHERE col0 BETWEEN 404 AND 372
 ----
 
 statement ok
-DROP VIEW view_1_tab1_816
+DROP VIEW IF EXISTS view_1_tab1_816 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_816
+DROP VIEW IF EXISTS view_2_tab1_816 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_816
+DROP VIEW IF EXISTS view_3_tab1_816 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8350,13 +8350,13 @@ SELECT pk FROM tab2 WHERE col0 BETWEEN 404 AND 372
 ----
 
 statement ok
-DROP VIEW view_1_tab2_816
+DROP VIEW IF EXISTS view_1_tab2_816 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_816
+DROP VIEW IF EXISTS view_2_tab2_816 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_816
+DROP VIEW IF EXISTS view_3_tab2_816 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8442,13 +8442,13 @@ SELECT pk FROM tab3 WHERE col0 BETWEEN 404 AND 372
 ----
 
 statement ok
-DROP VIEW view_1_tab3_816
+DROP VIEW IF EXISTS view_1_tab3_816 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_816
+DROP VIEW IF EXISTS view_2_tab3_816 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_816
+DROP VIEW IF EXISTS view_3_tab3_816 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8534,13 +8534,13 @@ SELECT pk FROM tab4 WHERE col0 BETWEEN 404 AND 372
 ----
 
 statement ok
-DROP VIEW view_1_tab4_816
+DROP VIEW IF EXISTS view_1_tab4_816 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_816
+DROP VIEW IF EXISTS view_2_tab4_816 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_816
+DROP VIEW IF EXISTS view_3_tab4_816 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8649,13 +8649,13 @@ SELECT pk FROM tab0 WHERE col4 > 933.53
 91
 
 statement ok
-DROP VIEW view_1_tab0_817
+DROP VIEW IF EXISTS view_1_tab0_817 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_817
+DROP VIEW IF EXISTS view_2_tab0_817 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_817
+DROP VIEW IF EXISTS view_3_tab0_817 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8764,13 +8764,13 @@ SELECT pk FROM tab1 WHERE col4 > 933.53
 91
 
 statement ok
-DROP VIEW view_1_tab1_817
+DROP VIEW IF EXISTS view_1_tab1_817 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_817
+DROP VIEW IF EXISTS view_2_tab1_817 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_817
+DROP VIEW IF EXISTS view_3_tab1_817 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8879,13 +8879,13 @@ SELECT pk FROM tab2 WHERE col4 > 933.53
 91
 
 statement ok
-DROP VIEW view_1_tab2_817
+DROP VIEW IF EXISTS view_1_tab2_817 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_817
+DROP VIEW IF EXISTS view_2_tab2_817 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_817
+DROP VIEW IF EXISTS view_3_tab2_817 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8994,13 +8994,13 @@ SELECT pk FROM tab3 WHERE col4 > 933.53
 91
 
 statement ok
-DROP VIEW view_1_tab3_817
+DROP VIEW IF EXISTS view_1_tab3_817 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_817
+DROP VIEW IF EXISTS view_2_tab3_817 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_817
+DROP VIEW IF EXISTS view_3_tab3_817 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9109,13 +9109,13 @@ SELECT pk FROM tab4 WHERE col4 > 933.53
 91
 
 statement ok
-DROP VIEW view_1_tab4_817
+DROP VIEW IF EXISTS view_1_tab4_817 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_817
+DROP VIEW IF EXISTS view_2_tab4_817 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_817
+DROP VIEW IF EXISTS view_3_tab4_817 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9206,13 +9206,13 @@ SELECT pk FROM tab0 WHERE col0 < 283
 24 values hashing to acd4eb5f094fbac871bcf91fac9fc673
 
 statement ok
-DROP VIEW view_1_tab0_818
+DROP VIEW IF EXISTS view_1_tab0_818 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_818
+DROP VIEW IF EXISTS view_2_tab0_818 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_818
+DROP VIEW IF EXISTS view_3_tab0_818 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9303,13 +9303,13 @@ SELECT pk FROM tab1 WHERE col0 < 283
 24 values hashing to acd4eb5f094fbac871bcf91fac9fc673
 
 statement ok
-DROP VIEW view_1_tab1_818
+DROP VIEW IF EXISTS view_1_tab1_818 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_818
+DROP VIEW IF EXISTS view_2_tab1_818 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_818
+DROP VIEW IF EXISTS view_3_tab1_818 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9400,13 +9400,13 @@ SELECT pk FROM tab2 WHERE col0 < 283
 24 values hashing to acd4eb5f094fbac871bcf91fac9fc673
 
 statement ok
-DROP VIEW view_1_tab2_818
+DROP VIEW IF EXISTS view_1_tab2_818 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_818
+DROP VIEW IF EXISTS view_2_tab2_818 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_818
+DROP VIEW IF EXISTS view_3_tab2_818 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9497,13 +9497,13 @@ SELECT pk FROM tab3 WHERE col0 < 283
 24 values hashing to acd4eb5f094fbac871bcf91fac9fc673
 
 statement ok
-DROP VIEW view_1_tab3_818
+DROP VIEW IF EXISTS view_1_tab3_818 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_818
+DROP VIEW IF EXISTS view_2_tab3_818 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_818
+DROP VIEW IF EXISTS view_3_tab3_818 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9594,13 +9594,13 @@ SELECT pk FROM tab4 WHERE col0 < 283
 24 values hashing to acd4eb5f094fbac871bcf91fac9fc673
 
 statement ok
-DROP VIEW view_1_tab4_818
+DROP VIEW IF EXISTS view_1_tab4_818 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_818
+DROP VIEW IF EXISTS view_2_tab4_818 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_818
+DROP VIEW IF EXISTS view_3_tab4_818 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9691,13 +9691,13 @@ SELECT pk FROM tab0 WHERE (col0 < 774) AND col3 >= 398 OR col3 IS NULL AND col0 
 53 values hashing to 39b80419a883293fdb478a649151dbc7
 
 statement ok
-DROP VIEW view_1_tab0_819
+DROP VIEW IF EXISTS view_1_tab0_819 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_819
+DROP VIEW IF EXISTS view_2_tab0_819 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_819
+DROP VIEW IF EXISTS view_3_tab0_819 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9788,13 +9788,13 @@ SELECT pk FROM tab1 WHERE (col0 < 774) AND col3 >= 398 OR col3 IS NULL AND col0 
 53 values hashing to 39b80419a883293fdb478a649151dbc7
 
 statement ok
-DROP VIEW view_1_tab1_819
+DROP VIEW IF EXISTS view_1_tab1_819 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_819
+DROP VIEW IF EXISTS view_2_tab1_819 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_819
+DROP VIEW IF EXISTS view_3_tab1_819 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9885,13 +9885,13 @@ SELECT pk FROM tab2 WHERE (col0 < 774) AND col3 >= 398 OR col3 IS NULL AND col0 
 53 values hashing to 39b80419a883293fdb478a649151dbc7
 
 statement ok
-DROP VIEW view_1_tab2_819
+DROP VIEW IF EXISTS view_1_tab2_819 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_819
+DROP VIEW IF EXISTS view_2_tab2_819 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_819
+DROP VIEW IF EXISTS view_3_tab2_819 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9982,13 +9982,13 @@ SELECT pk FROM tab3 WHERE (col0 < 774) AND col3 >= 398 OR col3 IS NULL AND col0 
 53 values hashing to 39b80419a883293fdb478a649151dbc7
 
 statement ok
-DROP VIEW view_1_tab3_819
+DROP VIEW IF EXISTS view_1_tab3_819 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_819
+DROP VIEW IF EXISTS view_2_tab3_819 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_819
+DROP VIEW IF EXISTS view_3_tab3_819 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10079,13 +10079,13 @@ SELECT pk FROM tab4 WHERE (col0 < 774) AND col3 >= 398 OR col3 IS NULL AND col0 
 53 values hashing to 39b80419a883293fdb478a649151dbc7
 
 statement ok
-DROP VIEW view_1_tab4_819
+DROP VIEW IF EXISTS view_1_tab4_819 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_819
+DROP VIEW IF EXISTS view_2_tab4_819 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_819
+DROP VIEW IF EXISTS view_3_tab4_819 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10176,13 +10176,13 @@ SELECT pk FROM tab0 WHERE col3 < 234 AND ((col3 >= 356) AND col4 > 37.42 OR (col
 16 values hashing to 169250f5cee130b887c1b14effaa42ae
 
 statement ok
-DROP VIEW view_1_tab0_820
+DROP VIEW IF EXISTS view_1_tab0_820 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_820
+DROP VIEW IF EXISTS view_2_tab0_820 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_820
+DROP VIEW IF EXISTS view_3_tab0_820 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10273,13 +10273,13 @@ SELECT pk FROM tab1 WHERE col3 < 234 AND ((col3 >= 356) AND col4 > 37.42 OR (col
 16 values hashing to 169250f5cee130b887c1b14effaa42ae
 
 statement ok
-DROP VIEW view_1_tab1_820
+DROP VIEW IF EXISTS view_1_tab1_820 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_820
+DROP VIEW IF EXISTS view_2_tab1_820 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_820
+DROP VIEW IF EXISTS view_3_tab1_820 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10370,13 +10370,13 @@ SELECT pk FROM tab2 WHERE col3 < 234 AND ((col3 >= 356) AND col4 > 37.42 OR (col
 16 values hashing to 169250f5cee130b887c1b14effaa42ae
 
 statement ok
-DROP VIEW view_1_tab2_820
+DROP VIEW IF EXISTS view_1_tab2_820 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_820
+DROP VIEW IF EXISTS view_2_tab2_820 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_820
+DROP VIEW IF EXISTS view_3_tab2_820 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10467,13 +10467,13 @@ SELECT pk FROM tab3 WHERE col3 < 234 AND ((col3 >= 356) AND col4 > 37.42 OR (col
 16 values hashing to 169250f5cee130b887c1b14effaa42ae
 
 statement ok
-DROP VIEW view_1_tab3_820
+DROP VIEW IF EXISTS view_1_tab3_820 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_820
+DROP VIEW IF EXISTS view_2_tab3_820 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_820
+DROP VIEW IF EXISTS view_3_tab3_820 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10564,13 +10564,13 @@ SELECT pk FROM tab4 WHERE col3 < 234 AND ((col3 >= 356) AND col4 > 37.42 OR (col
 16 values hashing to 169250f5cee130b887c1b14effaa42ae
 
 statement ok
-DROP VIEW view_1_tab4_820
+DROP VIEW IF EXISTS view_1_tab4_820 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_820
+DROP VIEW IF EXISTS view_2_tab4_820 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_820
+DROP VIEW IF EXISTS view_3_tab4_820 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10661,13 +10661,13 @@ SELECT pk FROM tab0 WHERE ((col0 = 465) AND col0 BETWEEN 547 AND 973 OR col3 > 6
 22 values hashing to fa560d564065cba63efa2c98c96dd927
 
 statement ok
-DROP VIEW view_1_tab0_821
+DROP VIEW IF EXISTS view_1_tab0_821 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_821
+DROP VIEW IF EXISTS view_2_tab0_821 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_821
+DROP VIEW IF EXISTS view_3_tab0_821 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10758,13 +10758,13 @@ SELECT pk FROM tab1 WHERE ((col0 = 465) AND col0 BETWEEN 547 AND 973 OR col3 > 6
 22 values hashing to fa560d564065cba63efa2c98c96dd927
 
 statement ok
-DROP VIEW view_1_tab1_821
+DROP VIEW IF EXISTS view_1_tab1_821 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_821
+DROP VIEW IF EXISTS view_2_tab1_821 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_821
+DROP VIEW IF EXISTS view_3_tab1_821 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10855,13 +10855,13 @@ SELECT pk FROM tab2 WHERE ((col0 = 465) AND col0 BETWEEN 547 AND 973 OR col3 > 6
 22 values hashing to fa560d564065cba63efa2c98c96dd927
 
 statement ok
-DROP VIEW view_1_tab2_821
+DROP VIEW IF EXISTS view_1_tab2_821 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_821
+DROP VIEW IF EXISTS view_2_tab2_821 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_821
+DROP VIEW IF EXISTS view_3_tab2_821 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10952,13 +10952,13 @@ SELECT pk FROM tab3 WHERE ((col0 = 465) AND col0 BETWEEN 547 AND 973 OR col3 > 6
 22 values hashing to fa560d564065cba63efa2c98c96dd927
 
 statement ok
-DROP VIEW view_1_tab3_821
+DROP VIEW IF EXISTS view_1_tab3_821 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_821
+DROP VIEW IF EXISTS view_2_tab3_821 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_821
+DROP VIEW IF EXISTS view_3_tab3_821 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11049,13 +11049,13 @@ SELECT pk FROM tab4 WHERE ((col0 = 465) AND col0 BETWEEN 547 AND 973 OR col3 > 6
 22 values hashing to fa560d564065cba63efa2c98c96dd927
 
 statement ok
-DROP VIEW view_1_tab4_821
+DROP VIEW IF EXISTS view_1_tab4_821 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_821
+DROP VIEW IF EXISTS view_2_tab4_821 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_821
+DROP VIEW IF EXISTS view_3_tab4_821 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11146,13 +11146,13 @@ SELECT pk FROM tab0 WHERE col3 <= 656
 62 values hashing to e37a7ad542cc3c535eb736f629c9fafd
 
 statement ok
-DROP VIEW view_1_tab0_822
+DROP VIEW IF EXISTS view_1_tab0_822 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_822
+DROP VIEW IF EXISTS view_2_tab0_822 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_822
+DROP VIEW IF EXISTS view_3_tab0_822 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11243,13 +11243,13 @@ SELECT pk FROM tab1 WHERE col3 <= 656
 62 values hashing to e37a7ad542cc3c535eb736f629c9fafd
 
 statement ok
-DROP VIEW view_1_tab1_822
+DROP VIEW IF EXISTS view_1_tab1_822 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_822
+DROP VIEW IF EXISTS view_2_tab1_822 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_822
+DROP VIEW IF EXISTS view_3_tab1_822 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11340,13 +11340,13 @@ SELECT pk FROM tab2 WHERE col3 <= 656
 62 values hashing to e37a7ad542cc3c535eb736f629c9fafd
 
 statement ok
-DROP VIEW view_1_tab2_822
+DROP VIEW IF EXISTS view_1_tab2_822 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_822
+DROP VIEW IF EXISTS view_2_tab2_822 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_822
+DROP VIEW IF EXISTS view_3_tab2_822 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11437,13 +11437,13 @@ SELECT pk FROM tab3 WHERE col3 <= 656
 62 values hashing to e37a7ad542cc3c535eb736f629c9fafd
 
 statement ok
-DROP VIEW view_1_tab3_822
+DROP VIEW IF EXISTS view_1_tab3_822 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_822
+DROP VIEW IF EXISTS view_2_tab3_822 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_822
+DROP VIEW IF EXISTS view_3_tab3_822 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11534,13 +11534,13 @@ SELECT pk FROM tab4 WHERE col3 <= 656
 62 values hashing to e37a7ad542cc3c535eb736f629c9fafd
 
 statement ok
-DROP VIEW view_1_tab4_822
+DROP VIEW IF EXISTS view_1_tab4_822 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_822
+DROP VIEW IF EXISTS view_2_tab4_822 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_822
+DROP VIEW IF EXISTS view_3_tab4_822 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11626,13 +11626,13 @@ SELECT pk FROM tab0 WHERE (col0 < 174 AND (col0 = 365))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_823
+DROP VIEW IF EXISTS view_1_tab0_823 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_823
+DROP VIEW IF EXISTS view_2_tab0_823 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_823
+DROP VIEW IF EXISTS view_3_tab0_823 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11718,13 +11718,13 @@ SELECT pk FROM tab1 WHERE (col0 < 174 AND (col0 = 365))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_823
+DROP VIEW IF EXISTS view_1_tab1_823 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_823
+DROP VIEW IF EXISTS view_2_tab1_823 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_823
+DROP VIEW IF EXISTS view_3_tab1_823 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11810,13 +11810,13 @@ SELECT pk FROM tab2 WHERE (col0 < 174 AND (col0 = 365))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_823
+DROP VIEW IF EXISTS view_1_tab2_823 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_823
+DROP VIEW IF EXISTS view_2_tab2_823 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_823
+DROP VIEW IF EXISTS view_3_tab2_823 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11902,13 +11902,13 @@ SELECT pk FROM tab3 WHERE (col0 < 174 AND (col0 = 365))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_823
+DROP VIEW IF EXISTS view_1_tab3_823 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_823
+DROP VIEW IF EXISTS view_2_tab3_823 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_823
+DROP VIEW IF EXISTS view_3_tab3_823 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11994,13 +11994,13 @@ SELECT pk FROM tab4 WHERE (col0 < 174 AND (col0 = 365))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_823
+DROP VIEW IF EXISTS view_1_tab4_823 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_823
+DROP VIEW IF EXISTS view_2_tab4_823 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_823
+DROP VIEW IF EXISTS view_3_tab4_823 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12091,13 +12091,13 @@ SELECT pk FROM tab0 WHERE (col1 >= 499.38 AND col4 >= 64.68)
 48 values hashing to 2e06bf3518ad1d975ecbcb162f697e0a
 
 statement ok
-DROP VIEW view_1_tab0_824
+DROP VIEW IF EXISTS view_1_tab0_824 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_824
+DROP VIEW IF EXISTS view_2_tab0_824 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_824
+DROP VIEW IF EXISTS view_3_tab0_824 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12188,13 +12188,13 @@ SELECT pk FROM tab1 WHERE (col1 >= 499.38 AND col4 >= 64.68)
 48 values hashing to 2e06bf3518ad1d975ecbcb162f697e0a
 
 statement ok
-DROP VIEW view_1_tab1_824
+DROP VIEW IF EXISTS view_1_tab1_824 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_824
+DROP VIEW IF EXISTS view_2_tab1_824 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_824
+DROP VIEW IF EXISTS view_3_tab1_824 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12285,13 +12285,13 @@ SELECT pk FROM tab2 WHERE (col1 >= 499.38 AND col4 >= 64.68)
 48 values hashing to 2e06bf3518ad1d975ecbcb162f697e0a
 
 statement ok
-DROP VIEW view_1_tab2_824
+DROP VIEW IF EXISTS view_1_tab2_824 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_824
+DROP VIEW IF EXISTS view_2_tab2_824 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_824
+DROP VIEW IF EXISTS view_3_tab2_824 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12382,13 +12382,13 @@ SELECT pk FROM tab3 WHERE (col1 >= 499.38 AND col4 >= 64.68)
 48 values hashing to 2e06bf3518ad1d975ecbcb162f697e0a
 
 statement ok
-DROP VIEW view_1_tab3_824
+DROP VIEW IF EXISTS view_1_tab3_824 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_824
+DROP VIEW IF EXISTS view_2_tab3_824 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_824
+DROP VIEW IF EXISTS view_3_tab3_824 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12479,13 +12479,13 @@ SELECT pk FROM tab4 WHERE (col1 >= 499.38 AND col4 >= 64.68)
 48 values hashing to 2e06bf3518ad1d975ecbcb162f697e0a
 
 statement ok
-DROP VIEW view_1_tab4_824
+DROP VIEW IF EXISTS view_1_tab4_824 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_824
+DROP VIEW IF EXISTS view_2_tab4_824 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_824
+DROP VIEW IF EXISTS view_3_tab4_824 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12576,13 +12576,13 @@ SELECT pk FROM tab0 WHERE col0 <= 881 OR col0 < 634 OR (col4 IS NULL AND col1 <=
 93 values hashing to 3408e0b17701a5f5f812818cebee1a2e
 
 statement ok
-DROP VIEW view_1_tab0_825
+DROP VIEW IF EXISTS view_1_tab0_825 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_825
+DROP VIEW IF EXISTS view_2_tab0_825 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_825
+DROP VIEW IF EXISTS view_3_tab0_825 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12673,13 +12673,13 @@ SELECT pk FROM tab1 WHERE col0 <= 881 OR col0 < 634 OR (col4 IS NULL AND col1 <=
 93 values hashing to 3408e0b17701a5f5f812818cebee1a2e
 
 statement ok
-DROP VIEW view_1_tab1_825
+DROP VIEW IF EXISTS view_1_tab1_825 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_825
+DROP VIEW IF EXISTS view_2_tab1_825 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_825
+DROP VIEW IF EXISTS view_3_tab1_825 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12770,13 +12770,13 @@ SELECT pk FROM tab2 WHERE col0 <= 881 OR col0 < 634 OR (col4 IS NULL AND col1 <=
 93 values hashing to 3408e0b17701a5f5f812818cebee1a2e
 
 statement ok
-DROP VIEW view_1_tab2_825
+DROP VIEW IF EXISTS view_1_tab2_825 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_825
+DROP VIEW IF EXISTS view_2_tab2_825 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_825
+DROP VIEW IF EXISTS view_3_tab2_825 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12867,13 +12867,13 @@ SELECT pk FROM tab3 WHERE col0 <= 881 OR col0 < 634 OR (col4 IS NULL AND col1 <=
 93 values hashing to 3408e0b17701a5f5f812818cebee1a2e
 
 statement ok
-DROP VIEW view_1_tab3_825
+DROP VIEW IF EXISTS view_1_tab3_825 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_825
+DROP VIEW IF EXISTS view_2_tab3_825 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_825
+DROP VIEW IF EXISTS view_3_tab3_825 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12964,13 +12964,13 @@ SELECT pk FROM tab4 WHERE col0 <= 881 OR col0 < 634 OR (col4 IS NULL AND col1 <=
 93 values hashing to 3408e0b17701a5f5f812818cebee1a2e
 
 statement ok
-DROP VIEW view_1_tab4_825
+DROP VIEW IF EXISTS view_1_tab4_825 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_825
+DROP VIEW IF EXISTS view_2_tab4_825 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_825
+DROP VIEW IF EXISTS view_3_tab4_825 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13061,13 +13061,13 @@ SELECT pk FROM tab0 WHERE (col3 >= 850)
 14 values hashing to 79dbd7c2b04da15055bffe925a103246
 
 statement ok
-DROP VIEW view_1_tab0_826
+DROP VIEW IF EXISTS view_1_tab0_826 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_826
+DROP VIEW IF EXISTS view_2_tab0_826 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_826
+DROP VIEW IF EXISTS view_3_tab0_826 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13158,13 +13158,13 @@ SELECT pk FROM tab1 WHERE (col3 >= 850)
 14 values hashing to 79dbd7c2b04da15055bffe925a103246
 
 statement ok
-DROP VIEW view_1_tab1_826
+DROP VIEW IF EXISTS view_1_tab1_826 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_826
+DROP VIEW IF EXISTS view_2_tab1_826 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_826
+DROP VIEW IF EXISTS view_3_tab1_826 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13255,13 +13255,13 @@ SELECT pk FROM tab2 WHERE (col3 >= 850)
 14 values hashing to 79dbd7c2b04da15055bffe925a103246
 
 statement ok
-DROP VIEW view_1_tab2_826
+DROP VIEW IF EXISTS view_1_tab2_826 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_826
+DROP VIEW IF EXISTS view_2_tab2_826 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_826
+DROP VIEW IF EXISTS view_3_tab2_826 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13352,13 +13352,13 @@ SELECT pk FROM tab3 WHERE (col3 >= 850)
 14 values hashing to 79dbd7c2b04da15055bffe925a103246
 
 statement ok
-DROP VIEW view_1_tab3_826
+DROP VIEW IF EXISTS view_1_tab3_826 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_826
+DROP VIEW IF EXISTS view_2_tab3_826 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_826
+DROP VIEW IF EXISTS view_3_tab3_826 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13449,13 +13449,13 @@ SELECT pk FROM tab4 WHERE (col3 >= 850)
 14 values hashing to 79dbd7c2b04da15055bffe925a103246
 
 statement ok
-DROP VIEW view_1_tab4_826
+DROP VIEW IF EXISTS view_1_tab4_826 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_826
+DROP VIEW IF EXISTS view_2_tab4_826 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_826
+DROP VIEW IF EXISTS view_3_tab4_826 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13546,13 +13546,13 @@ SELECT pk FROM tab0 WHERE col0 < 914 AND col1 < 446.23
 38 values hashing to 1efa0cb3bf3974705e352fb091e420bf
 
 statement ok
-DROP VIEW view_1_tab0_827
+DROP VIEW IF EXISTS view_1_tab0_827 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_827
+DROP VIEW IF EXISTS view_2_tab0_827 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_827
+DROP VIEW IF EXISTS view_3_tab0_827 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13643,13 +13643,13 @@ SELECT pk FROM tab1 WHERE col0 < 914 AND col1 < 446.23
 38 values hashing to 1efa0cb3bf3974705e352fb091e420bf
 
 statement ok
-DROP VIEW view_1_tab1_827
+DROP VIEW IF EXISTS view_1_tab1_827 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_827
+DROP VIEW IF EXISTS view_2_tab1_827 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_827
+DROP VIEW IF EXISTS view_3_tab1_827 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13740,13 +13740,13 @@ SELECT pk FROM tab2 WHERE col0 < 914 AND col1 < 446.23
 38 values hashing to 1efa0cb3bf3974705e352fb091e420bf
 
 statement ok
-DROP VIEW view_1_tab2_827
+DROP VIEW IF EXISTS view_1_tab2_827 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_827
+DROP VIEW IF EXISTS view_2_tab2_827 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_827
+DROP VIEW IF EXISTS view_3_tab2_827 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13837,13 +13837,13 @@ SELECT pk FROM tab3 WHERE col0 < 914 AND col1 < 446.23
 38 values hashing to 1efa0cb3bf3974705e352fb091e420bf
 
 statement ok
-DROP VIEW view_1_tab3_827
+DROP VIEW IF EXISTS view_1_tab3_827 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_827
+DROP VIEW IF EXISTS view_2_tab3_827 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_827
+DROP VIEW IF EXISTS view_3_tab3_827 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13934,13 +13934,13 @@ SELECT pk FROM tab4 WHERE col0 < 914 AND col1 < 446.23
 38 values hashing to 1efa0cb3bf3974705e352fb091e420bf
 
 statement ok
-DROP VIEW view_1_tab4_827
+DROP VIEW IF EXISTS view_1_tab4_827 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_827
+DROP VIEW IF EXISTS view_2_tab4_827 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_827
+DROP VIEW IF EXISTS view_3_tab4_827 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14031,13 +14031,13 @@ SELECT pk FROM tab0 WHERE col0 <= 536 OR col3 = 933
 48 values hashing to 3ec2314c54f090ac49573e2e0cefc2d8
 
 statement ok
-DROP VIEW view_1_tab0_828
+DROP VIEW IF EXISTS view_1_tab0_828 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_828
+DROP VIEW IF EXISTS view_2_tab0_828 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_828
+DROP VIEW IF EXISTS view_3_tab0_828 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14128,13 +14128,13 @@ SELECT pk FROM tab1 WHERE col0 <= 536 OR col3 = 933
 48 values hashing to 3ec2314c54f090ac49573e2e0cefc2d8
 
 statement ok
-DROP VIEW view_1_tab1_828
+DROP VIEW IF EXISTS view_1_tab1_828 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_828
+DROP VIEW IF EXISTS view_2_tab1_828 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_828
+DROP VIEW IF EXISTS view_3_tab1_828 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14225,13 +14225,13 @@ SELECT pk FROM tab2 WHERE col0 <= 536 OR col3 = 933
 48 values hashing to 3ec2314c54f090ac49573e2e0cefc2d8
 
 statement ok
-DROP VIEW view_1_tab2_828
+DROP VIEW IF EXISTS view_1_tab2_828 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_828
+DROP VIEW IF EXISTS view_2_tab2_828 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_828
+DROP VIEW IF EXISTS view_3_tab2_828 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14322,13 +14322,13 @@ SELECT pk FROM tab3 WHERE col0 <= 536 OR col3 = 933
 48 values hashing to 3ec2314c54f090ac49573e2e0cefc2d8
 
 statement ok
-DROP VIEW view_1_tab3_828
+DROP VIEW IF EXISTS view_1_tab3_828 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_828
+DROP VIEW IF EXISTS view_2_tab3_828 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_828
+DROP VIEW IF EXISTS view_3_tab3_828 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14419,13 +14419,13 @@ SELECT pk FROM tab4 WHERE col0 <= 536 OR col3 = 933
 48 values hashing to 3ec2314c54f090ac49573e2e0cefc2d8
 
 statement ok
-DROP VIEW view_1_tab4_828
+DROP VIEW IF EXISTS view_1_tab4_828 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_828
+DROP VIEW IF EXISTS view_2_tab4_828 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_828
+DROP VIEW IF EXISTS view_3_tab4_828 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14516,13 +14516,13 @@ SELECT pk FROM tab0 WHERE col0 > 41
 95 values hashing to 687246e8b77dc53bda1c9f1b957edd50
 
 statement ok
-DROP VIEW view_1_tab0_829
+DROP VIEW IF EXISTS view_1_tab0_829 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_829
+DROP VIEW IF EXISTS view_2_tab0_829 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_829
+DROP VIEW IF EXISTS view_3_tab0_829 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14613,13 +14613,13 @@ SELECT pk FROM tab1 WHERE col0 > 41
 95 values hashing to 687246e8b77dc53bda1c9f1b957edd50
 
 statement ok
-DROP VIEW view_1_tab1_829
+DROP VIEW IF EXISTS view_1_tab1_829 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_829
+DROP VIEW IF EXISTS view_2_tab1_829 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_829
+DROP VIEW IF EXISTS view_3_tab1_829 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14710,13 +14710,13 @@ SELECT pk FROM tab2 WHERE col0 > 41
 95 values hashing to 687246e8b77dc53bda1c9f1b957edd50
 
 statement ok
-DROP VIEW view_1_tab2_829
+DROP VIEW IF EXISTS view_1_tab2_829 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_829
+DROP VIEW IF EXISTS view_2_tab2_829 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_829
+DROP VIEW IF EXISTS view_3_tab2_829 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14807,13 +14807,13 @@ SELECT pk FROM tab3 WHERE col0 > 41
 95 values hashing to 687246e8b77dc53bda1c9f1b957edd50
 
 statement ok
-DROP VIEW view_1_tab3_829
+DROP VIEW IF EXISTS view_1_tab3_829 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_829
+DROP VIEW IF EXISTS view_2_tab3_829 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_829
+DROP VIEW IF EXISTS view_3_tab3_829 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14904,13 +14904,13 @@ SELECT pk FROM tab4 WHERE col0 > 41
 95 values hashing to 687246e8b77dc53bda1c9f1b957edd50
 
 statement ok
-DROP VIEW view_1_tab4_829
+DROP VIEW IF EXISTS view_1_tab4_829 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_829
+DROP VIEW IF EXISTS view_2_tab4_829 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_829
+DROP VIEW IF EXISTS view_3_tab4_829 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15001,13 +15001,13 @@ SELECT pk FROM tab0 WHERE col3 > 556 AND (col1 >= 664.28) OR (col3 < 788 AND (co
 22 values hashing to 809b755e6f45574914469a78f8c078e5
 
 statement ok
-DROP VIEW view_1_tab0_830
+DROP VIEW IF EXISTS view_1_tab0_830 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_830
+DROP VIEW IF EXISTS view_2_tab0_830 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_830
+DROP VIEW IF EXISTS view_3_tab0_830 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15098,13 +15098,13 @@ SELECT pk FROM tab1 WHERE col3 > 556 AND (col1 >= 664.28) OR (col3 < 788 AND (co
 22 values hashing to 809b755e6f45574914469a78f8c078e5
 
 statement ok
-DROP VIEW view_1_tab1_830
+DROP VIEW IF EXISTS view_1_tab1_830 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_830
+DROP VIEW IF EXISTS view_2_tab1_830 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_830
+DROP VIEW IF EXISTS view_3_tab1_830 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15195,13 +15195,13 @@ SELECT pk FROM tab2 WHERE col3 > 556 AND (col1 >= 664.28) OR (col3 < 788 AND (co
 22 values hashing to 809b755e6f45574914469a78f8c078e5
 
 statement ok
-DROP VIEW view_1_tab2_830
+DROP VIEW IF EXISTS view_1_tab2_830 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_830
+DROP VIEW IF EXISTS view_2_tab2_830 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_830
+DROP VIEW IF EXISTS view_3_tab2_830 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15292,13 +15292,13 @@ SELECT pk FROM tab3 WHERE col3 > 556 AND (col1 >= 664.28) OR (col3 < 788 AND (co
 22 values hashing to 809b755e6f45574914469a78f8c078e5
 
 statement ok
-DROP VIEW view_1_tab3_830
+DROP VIEW IF EXISTS view_1_tab3_830 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_830
+DROP VIEW IF EXISTS view_2_tab3_830 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_830
+DROP VIEW IF EXISTS view_3_tab3_830 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15389,13 +15389,13 @@ SELECT pk FROM tab4 WHERE col3 > 556 AND (col1 >= 664.28) OR (col3 < 788 AND (co
 22 values hashing to 809b755e6f45574914469a78f8c078e5
 
 statement ok
-DROP VIEW view_1_tab4_830
+DROP VIEW IF EXISTS view_1_tab4_830 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_830
+DROP VIEW IF EXISTS view_2_tab4_830 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_830
+DROP VIEW IF EXISTS view_3_tab4_830 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15486,13 +15486,13 @@ SELECT pk FROM tab0 WHERE ((((col0 IS NULL AND col3 >= 781)))) OR ((col3 > 562 A
 54 values hashing to 4139fe94af52a86c1002ef3732f9946f
 
 statement ok
-DROP VIEW view_1_tab0_831
+DROP VIEW IF EXISTS view_1_tab0_831 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_831
+DROP VIEW IF EXISTS view_2_tab0_831 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_831
+DROP VIEW IF EXISTS view_3_tab0_831 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15583,13 +15583,13 @@ SELECT pk FROM tab1 WHERE ((((col0 IS NULL AND col3 >= 781)))) OR ((col3 > 562 A
 54 values hashing to 4139fe94af52a86c1002ef3732f9946f
 
 statement ok
-DROP VIEW view_1_tab1_831
+DROP VIEW IF EXISTS view_1_tab1_831 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_831
+DROP VIEW IF EXISTS view_2_tab1_831 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_831
+DROP VIEW IF EXISTS view_3_tab1_831 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15680,13 +15680,13 @@ SELECT pk FROM tab2 WHERE ((((col0 IS NULL AND col3 >= 781)))) OR ((col3 > 562 A
 54 values hashing to 4139fe94af52a86c1002ef3732f9946f
 
 statement ok
-DROP VIEW view_1_tab2_831
+DROP VIEW IF EXISTS view_1_tab2_831 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_831
+DROP VIEW IF EXISTS view_2_tab2_831 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_831
+DROP VIEW IF EXISTS view_3_tab2_831 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15777,13 +15777,13 @@ SELECT pk FROM tab3 WHERE ((((col0 IS NULL AND col3 >= 781)))) OR ((col3 > 562 A
 54 values hashing to 4139fe94af52a86c1002ef3732f9946f
 
 statement ok
-DROP VIEW view_1_tab3_831
+DROP VIEW IF EXISTS view_1_tab3_831 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_831
+DROP VIEW IF EXISTS view_2_tab3_831 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_831
+DROP VIEW IF EXISTS view_3_tab3_831 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15874,13 +15874,13 @@ SELECT pk FROM tab4 WHERE ((((col0 IS NULL AND col3 >= 781)))) OR ((col3 > 562 A
 54 values hashing to 4139fe94af52a86c1002ef3732f9946f
 
 statement ok
-DROP VIEW view_1_tab4_831
+DROP VIEW IF EXISTS view_1_tab4_831 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_831
+DROP VIEW IF EXISTS view_2_tab4_831 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_831
+DROP VIEW IF EXISTS view_3_tab4_831 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15971,13 +15971,13 @@ SELECT pk FROM tab0 WHERE ((col3 <= 742) OR ((((col0 > 222) AND col4 >= 520.84 O
 82 values hashing to 49826a80d63cbbacd29ef6d0e1df30f1
 
 statement ok
-DROP VIEW view_1_tab0_832
+DROP VIEW IF EXISTS view_1_tab0_832 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_832
+DROP VIEW IF EXISTS view_2_tab0_832 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_832
+DROP VIEW IF EXISTS view_3_tab0_832 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16068,13 +16068,13 @@ SELECT pk FROM tab1 WHERE ((col3 <= 742) OR ((((col0 > 222) AND col4 >= 520.84 O
 82 values hashing to 49826a80d63cbbacd29ef6d0e1df30f1
 
 statement ok
-DROP VIEW view_1_tab1_832
+DROP VIEW IF EXISTS view_1_tab1_832 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_832
+DROP VIEW IF EXISTS view_2_tab1_832 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_832
+DROP VIEW IF EXISTS view_3_tab1_832 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16165,13 +16165,13 @@ SELECT pk FROM tab2 WHERE ((col3 <= 742) OR ((((col0 > 222) AND col4 >= 520.84 O
 82 values hashing to 49826a80d63cbbacd29ef6d0e1df30f1
 
 statement ok
-DROP VIEW view_1_tab2_832
+DROP VIEW IF EXISTS view_1_tab2_832 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_832
+DROP VIEW IF EXISTS view_2_tab2_832 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_832
+DROP VIEW IF EXISTS view_3_tab2_832 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16262,13 +16262,13 @@ SELECT pk FROM tab3 WHERE ((col3 <= 742) OR ((((col0 > 222) AND col4 >= 520.84 O
 82 values hashing to 49826a80d63cbbacd29ef6d0e1df30f1
 
 statement ok
-DROP VIEW view_1_tab3_832
+DROP VIEW IF EXISTS view_1_tab3_832 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_832
+DROP VIEW IF EXISTS view_2_tab3_832 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_832
+DROP VIEW IF EXISTS view_3_tab3_832 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16359,13 +16359,13 @@ SELECT pk FROM tab4 WHERE ((col3 <= 742) OR ((((col0 > 222) AND col4 >= 520.84 O
 82 values hashing to 49826a80d63cbbacd29ef6d0e1df30f1
 
 statement ok
-DROP VIEW view_1_tab4_832
+DROP VIEW IF EXISTS view_1_tab4_832 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_832
+DROP VIEW IF EXISTS view_2_tab4_832 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_832
+DROP VIEW IF EXISTS view_3_tab4_832 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16451,13 +16451,13 @@ SELECT pk FROM tab0 WHERE col4 < 807.28 AND ((col3 < 156) AND (((col0 IS NULL)) 
 ----
 
 statement ok
-DROP VIEW view_1_tab0_833
+DROP VIEW IF EXISTS view_1_tab0_833 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_833
+DROP VIEW IF EXISTS view_2_tab0_833 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_833
+DROP VIEW IF EXISTS view_3_tab0_833 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16543,13 +16543,13 @@ SELECT pk FROM tab1 WHERE col4 < 807.28 AND ((col3 < 156) AND (((col0 IS NULL)) 
 ----
 
 statement ok
-DROP VIEW view_1_tab1_833
+DROP VIEW IF EXISTS view_1_tab1_833 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_833
+DROP VIEW IF EXISTS view_2_tab1_833 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_833
+DROP VIEW IF EXISTS view_3_tab1_833 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16635,13 +16635,13 @@ SELECT pk FROM tab2 WHERE col4 < 807.28 AND ((col3 < 156) AND (((col0 IS NULL)) 
 ----
 
 statement ok
-DROP VIEW view_1_tab2_833
+DROP VIEW IF EXISTS view_1_tab2_833 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_833
+DROP VIEW IF EXISTS view_2_tab2_833 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_833
+DROP VIEW IF EXISTS view_3_tab2_833 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16727,13 +16727,13 @@ SELECT pk FROM tab3 WHERE col4 < 807.28 AND ((col3 < 156) AND (((col0 IS NULL)) 
 ----
 
 statement ok
-DROP VIEW view_1_tab3_833
+DROP VIEW IF EXISTS view_1_tab3_833 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_833
+DROP VIEW IF EXISTS view_2_tab3_833 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_833
+DROP VIEW IF EXISTS view_3_tab3_833 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16819,13 +16819,13 @@ SELECT pk FROM tab4 WHERE col4 < 807.28 AND ((col3 < 156) AND (((col0 IS NULL)) 
 ----
 
 statement ok
-DROP VIEW view_1_tab4_833
+DROP VIEW IF EXISTS view_1_tab4_833 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_833
+DROP VIEW IF EXISTS view_2_tab4_833 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_833
+DROP VIEW IF EXISTS view_3_tab4_833 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16916,13 +16916,13 @@ SELECT pk FROM tab0 WHERE col0 < 900
 88 values hashing to ef3cc7938fb7135a6f01bb9392c5b371
 
 statement ok
-DROP VIEW view_1_tab0_834
+DROP VIEW IF EXISTS view_1_tab0_834 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_834
+DROP VIEW IF EXISTS view_2_tab0_834 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_834
+DROP VIEW IF EXISTS view_3_tab0_834 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17013,13 +17013,13 @@ SELECT pk FROM tab1 WHERE col0 < 900
 88 values hashing to ef3cc7938fb7135a6f01bb9392c5b371
 
 statement ok
-DROP VIEW view_1_tab1_834
+DROP VIEW IF EXISTS view_1_tab1_834 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_834
+DROP VIEW IF EXISTS view_2_tab1_834 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_834
+DROP VIEW IF EXISTS view_3_tab1_834 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17110,13 +17110,13 @@ SELECT pk FROM tab2 WHERE col0 < 900
 88 values hashing to ef3cc7938fb7135a6f01bb9392c5b371
 
 statement ok
-DROP VIEW view_1_tab2_834
+DROP VIEW IF EXISTS view_1_tab2_834 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_834
+DROP VIEW IF EXISTS view_2_tab2_834 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_834
+DROP VIEW IF EXISTS view_3_tab2_834 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17207,13 +17207,13 @@ SELECT pk FROM tab3 WHERE col0 < 900
 88 values hashing to ef3cc7938fb7135a6f01bb9392c5b371
 
 statement ok
-DROP VIEW view_1_tab3_834
+DROP VIEW IF EXISTS view_1_tab3_834 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_834
+DROP VIEW IF EXISTS view_2_tab3_834 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_834
+DROP VIEW IF EXISTS view_3_tab3_834 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17304,13 +17304,13 @@ SELECT pk FROM tab4 WHERE col0 < 900
 88 values hashing to ef3cc7938fb7135a6f01bb9392c5b371
 
 statement ok
-DROP VIEW view_1_tab4_834
+DROP VIEW IF EXISTS view_1_tab4_834 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_834
+DROP VIEW IF EXISTS view_2_tab4_834 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_834
+DROP VIEW IF EXISTS view_3_tab4_834 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17407,13 +17407,13 @@ SELECT pk FROM tab0 WHERE col0 IS NULL OR (((((col3 > 622) OR col0 IN (192,92)))
 98 values hashing to 2f1073805e7af2512ba4608efb625e20
 
 statement ok
-DROP VIEW view_1_tab0_835
+DROP VIEW IF EXISTS view_1_tab0_835 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_835
+DROP VIEW IF EXISTS view_2_tab0_835 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_835
+DROP VIEW IF EXISTS view_3_tab0_835 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17510,13 +17510,13 @@ SELECT pk FROM tab1 WHERE col0 IS NULL OR (((((col3 > 622) OR col0 IN (192,92)))
 98 values hashing to 2f1073805e7af2512ba4608efb625e20
 
 statement ok
-DROP VIEW view_1_tab1_835
+DROP VIEW IF EXISTS view_1_tab1_835 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_835
+DROP VIEW IF EXISTS view_2_tab1_835 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_835
+DROP VIEW IF EXISTS view_3_tab1_835 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17613,13 +17613,13 @@ SELECT pk FROM tab2 WHERE col0 IS NULL OR (((((col3 > 622) OR col0 IN (192,92)))
 98 values hashing to 2f1073805e7af2512ba4608efb625e20
 
 statement ok
-DROP VIEW view_1_tab2_835
+DROP VIEW IF EXISTS view_1_tab2_835 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_835
+DROP VIEW IF EXISTS view_2_tab2_835 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_835
+DROP VIEW IF EXISTS view_3_tab2_835 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17716,13 +17716,13 @@ SELECT pk FROM tab3 WHERE col0 IS NULL OR (((((col3 > 622) OR col0 IN (192,92)))
 98 values hashing to 2f1073805e7af2512ba4608efb625e20
 
 statement ok
-DROP VIEW view_1_tab3_835
+DROP VIEW IF EXISTS view_1_tab3_835 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_835
+DROP VIEW IF EXISTS view_2_tab3_835 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_835
+DROP VIEW IF EXISTS view_3_tab3_835 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17819,13 +17819,13 @@ SELECT pk FROM tab4 WHERE col0 IS NULL OR (((((col3 > 622) OR col0 IN (192,92)))
 98 values hashing to 2f1073805e7af2512ba4608efb625e20
 
 statement ok
-DROP VIEW view_1_tab4_835
+DROP VIEW IF EXISTS view_1_tab4_835 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_835
+DROP VIEW IF EXISTS view_2_tab4_835 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_835
+DROP VIEW IF EXISTS view_3_tab4_835 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17916,13 +17916,13 @@ SELECT pk FROM tab0 WHERE col3 < 819
 80 values hashing to ac14f200848aff55b305b5f63961891d
 
 statement ok
-DROP VIEW view_1_tab0_836
+DROP VIEW IF EXISTS view_1_tab0_836 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_836
+DROP VIEW IF EXISTS view_2_tab0_836 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_836
+DROP VIEW IF EXISTS view_3_tab0_836 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18013,13 +18013,13 @@ SELECT pk FROM tab1 WHERE col3 < 819
 80 values hashing to ac14f200848aff55b305b5f63961891d
 
 statement ok
-DROP VIEW view_1_tab1_836
+DROP VIEW IF EXISTS view_1_tab1_836 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_836
+DROP VIEW IF EXISTS view_2_tab1_836 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_836
+DROP VIEW IF EXISTS view_3_tab1_836 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18110,13 +18110,13 @@ SELECT pk FROM tab2 WHERE col3 < 819
 80 values hashing to ac14f200848aff55b305b5f63961891d
 
 statement ok
-DROP VIEW view_1_tab2_836
+DROP VIEW IF EXISTS view_1_tab2_836 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_836
+DROP VIEW IF EXISTS view_2_tab2_836 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_836
+DROP VIEW IF EXISTS view_3_tab2_836 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18207,13 +18207,13 @@ SELECT pk FROM tab3 WHERE col3 < 819
 80 values hashing to ac14f200848aff55b305b5f63961891d
 
 statement ok
-DROP VIEW view_1_tab3_836
+DROP VIEW IF EXISTS view_1_tab3_836 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_836
+DROP VIEW IF EXISTS view_2_tab3_836 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_836
+DROP VIEW IF EXISTS view_3_tab3_836 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18304,13 +18304,13 @@ SELECT pk FROM tab4 WHERE col3 < 819
 80 values hashing to ac14f200848aff55b305b5f63961891d
 
 statement ok
-DROP VIEW view_1_tab4_836
+DROP VIEW IF EXISTS view_1_tab4_836 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_836
+DROP VIEW IF EXISTS view_2_tab4_836 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_836
+DROP VIEW IF EXISTS view_3_tab4_836 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18413,13 +18413,13 @@ SELECT pk FROM tab0 WHERE col1 > 949.60
 96
 
 statement ok
-DROP VIEW view_1_tab0_837
+DROP VIEW IF EXISTS view_1_tab0_837 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_837
+DROP VIEW IF EXISTS view_2_tab0_837 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_837
+DROP VIEW IF EXISTS view_3_tab0_837 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18522,13 +18522,13 @@ SELECT pk FROM tab1 WHERE col1 > 949.60
 96
 
 statement ok
-DROP VIEW view_1_tab1_837
+DROP VIEW IF EXISTS view_1_tab1_837 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_837
+DROP VIEW IF EXISTS view_2_tab1_837 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_837
+DROP VIEW IF EXISTS view_3_tab1_837 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18631,13 +18631,13 @@ SELECT pk FROM tab2 WHERE col1 > 949.60
 96
 
 statement ok
-DROP VIEW view_1_tab2_837
+DROP VIEW IF EXISTS view_1_tab2_837 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_837
+DROP VIEW IF EXISTS view_2_tab2_837 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_837
+DROP VIEW IF EXISTS view_3_tab2_837 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18740,13 +18740,13 @@ SELECT pk FROM tab3 WHERE col1 > 949.60
 96
 
 statement ok
-DROP VIEW view_1_tab3_837
+DROP VIEW IF EXISTS view_1_tab3_837 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_837
+DROP VIEW IF EXISTS view_2_tab3_837 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_837
+DROP VIEW IF EXISTS view_3_tab3_837 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18849,13 +18849,13 @@ SELECT pk FROM tab4 WHERE col1 > 949.60
 96
 
 statement ok
-DROP VIEW view_1_tab4_837
+DROP VIEW IF EXISTS view_1_tab4_837 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_837
+DROP VIEW IF EXISTS view_2_tab4_837 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_837
+DROP VIEW IF EXISTS view_3_tab4_837 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18944,13 +18944,13 @@ SELECT pk FROM tab0 WHERE (col0 < 914 OR col1 > 906.49 OR col0 BETWEEN 389 AND 9
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab0_838
+DROP VIEW IF EXISTS view_1_tab0_838 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_838
+DROP VIEW IF EXISTS view_2_tab0_838 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_838
+DROP VIEW IF EXISTS view_3_tab0_838 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19039,13 +19039,13 @@ SELECT pk FROM tab1 WHERE (col0 < 914 OR col1 > 906.49 OR col0 BETWEEN 389 AND 9
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab1_838
+DROP VIEW IF EXISTS view_1_tab1_838 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_838
+DROP VIEW IF EXISTS view_2_tab1_838 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_838
+DROP VIEW IF EXISTS view_3_tab1_838 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19134,13 +19134,13 @@ SELECT pk FROM tab2 WHERE (col0 < 914 OR col1 > 906.49 OR col0 BETWEEN 389 AND 9
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab2_838
+DROP VIEW IF EXISTS view_1_tab2_838 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_838
+DROP VIEW IF EXISTS view_2_tab2_838 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_838
+DROP VIEW IF EXISTS view_3_tab2_838 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19229,13 +19229,13 @@ SELECT pk FROM tab3 WHERE (col0 < 914 OR col1 > 906.49 OR col0 BETWEEN 389 AND 9
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab3_838
+DROP VIEW IF EXISTS view_1_tab3_838 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_838
+DROP VIEW IF EXISTS view_2_tab3_838 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_838
+DROP VIEW IF EXISTS view_3_tab3_838 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19324,13 +19324,13 @@ SELECT pk FROM tab4 WHERE (col0 < 914 OR col1 > 906.49 OR col0 BETWEEN 389 AND 9
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab4_838
+DROP VIEW IF EXISTS view_1_tab4_838 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_838
+DROP VIEW IF EXISTS view_2_tab4_838 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_838
+DROP VIEW IF EXISTS view_3_tab4_838 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19416,13 +19416,13 @@ SELECT pk FROM tab0 WHERE col1 = 987.33 OR ((col0 < 781 AND (col0 < 934 AND col3
 ----
 
 statement ok
-DROP VIEW view_1_tab0_839
+DROP VIEW IF EXISTS view_1_tab0_839 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_839
+DROP VIEW IF EXISTS view_2_tab0_839 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_839
+DROP VIEW IF EXISTS view_3_tab0_839 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19508,13 +19508,13 @@ SELECT pk FROM tab1 WHERE col1 = 987.33 OR ((col0 < 781 AND (col0 < 934 AND col3
 ----
 
 statement ok
-DROP VIEW view_1_tab1_839
+DROP VIEW IF EXISTS view_1_tab1_839 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_839
+DROP VIEW IF EXISTS view_2_tab1_839 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_839
+DROP VIEW IF EXISTS view_3_tab1_839 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19600,13 +19600,13 @@ SELECT pk FROM tab2 WHERE col1 = 987.33 OR ((col0 < 781 AND (col0 < 934 AND col3
 ----
 
 statement ok
-DROP VIEW view_1_tab2_839
+DROP VIEW IF EXISTS view_1_tab2_839 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_839
+DROP VIEW IF EXISTS view_2_tab2_839 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_839
+DROP VIEW IF EXISTS view_3_tab2_839 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19692,13 +19692,13 @@ SELECT pk FROM tab3 WHERE col1 = 987.33 OR ((col0 < 781 AND (col0 < 934 AND col3
 ----
 
 statement ok
-DROP VIEW view_1_tab3_839
+DROP VIEW IF EXISTS view_1_tab3_839 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_839
+DROP VIEW IF EXISTS view_2_tab3_839 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_839
+DROP VIEW IF EXISTS view_3_tab3_839 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19784,13 +19784,13 @@ SELECT pk FROM tab4 WHERE col1 = 987.33 OR ((col0 < 781 AND (col0 < 934 AND col3
 ----
 
 statement ok
-DROP VIEW view_1_tab4_839
+DROP VIEW IF EXISTS view_1_tab4_839 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_839
+DROP VIEW IF EXISTS view_2_tab4_839 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_839
+DROP VIEW IF EXISTS view_3_tab4_839 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19881,13 +19881,13 @@ SELECT pk FROM tab0 WHERE col3 > 761
 27 values hashing to e3c03bb86ea056784b60ef65ed0fc065
 
 statement ok
-DROP VIEW view_1_tab0_840
+DROP VIEW IF EXISTS view_1_tab0_840 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_840
+DROP VIEW IF EXISTS view_2_tab0_840 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_840
+DROP VIEW IF EXISTS view_3_tab0_840 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19978,13 +19978,13 @@ SELECT pk FROM tab1 WHERE col3 > 761
 27 values hashing to e3c03bb86ea056784b60ef65ed0fc065
 
 statement ok
-DROP VIEW view_1_tab1_840
+DROP VIEW IF EXISTS view_1_tab1_840 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_840
+DROP VIEW IF EXISTS view_2_tab1_840 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_840
+DROP VIEW IF EXISTS view_3_tab1_840 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20075,13 +20075,13 @@ SELECT pk FROM tab2 WHERE col3 > 761
 27 values hashing to e3c03bb86ea056784b60ef65ed0fc065
 
 statement ok
-DROP VIEW view_1_tab2_840
+DROP VIEW IF EXISTS view_1_tab2_840 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_840
+DROP VIEW IF EXISTS view_2_tab2_840 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_840
+DROP VIEW IF EXISTS view_3_tab2_840 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20172,13 +20172,13 @@ SELECT pk FROM tab3 WHERE col3 > 761
 27 values hashing to e3c03bb86ea056784b60ef65ed0fc065
 
 statement ok
-DROP VIEW view_1_tab3_840
+DROP VIEW IF EXISTS view_1_tab3_840 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_840
+DROP VIEW IF EXISTS view_2_tab3_840 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_840
+DROP VIEW IF EXISTS view_3_tab3_840 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20269,13 +20269,13 @@ SELECT pk FROM tab4 WHERE col3 > 761
 27 values hashing to e3c03bb86ea056784b60ef65ed0fc065
 
 statement ok
-DROP VIEW view_1_tab4_840
+DROP VIEW IF EXISTS view_1_tab4_840 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_840
+DROP VIEW IF EXISTS view_2_tab4_840 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_840
+DROP VIEW IF EXISTS view_3_tab4_840 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20366,13 +20366,13 @@ SELECT pk FROM tab0 WHERE col3 < 718
 67 values hashing to cb2ebad3b31fcf5d67495117d9455def
 
 statement ok
-DROP VIEW view_1_tab0_841
+DROP VIEW IF EXISTS view_1_tab0_841 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_841
+DROP VIEW IF EXISTS view_2_tab0_841 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_841
+DROP VIEW IF EXISTS view_3_tab0_841 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20463,13 +20463,13 @@ SELECT pk FROM tab1 WHERE col3 < 718
 67 values hashing to cb2ebad3b31fcf5d67495117d9455def
 
 statement ok
-DROP VIEW view_1_tab1_841
+DROP VIEW IF EXISTS view_1_tab1_841 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_841
+DROP VIEW IF EXISTS view_2_tab1_841 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_841
+DROP VIEW IF EXISTS view_3_tab1_841 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20560,13 +20560,13 @@ SELECT pk FROM tab2 WHERE col3 < 718
 67 values hashing to cb2ebad3b31fcf5d67495117d9455def
 
 statement ok
-DROP VIEW view_1_tab2_841
+DROP VIEW IF EXISTS view_1_tab2_841 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_841
+DROP VIEW IF EXISTS view_2_tab2_841 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_841
+DROP VIEW IF EXISTS view_3_tab2_841 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20657,13 +20657,13 @@ SELECT pk FROM tab3 WHERE col3 < 718
 67 values hashing to cb2ebad3b31fcf5d67495117d9455def
 
 statement ok
-DROP VIEW view_1_tab3_841
+DROP VIEW IF EXISTS view_1_tab3_841 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_841
+DROP VIEW IF EXISTS view_2_tab3_841 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_841
+DROP VIEW IF EXISTS view_3_tab3_841 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20754,13 +20754,13 @@ SELECT pk FROM tab4 WHERE col3 < 718
 67 values hashing to cb2ebad3b31fcf5d67495117d9455def
 
 statement ok
-DROP VIEW view_1_tab4_841
+DROP VIEW IF EXISTS view_1_tab4_841 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_841
+DROP VIEW IF EXISTS view_2_tab4_841 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_841
+DROP VIEW IF EXISTS view_3_tab4_841 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20851,13 +20851,13 @@ SELECT pk FROM tab0 WHERE ((col0 > 377))
 68 values hashing to 370d3b50fb73a34e3c099722326f064b
 
 statement ok
-DROP VIEW view_1_tab0_842
+DROP VIEW IF EXISTS view_1_tab0_842 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_842
+DROP VIEW IF EXISTS view_2_tab0_842 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_842
+DROP VIEW IF EXISTS view_3_tab0_842 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20948,13 +20948,13 @@ SELECT pk FROM tab1 WHERE ((col0 > 377))
 68 values hashing to 370d3b50fb73a34e3c099722326f064b
 
 statement ok
-DROP VIEW view_1_tab1_842
+DROP VIEW IF EXISTS view_1_tab1_842 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_842
+DROP VIEW IF EXISTS view_2_tab1_842 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_842
+DROP VIEW IF EXISTS view_3_tab1_842 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21045,13 +21045,13 @@ SELECT pk FROM tab2 WHERE ((col0 > 377))
 68 values hashing to 370d3b50fb73a34e3c099722326f064b
 
 statement ok
-DROP VIEW view_1_tab2_842
+DROP VIEW IF EXISTS view_1_tab2_842 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_842
+DROP VIEW IF EXISTS view_2_tab2_842 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_842
+DROP VIEW IF EXISTS view_3_tab2_842 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21142,13 +21142,13 @@ SELECT pk FROM tab3 WHERE ((col0 > 377))
 68 values hashing to 370d3b50fb73a34e3c099722326f064b
 
 statement ok
-DROP VIEW view_1_tab3_842
+DROP VIEW IF EXISTS view_1_tab3_842 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_842
+DROP VIEW IF EXISTS view_2_tab3_842 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_842
+DROP VIEW IF EXISTS view_3_tab3_842 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21239,13 +21239,13 @@ SELECT pk FROM tab4 WHERE ((col0 > 377))
 68 values hashing to 370d3b50fb73a34e3c099722326f064b
 
 statement ok
-DROP VIEW view_1_tab4_842
+DROP VIEW IF EXISTS view_1_tab4_842 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_842
+DROP VIEW IF EXISTS view_2_tab4_842 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_842
+DROP VIEW IF EXISTS view_3_tab4_842 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21336,13 +21336,13 @@ SELECT pk FROM tab0 WHERE col4 <= 776.29
 78 values hashing to 662725f9cb5319478c2f3dd34597dddc
 
 statement ok
-DROP VIEW view_1_tab0_843
+DROP VIEW IF EXISTS view_1_tab0_843 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_843
+DROP VIEW IF EXISTS view_2_tab0_843 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_843
+DROP VIEW IF EXISTS view_3_tab0_843 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21433,13 +21433,13 @@ SELECT pk FROM tab1 WHERE col4 <= 776.29
 78 values hashing to 662725f9cb5319478c2f3dd34597dddc
 
 statement ok
-DROP VIEW view_1_tab1_843
+DROP VIEW IF EXISTS view_1_tab1_843 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_843
+DROP VIEW IF EXISTS view_2_tab1_843 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_843
+DROP VIEW IF EXISTS view_3_tab1_843 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21530,13 +21530,13 @@ SELECT pk FROM tab2 WHERE col4 <= 776.29
 78 values hashing to 662725f9cb5319478c2f3dd34597dddc
 
 statement ok
-DROP VIEW view_1_tab2_843
+DROP VIEW IF EXISTS view_1_tab2_843 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_843
+DROP VIEW IF EXISTS view_2_tab2_843 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_843
+DROP VIEW IF EXISTS view_3_tab2_843 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21627,13 +21627,13 @@ SELECT pk FROM tab3 WHERE col4 <= 776.29
 78 values hashing to 662725f9cb5319478c2f3dd34597dddc
 
 statement ok
-DROP VIEW view_1_tab3_843
+DROP VIEW IF EXISTS view_1_tab3_843 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_843
+DROP VIEW IF EXISTS view_2_tab3_843 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_843
+DROP VIEW IF EXISTS view_3_tab3_843 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21724,13 +21724,13 @@ SELECT pk FROM tab4 WHERE col4 <= 776.29
 78 values hashing to 662725f9cb5319478c2f3dd34597dddc
 
 statement ok
-DROP VIEW view_1_tab4_843
+DROP VIEW IF EXISTS view_1_tab4_843 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_843
+DROP VIEW IF EXISTS view_2_tab4_843 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_843
+DROP VIEW IF EXISTS view_3_tab4_843 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21821,13 +21821,13 @@ SELECT pk FROM tab0 WHERE col3 > 216 AND ((col3 >= 345))
 70 values hashing to 51f73b98a243cf85cbaeeebfd6326395
 
 statement ok
-DROP VIEW view_1_tab0_844
+DROP VIEW IF EXISTS view_1_tab0_844 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_844
+DROP VIEW IF EXISTS view_2_tab0_844 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_844
+DROP VIEW IF EXISTS view_3_tab0_844 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21918,13 +21918,13 @@ SELECT pk FROM tab1 WHERE col3 > 216 AND ((col3 >= 345))
 70 values hashing to 51f73b98a243cf85cbaeeebfd6326395
 
 statement ok
-DROP VIEW view_1_tab1_844
+DROP VIEW IF EXISTS view_1_tab1_844 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_844
+DROP VIEW IF EXISTS view_2_tab1_844 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_844
+DROP VIEW IF EXISTS view_3_tab1_844 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22015,13 +22015,13 @@ SELECT pk FROM tab2 WHERE col3 > 216 AND ((col3 >= 345))
 70 values hashing to 51f73b98a243cf85cbaeeebfd6326395
 
 statement ok
-DROP VIEW view_1_tab2_844
+DROP VIEW IF EXISTS view_1_tab2_844 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_844
+DROP VIEW IF EXISTS view_2_tab2_844 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_844
+DROP VIEW IF EXISTS view_3_tab2_844 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22112,13 +22112,13 @@ SELECT pk FROM tab3 WHERE col3 > 216 AND ((col3 >= 345))
 70 values hashing to 51f73b98a243cf85cbaeeebfd6326395
 
 statement ok
-DROP VIEW view_1_tab3_844
+DROP VIEW IF EXISTS view_1_tab3_844 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_844
+DROP VIEW IF EXISTS view_2_tab3_844 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_844
+DROP VIEW IF EXISTS view_3_tab3_844 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22209,13 +22209,13 @@ SELECT pk FROM tab4 WHERE col3 > 216 AND ((col3 >= 345))
 70 values hashing to 51f73b98a243cf85cbaeeebfd6326395
 
 statement ok
-DROP VIEW view_1_tab4_844
+DROP VIEW IF EXISTS view_1_tab4_844 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_844
+DROP VIEW IF EXISTS view_2_tab4_844 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_844
+DROP VIEW IF EXISTS view_3_tab4_844 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22306,13 +22306,13 @@ SELECT pk FROM tab0 WHERE col3 <= 683
 64 values hashing to a7bcc09fe1a636c8ef1e759416222c83
 
 statement ok
-DROP VIEW view_1_tab0_845
+DROP VIEW IF EXISTS view_1_tab0_845 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_845
+DROP VIEW IF EXISTS view_2_tab0_845 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_845
+DROP VIEW IF EXISTS view_3_tab0_845 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22403,13 +22403,13 @@ SELECT pk FROM tab1 WHERE col3 <= 683
 64 values hashing to a7bcc09fe1a636c8ef1e759416222c83
 
 statement ok
-DROP VIEW view_1_tab1_845
+DROP VIEW IF EXISTS view_1_tab1_845 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_845
+DROP VIEW IF EXISTS view_2_tab1_845 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_845
+DROP VIEW IF EXISTS view_3_tab1_845 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22500,13 +22500,13 @@ SELECT pk FROM tab2 WHERE col3 <= 683
 64 values hashing to a7bcc09fe1a636c8ef1e759416222c83
 
 statement ok
-DROP VIEW view_1_tab2_845
+DROP VIEW IF EXISTS view_1_tab2_845 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_845
+DROP VIEW IF EXISTS view_2_tab2_845 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_845
+DROP VIEW IF EXISTS view_3_tab2_845 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22597,13 +22597,13 @@ SELECT pk FROM tab3 WHERE col3 <= 683
 64 values hashing to a7bcc09fe1a636c8ef1e759416222c83
 
 statement ok
-DROP VIEW view_1_tab3_845
+DROP VIEW IF EXISTS view_1_tab3_845 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_845
+DROP VIEW IF EXISTS view_2_tab3_845 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_845
+DROP VIEW IF EXISTS view_3_tab3_845 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22694,13 +22694,13 @@ SELECT pk FROM tab4 WHERE col3 <= 683
 64 values hashing to a7bcc09fe1a636c8ef1e759416222c83
 
 statement ok
-DROP VIEW view_1_tab4_845
+DROP VIEW IF EXISTS view_1_tab4_845 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_845
+DROP VIEW IF EXISTS view_2_tab4_845 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_845
+DROP VIEW IF EXISTS view_3_tab4_845 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22791,13 +22791,13 @@ SELECT pk FROM tab0 WHERE (col0 > 167 AND col0 <= 716) OR col3 IS NULL
 50 values hashing to ef3a6a62c5a18f6e9c261cdff0811a03
 
 statement ok
-DROP VIEW view_1_tab0_846
+DROP VIEW IF EXISTS view_1_tab0_846 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_846
+DROP VIEW IF EXISTS view_2_tab0_846 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_846
+DROP VIEW IF EXISTS view_3_tab0_846 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22888,13 +22888,13 @@ SELECT pk FROM tab1 WHERE (col0 > 167 AND col0 <= 716) OR col3 IS NULL
 50 values hashing to ef3a6a62c5a18f6e9c261cdff0811a03
 
 statement ok
-DROP VIEW view_1_tab1_846
+DROP VIEW IF EXISTS view_1_tab1_846 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_846
+DROP VIEW IF EXISTS view_2_tab1_846 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_846
+DROP VIEW IF EXISTS view_3_tab1_846 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22985,13 +22985,13 @@ SELECT pk FROM tab2 WHERE (col0 > 167 AND col0 <= 716) OR col3 IS NULL
 50 values hashing to ef3a6a62c5a18f6e9c261cdff0811a03
 
 statement ok
-DROP VIEW view_1_tab2_846
+DROP VIEW IF EXISTS view_1_tab2_846 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_846
+DROP VIEW IF EXISTS view_2_tab2_846 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_846
+DROP VIEW IF EXISTS view_3_tab2_846 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23082,13 +23082,13 @@ SELECT pk FROM tab3 WHERE (col0 > 167 AND col0 <= 716) OR col3 IS NULL
 50 values hashing to ef3a6a62c5a18f6e9c261cdff0811a03
 
 statement ok
-DROP VIEW view_1_tab3_846
+DROP VIEW IF EXISTS view_1_tab3_846 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_846
+DROP VIEW IF EXISTS view_2_tab3_846 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_846
+DROP VIEW IF EXISTS view_3_tab3_846 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23179,13 +23179,13 @@ SELECT pk FROM tab4 WHERE (col0 > 167 AND col0 <= 716) OR col3 IS NULL
 50 values hashing to ef3a6a62c5a18f6e9c261cdff0811a03
 
 statement ok
-DROP VIEW view_1_tab4_846
+DROP VIEW IF EXISTS view_1_tab4_846 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_846
+DROP VIEW IF EXISTS view_2_tab4_846 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_846
+DROP VIEW IF EXISTS view_3_tab4_846 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23276,13 +23276,13 @@ SELECT pk FROM tab0 WHERE col1 <= 772.59
 81 values hashing to 86c2f404f22e1fa5f808f4830f116902
 
 statement ok
-DROP VIEW view_1_tab0_847
+DROP VIEW IF EXISTS view_1_tab0_847 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_847
+DROP VIEW IF EXISTS view_2_tab0_847 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_847
+DROP VIEW IF EXISTS view_3_tab0_847 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23373,13 +23373,13 @@ SELECT pk FROM tab1 WHERE col1 <= 772.59
 81 values hashing to 86c2f404f22e1fa5f808f4830f116902
 
 statement ok
-DROP VIEW view_1_tab1_847
+DROP VIEW IF EXISTS view_1_tab1_847 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_847
+DROP VIEW IF EXISTS view_2_tab1_847 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_847
+DROP VIEW IF EXISTS view_3_tab1_847 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23470,13 +23470,13 @@ SELECT pk FROM tab2 WHERE col1 <= 772.59
 81 values hashing to 86c2f404f22e1fa5f808f4830f116902
 
 statement ok
-DROP VIEW view_1_tab2_847
+DROP VIEW IF EXISTS view_1_tab2_847 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_847
+DROP VIEW IF EXISTS view_2_tab2_847 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_847
+DROP VIEW IF EXISTS view_3_tab2_847 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23567,13 +23567,13 @@ SELECT pk FROM tab3 WHERE col1 <= 772.59
 81 values hashing to 86c2f404f22e1fa5f808f4830f116902
 
 statement ok
-DROP VIEW view_1_tab3_847
+DROP VIEW IF EXISTS view_1_tab3_847 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_847
+DROP VIEW IF EXISTS view_2_tab3_847 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_847
+DROP VIEW IF EXISTS view_3_tab3_847 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23664,13 +23664,13 @@ SELECT pk FROM tab4 WHERE col1 <= 772.59
 81 values hashing to 86c2f404f22e1fa5f808f4830f116902
 
 statement ok
-DROP VIEW view_1_tab4_847
+DROP VIEW IF EXISTS view_1_tab4_847 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_847
+DROP VIEW IF EXISTS view_2_tab4_847 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_847
+DROP VIEW IF EXISTS view_3_tab4_847 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23761,13 +23761,13 @@ SELECT pk FROM tab0 WHERE (col3 > 125)
 87 values hashing to be2f79ae5942640c8aeaf9d509430f67
 
 statement ok
-DROP VIEW view_1_tab0_848
+DROP VIEW IF EXISTS view_1_tab0_848 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_848
+DROP VIEW IF EXISTS view_2_tab0_848 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_848
+DROP VIEW IF EXISTS view_3_tab0_848 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23858,13 +23858,13 @@ SELECT pk FROM tab1 WHERE (col3 > 125)
 87 values hashing to be2f79ae5942640c8aeaf9d509430f67
 
 statement ok
-DROP VIEW view_1_tab1_848
+DROP VIEW IF EXISTS view_1_tab1_848 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_848
+DROP VIEW IF EXISTS view_2_tab1_848 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_848
+DROP VIEW IF EXISTS view_3_tab1_848 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23955,13 +23955,13 @@ SELECT pk FROM tab2 WHERE (col3 > 125)
 87 values hashing to be2f79ae5942640c8aeaf9d509430f67
 
 statement ok
-DROP VIEW view_1_tab2_848
+DROP VIEW IF EXISTS view_1_tab2_848 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_848
+DROP VIEW IF EXISTS view_2_tab2_848 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_848
+DROP VIEW IF EXISTS view_3_tab2_848 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24052,13 +24052,13 @@ SELECT pk FROM tab3 WHERE (col3 > 125)
 87 values hashing to be2f79ae5942640c8aeaf9d509430f67
 
 statement ok
-DROP VIEW view_1_tab3_848
+DROP VIEW IF EXISTS view_1_tab3_848 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_848
+DROP VIEW IF EXISTS view_2_tab3_848 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_848
+DROP VIEW IF EXISTS view_3_tab3_848 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24149,13 +24149,13 @@ SELECT pk FROM tab4 WHERE (col3 > 125)
 87 values hashing to be2f79ae5942640c8aeaf9d509430f67
 
 statement ok
-DROP VIEW view_1_tab4_848
+DROP VIEW IF EXISTS view_1_tab4_848 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_848
+DROP VIEW IF EXISTS view_2_tab4_848 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_848
+DROP VIEW IF EXISTS view_3_tab4_848 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24246,13 +24246,13 @@ SELECT pk FROM tab0 WHERE (col1 > 978.14) OR (col0 > 568)
 48 values hashing to 7d3d6f56660370936000cfa77a1d92f3
 
 statement ok
-DROP VIEW view_1_tab0_850
+DROP VIEW IF EXISTS view_1_tab0_850 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_850
+DROP VIEW IF EXISTS view_2_tab0_850 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_850
+DROP VIEW IF EXISTS view_3_tab0_850 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24343,13 +24343,13 @@ SELECT pk FROM tab1 WHERE (col1 > 978.14) OR (col0 > 568)
 48 values hashing to 7d3d6f56660370936000cfa77a1d92f3
 
 statement ok
-DROP VIEW view_1_tab1_850
+DROP VIEW IF EXISTS view_1_tab1_850 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_850
+DROP VIEW IF EXISTS view_2_tab1_850 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_850
+DROP VIEW IF EXISTS view_3_tab1_850 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24440,13 +24440,13 @@ SELECT pk FROM tab2 WHERE (col1 > 978.14) OR (col0 > 568)
 48 values hashing to 7d3d6f56660370936000cfa77a1d92f3
 
 statement ok
-DROP VIEW view_1_tab2_850
+DROP VIEW IF EXISTS view_1_tab2_850 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_850
+DROP VIEW IF EXISTS view_2_tab2_850 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_850
+DROP VIEW IF EXISTS view_3_tab2_850 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24537,13 +24537,13 @@ SELECT pk FROM tab3 WHERE (col1 > 978.14) OR (col0 > 568)
 48 values hashing to 7d3d6f56660370936000cfa77a1d92f3
 
 statement ok
-DROP VIEW view_1_tab3_850
+DROP VIEW IF EXISTS view_1_tab3_850 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_850
+DROP VIEW IF EXISTS view_2_tab3_850 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_850
+DROP VIEW IF EXISTS view_3_tab3_850 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24634,13 +24634,13 @@ SELECT pk FROM tab4 WHERE (col1 > 978.14) OR (col0 > 568)
 48 values hashing to 7d3d6f56660370936000cfa77a1d92f3
 
 statement ok
-DROP VIEW view_1_tab4_850
+DROP VIEW IF EXISTS view_1_tab4_850 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_850
+DROP VIEW IF EXISTS view_2_tab4_850 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_850
+DROP VIEW IF EXISTS view_3_tab4_850 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24733,13 +24733,13 @@ SELECT pk FROM tab0 WHERE ((col0 IN (710,284,533,621,126,972) OR ((col3 = 723)) 
 60
 
 statement ok
-DROP VIEW view_1_tab0_851
+DROP VIEW IF EXISTS view_1_tab0_851 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_851
+DROP VIEW IF EXISTS view_2_tab0_851 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_851
+DROP VIEW IF EXISTS view_3_tab0_851 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24832,13 +24832,13 @@ SELECT pk FROM tab1 WHERE ((col0 IN (710,284,533,621,126,972) OR ((col3 = 723)) 
 60
 
 statement ok
-DROP VIEW view_1_tab1_851
+DROP VIEW IF EXISTS view_1_tab1_851 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_851
+DROP VIEW IF EXISTS view_2_tab1_851 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_851
+DROP VIEW IF EXISTS view_3_tab1_851 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24931,13 +24931,13 @@ SELECT pk FROM tab2 WHERE ((col0 IN (710,284,533,621,126,972) OR ((col3 = 723)) 
 60
 
 statement ok
-DROP VIEW view_1_tab2_851
+DROP VIEW IF EXISTS view_1_tab2_851 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_851
+DROP VIEW IF EXISTS view_2_tab2_851 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_851
+DROP VIEW IF EXISTS view_3_tab2_851 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25030,13 +25030,13 @@ SELECT pk FROM tab3 WHERE ((col0 IN (710,284,533,621,126,972) OR ((col3 = 723)) 
 60
 
 statement ok
-DROP VIEW view_1_tab3_851
+DROP VIEW IF EXISTS view_1_tab3_851 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_851
+DROP VIEW IF EXISTS view_2_tab3_851 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_851
+DROP VIEW IF EXISTS view_3_tab3_851 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25129,13 +25129,13 @@ SELECT pk FROM tab4 WHERE ((col0 IN (710,284,533,621,126,972) OR ((col3 = 723)) 
 60
 
 statement ok
-DROP VIEW view_1_tab4_851
+DROP VIEW IF EXISTS view_1_tab4_851 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_851
+DROP VIEW IF EXISTS view_2_tab4_851 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_851
+DROP VIEW IF EXISTS view_3_tab4_851 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25226,13 +25226,13 @@ SELECT pk FROM tab0 WHERE col3 <= 565 OR col4 >= 996.5
 50 values hashing to 2c82d8fa31c10ede846e0f90a99956ad
 
 statement ok
-DROP VIEW view_1_tab0_852
+DROP VIEW IF EXISTS view_1_tab0_852 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_852
+DROP VIEW IF EXISTS view_2_tab0_852 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_852
+DROP VIEW IF EXISTS view_3_tab0_852 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25323,13 +25323,13 @@ SELECT pk FROM tab1 WHERE col3 <= 565 OR col4 >= 996.5
 50 values hashing to 2c82d8fa31c10ede846e0f90a99956ad
 
 statement ok
-DROP VIEW view_1_tab1_852
+DROP VIEW IF EXISTS view_1_tab1_852 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_852
+DROP VIEW IF EXISTS view_2_tab1_852 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_852
+DROP VIEW IF EXISTS view_3_tab1_852 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25420,13 +25420,13 @@ SELECT pk FROM tab2 WHERE col3 <= 565 OR col4 >= 996.5
 50 values hashing to 2c82d8fa31c10ede846e0f90a99956ad
 
 statement ok
-DROP VIEW view_1_tab2_852
+DROP VIEW IF EXISTS view_1_tab2_852 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_852
+DROP VIEW IF EXISTS view_2_tab2_852 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_852
+DROP VIEW IF EXISTS view_3_tab2_852 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25517,13 +25517,13 @@ SELECT pk FROM tab3 WHERE col3 <= 565 OR col4 >= 996.5
 50 values hashing to 2c82d8fa31c10ede846e0f90a99956ad
 
 statement ok
-DROP VIEW view_1_tab3_852
+DROP VIEW IF EXISTS view_1_tab3_852 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_852
+DROP VIEW IF EXISTS view_2_tab3_852 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_852
+DROP VIEW IF EXISTS view_3_tab3_852 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25614,13 +25614,13 @@ SELECT pk FROM tab4 WHERE col3 <= 565 OR col4 >= 996.5
 50 values hashing to 2c82d8fa31c10ede846e0f90a99956ad
 
 statement ok
-DROP VIEW view_1_tab4_852
+DROP VIEW IF EXISTS view_1_tab4_852 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_852
+DROP VIEW IF EXISTS view_2_tab4_852 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_852
+DROP VIEW IF EXISTS view_3_tab4_852 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25711,13 +25711,13 @@ SELECT pk FROM tab0 WHERE ((col3 >= 580))
 50 values hashing to ccb908553e6c840f768fdcbbe711e2bf
 
 statement ok
-DROP VIEW view_1_tab0_853
+DROP VIEW IF EXISTS view_1_tab0_853 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_853
+DROP VIEW IF EXISTS view_2_tab0_853 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_853
+DROP VIEW IF EXISTS view_3_tab0_853 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25808,13 +25808,13 @@ SELECT pk FROM tab1 WHERE ((col3 >= 580))
 50 values hashing to ccb908553e6c840f768fdcbbe711e2bf
 
 statement ok
-DROP VIEW view_1_tab1_853
+DROP VIEW IF EXISTS view_1_tab1_853 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_853
+DROP VIEW IF EXISTS view_2_tab1_853 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_853
+DROP VIEW IF EXISTS view_3_tab1_853 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25905,13 +25905,13 @@ SELECT pk FROM tab2 WHERE ((col3 >= 580))
 50 values hashing to ccb908553e6c840f768fdcbbe711e2bf
 
 statement ok
-DROP VIEW view_1_tab2_853
+DROP VIEW IF EXISTS view_1_tab2_853 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_853
+DROP VIEW IF EXISTS view_2_tab2_853 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_853
+DROP VIEW IF EXISTS view_3_tab2_853 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26002,13 +26002,13 @@ SELECT pk FROM tab3 WHERE ((col3 >= 580))
 50 values hashing to ccb908553e6c840f768fdcbbe711e2bf
 
 statement ok
-DROP VIEW view_1_tab3_853
+DROP VIEW IF EXISTS view_1_tab3_853 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_853
+DROP VIEW IF EXISTS view_2_tab3_853 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_853
+DROP VIEW IF EXISTS view_3_tab3_853 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26099,13 +26099,13 @@ SELECT pk FROM tab4 WHERE ((col3 >= 580))
 50 values hashing to ccb908553e6c840f768fdcbbe711e2bf
 
 statement ok
-DROP VIEW view_1_tab4_853
+DROP VIEW IF EXISTS view_1_tab4_853 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_853
+DROP VIEW IF EXISTS view_2_tab4_853 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_853
+DROP VIEW IF EXISTS view_3_tab4_853 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26191,13 +26191,13 @@ SELECT pk FROM tab0 WHERE col3 IN (704,482,213,837)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_854
+DROP VIEW IF EXISTS view_1_tab0_854 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_854
+DROP VIEW IF EXISTS view_2_tab0_854 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_854
+DROP VIEW IF EXISTS view_3_tab0_854 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26283,13 +26283,13 @@ SELECT pk FROM tab1 WHERE col3 IN (704,482,213,837)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_854
+DROP VIEW IF EXISTS view_1_tab1_854 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_854
+DROP VIEW IF EXISTS view_2_tab1_854 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_854
+DROP VIEW IF EXISTS view_3_tab1_854 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26375,13 +26375,13 @@ SELECT pk FROM tab2 WHERE col3 IN (704,482,213,837)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_854
+DROP VIEW IF EXISTS view_1_tab2_854 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_854
+DROP VIEW IF EXISTS view_2_tab2_854 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_854
+DROP VIEW IF EXISTS view_3_tab2_854 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26467,13 +26467,13 @@ SELECT pk FROM tab3 WHERE col3 IN (704,482,213,837)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_854
+DROP VIEW IF EXISTS view_1_tab3_854 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_854
+DROP VIEW IF EXISTS view_2_tab3_854 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_854
+DROP VIEW IF EXISTS view_3_tab3_854 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26559,13 +26559,13 @@ SELECT pk FROM tab4 WHERE col3 IN (704,482,213,837)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_854
+DROP VIEW IF EXISTS view_1_tab4_854 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_854
+DROP VIEW IF EXISTS view_2_tab4_854 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_854
+DROP VIEW IF EXISTS view_3_tab4_854 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26656,13 +26656,13 @@ SELECT pk FROM tab0 WHERE col3 > 740
 32 values hashing to 09b47ccd9e4a24f5772ebdeb5d638066
 
 statement ok
-DROP VIEW view_1_tab0_856
+DROP VIEW IF EXISTS view_1_tab0_856 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_856
+DROP VIEW IF EXISTS view_2_tab0_856 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_856
+DROP VIEW IF EXISTS view_3_tab0_856 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26753,13 +26753,13 @@ SELECT pk FROM tab1 WHERE col3 > 740
 32 values hashing to 09b47ccd9e4a24f5772ebdeb5d638066
 
 statement ok
-DROP VIEW view_1_tab1_856
+DROP VIEW IF EXISTS view_1_tab1_856 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_856
+DROP VIEW IF EXISTS view_2_tab1_856 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_856
+DROP VIEW IF EXISTS view_3_tab1_856 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26850,13 +26850,13 @@ SELECT pk FROM tab2 WHERE col3 > 740
 32 values hashing to 09b47ccd9e4a24f5772ebdeb5d638066
 
 statement ok
-DROP VIEW view_1_tab2_856
+DROP VIEW IF EXISTS view_1_tab2_856 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_856
+DROP VIEW IF EXISTS view_2_tab2_856 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_856
+DROP VIEW IF EXISTS view_3_tab2_856 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26947,13 +26947,13 @@ SELECT pk FROM tab3 WHERE col3 > 740
 32 values hashing to 09b47ccd9e4a24f5772ebdeb5d638066
 
 statement ok
-DROP VIEW view_1_tab3_856
+DROP VIEW IF EXISTS view_1_tab3_856 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_856
+DROP VIEW IF EXISTS view_2_tab3_856 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_856
+DROP VIEW IF EXISTS view_3_tab3_856 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27044,13 +27044,13 @@ SELECT pk FROM tab4 WHERE col3 > 740
 32 values hashing to 09b47ccd9e4a24f5772ebdeb5d638066
 
 statement ok
-DROP VIEW view_1_tab4_856
+DROP VIEW IF EXISTS view_1_tab4_856 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_856
+DROP VIEW IF EXISTS view_2_tab4_856 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_856
+DROP VIEW IF EXISTS view_3_tab4_856 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27143,13 +27143,13 @@ SELECT pk FROM tab0 WHERE (col3 = 847)
 14
 
 statement ok
-DROP VIEW view_1_tab0_857
+DROP VIEW IF EXISTS view_1_tab0_857 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_857
+DROP VIEW IF EXISTS view_2_tab0_857 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_857
+DROP VIEW IF EXISTS view_3_tab0_857 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27242,13 +27242,13 @@ SELECT pk FROM tab1 WHERE (col3 = 847)
 14
 
 statement ok
-DROP VIEW view_1_tab1_857
+DROP VIEW IF EXISTS view_1_tab1_857 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_857
+DROP VIEW IF EXISTS view_2_tab1_857 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_857
+DROP VIEW IF EXISTS view_3_tab1_857 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27341,13 +27341,13 @@ SELECT pk FROM tab2 WHERE (col3 = 847)
 14
 
 statement ok
-DROP VIEW view_1_tab2_857
+DROP VIEW IF EXISTS view_1_tab2_857 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_857
+DROP VIEW IF EXISTS view_2_tab2_857 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_857
+DROP VIEW IF EXISTS view_3_tab2_857 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27440,13 +27440,13 @@ SELECT pk FROM tab3 WHERE (col3 = 847)
 14
 
 statement ok
-DROP VIEW view_1_tab3_857
+DROP VIEW IF EXISTS view_1_tab3_857 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_857
+DROP VIEW IF EXISTS view_2_tab3_857 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_857
+DROP VIEW IF EXISTS view_3_tab3_857 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27539,13 +27539,13 @@ SELECT pk FROM tab4 WHERE (col3 = 847)
 14
 
 statement ok
-DROP VIEW view_1_tab4_857
+DROP VIEW IF EXISTS view_1_tab4_857 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_857
+DROP VIEW IF EXISTS view_2_tab4_857 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_857
+DROP VIEW IF EXISTS view_3_tab4_857 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27636,13 +27636,13 @@ SELECT pk FROM tab0 WHERE (col4 < 865.42)
 86 values hashing to 036457a5d35b29289ab022a1e75b261a
 
 statement ok
-DROP VIEW view_1_tab0_858
+DROP VIEW IF EXISTS view_1_tab0_858 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_858
+DROP VIEW IF EXISTS view_2_tab0_858 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_858
+DROP VIEW IF EXISTS view_3_tab0_858 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27733,13 +27733,13 @@ SELECT pk FROM tab1 WHERE (col4 < 865.42)
 86 values hashing to 036457a5d35b29289ab022a1e75b261a
 
 statement ok
-DROP VIEW view_1_tab1_858
+DROP VIEW IF EXISTS view_1_tab1_858 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_858
+DROP VIEW IF EXISTS view_2_tab1_858 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_858
+DROP VIEW IF EXISTS view_3_tab1_858 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27830,13 +27830,13 @@ SELECT pk FROM tab2 WHERE (col4 < 865.42)
 86 values hashing to 036457a5d35b29289ab022a1e75b261a
 
 statement ok
-DROP VIEW view_1_tab2_858
+DROP VIEW IF EXISTS view_1_tab2_858 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_858
+DROP VIEW IF EXISTS view_2_tab2_858 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_858
+DROP VIEW IF EXISTS view_3_tab2_858 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27927,13 +27927,13 @@ SELECT pk FROM tab3 WHERE (col4 < 865.42)
 86 values hashing to 036457a5d35b29289ab022a1e75b261a
 
 statement ok
-DROP VIEW view_1_tab3_858
+DROP VIEW IF EXISTS view_1_tab3_858 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_858
+DROP VIEW IF EXISTS view_2_tab3_858 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_858
+DROP VIEW IF EXISTS view_3_tab3_858 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28024,13 +28024,13 @@ SELECT pk FROM tab4 WHERE (col4 < 865.42)
 86 values hashing to 036457a5d35b29289ab022a1e75b261a
 
 statement ok
-DROP VIEW view_1_tab4_858
+DROP VIEW IF EXISTS view_1_tab4_858 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_858
+DROP VIEW IF EXISTS view_2_tab4_858 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_858
+DROP VIEW IF EXISTS view_3_tab4_858 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28123,13 +28123,13 @@ SELECT pk FROM tab0 WHERE col0 = 133
 77
 
 statement ok
-DROP VIEW view_1_tab0_859
+DROP VIEW IF EXISTS view_1_tab0_859 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_859
+DROP VIEW IF EXISTS view_2_tab0_859 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_859
+DROP VIEW IF EXISTS view_3_tab0_859 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28222,13 +28222,13 @@ SELECT pk FROM tab1 WHERE col0 = 133
 77
 
 statement ok
-DROP VIEW view_1_tab1_859
+DROP VIEW IF EXISTS view_1_tab1_859 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_859
+DROP VIEW IF EXISTS view_2_tab1_859 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_859
+DROP VIEW IF EXISTS view_3_tab1_859 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28321,13 +28321,13 @@ SELECT pk FROM tab2 WHERE col0 = 133
 77
 
 statement ok
-DROP VIEW view_1_tab2_859
+DROP VIEW IF EXISTS view_1_tab2_859 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_859
+DROP VIEW IF EXISTS view_2_tab2_859 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_859
+DROP VIEW IF EXISTS view_3_tab2_859 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28420,13 +28420,13 @@ SELECT pk FROM tab3 WHERE col0 = 133
 77
 
 statement ok
-DROP VIEW view_1_tab3_859
+DROP VIEW IF EXISTS view_1_tab3_859 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_859
+DROP VIEW IF EXISTS view_2_tab3_859 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_859
+DROP VIEW IF EXISTS view_3_tab3_859 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28519,13 +28519,13 @@ SELECT pk FROM tab4 WHERE col0 = 133
 77
 
 statement ok
-DROP VIEW view_1_tab4_859
+DROP VIEW IF EXISTS view_1_tab4_859 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_859
+DROP VIEW IF EXISTS view_2_tab4_859 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_859
+DROP VIEW IF EXISTS view_3_tab4_859 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28611,13 +28611,13 @@ SELECT pk FROM tab0 WHERE (col4 = 132.35)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_860
+DROP VIEW IF EXISTS view_1_tab0_860 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_860
+DROP VIEW IF EXISTS view_2_tab0_860 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_860
+DROP VIEW IF EXISTS view_3_tab0_860 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28703,13 +28703,13 @@ SELECT pk FROM tab1 WHERE (col4 = 132.35)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_860
+DROP VIEW IF EXISTS view_1_tab1_860 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_860
+DROP VIEW IF EXISTS view_2_tab1_860 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_860
+DROP VIEW IF EXISTS view_3_tab1_860 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28795,13 +28795,13 @@ SELECT pk FROM tab2 WHERE (col4 = 132.35)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_860
+DROP VIEW IF EXISTS view_1_tab2_860 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_860
+DROP VIEW IF EXISTS view_2_tab2_860 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_860
+DROP VIEW IF EXISTS view_3_tab2_860 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28887,13 +28887,13 @@ SELECT pk FROM tab3 WHERE (col4 = 132.35)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_860
+DROP VIEW IF EXISTS view_1_tab3_860 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_860
+DROP VIEW IF EXISTS view_2_tab3_860 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_860
+DROP VIEW IF EXISTS view_3_tab3_860 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28979,13 +28979,13 @@ SELECT pk FROM tab4 WHERE (col4 = 132.35)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_860
+DROP VIEW IF EXISTS view_1_tab4_860 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_860
+DROP VIEW IF EXISTS view_2_tab4_860 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_860
+DROP VIEW IF EXISTS view_3_tab4_860 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29076,13 +29076,13 @@ SELECT pk FROM tab0 WHERE col1 >= 338.2
 66 values hashing to d25984b7b6d7252d07dc6d1792664dda
 
 statement ok
-DROP VIEW view_1_tab0_861
+DROP VIEW IF EXISTS view_1_tab0_861 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_861
+DROP VIEW IF EXISTS view_2_tab0_861 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_861
+DROP VIEW IF EXISTS view_3_tab0_861 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29173,13 +29173,13 @@ SELECT pk FROM tab1 WHERE col1 >= 338.2
 66 values hashing to d25984b7b6d7252d07dc6d1792664dda
 
 statement ok
-DROP VIEW view_1_tab1_861
+DROP VIEW IF EXISTS view_1_tab1_861 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_861
+DROP VIEW IF EXISTS view_2_tab1_861 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_861
+DROP VIEW IF EXISTS view_3_tab1_861 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29270,13 +29270,13 @@ SELECT pk FROM tab2 WHERE col1 >= 338.2
 66 values hashing to d25984b7b6d7252d07dc6d1792664dda
 
 statement ok
-DROP VIEW view_1_tab2_861
+DROP VIEW IF EXISTS view_1_tab2_861 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_861
+DROP VIEW IF EXISTS view_2_tab2_861 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_861
+DROP VIEW IF EXISTS view_3_tab2_861 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29367,13 +29367,13 @@ SELECT pk FROM tab3 WHERE col1 >= 338.2
 66 values hashing to d25984b7b6d7252d07dc6d1792664dda
 
 statement ok
-DROP VIEW view_1_tab3_861
+DROP VIEW IF EXISTS view_1_tab3_861 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_861
+DROP VIEW IF EXISTS view_2_tab3_861 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_861
+DROP VIEW IF EXISTS view_3_tab3_861 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29464,13 +29464,13 @@ SELECT pk FROM tab4 WHERE col1 >= 338.2
 66 values hashing to d25984b7b6d7252d07dc6d1792664dda
 
 statement ok
-DROP VIEW view_1_tab4_861
+DROP VIEW IF EXISTS view_1_tab4_861 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_861
+DROP VIEW IF EXISTS view_2_tab4_861 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_861
+DROP VIEW IF EXISTS view_3_tab4_861 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29561,13 +29561,13 @@ SELECT pk FROM tab0 WHERE (col1 >= 62.15)
 93 values hashing to e154680bf575837bc0291255e5147220
 
 statement ok
-DROP VIEW view_1_tab0_862
+DROP VIEW IF EXISTS view_1_tab0_862 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_862
+DROP VIEW IF EXISTS view_2_tab0_862 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_862
+DROP VIEW IF EXISTS view_3_tab0_862 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29658,13 +29658,13 @@ SELECT pk FROM tab1 WHERE (col1 >= 62.15)
 93 values hashing to e154680bf575837bc0291255e5147220
 
 statement ok
-DROP VIEW view_1_tab1_862
+DROP VIEW IF EXISTS view_1_tab1_862 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_862
+DROP VIEW IF EXISTS view_2_tab1_862 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_862
+DROP VIEW IF EXISTS view_3_tab1_862 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29755,13 +29755,13 @@ SELECT pk FROM tab2 WHERE (col1 >= 62.15)
 93 values hashing to e154680bf575837bc0291255e5147220
 
 statement ok
-DROP VIEW view_1_tab2_862
+DROP VIEW IF EXISTS view_1_tab2_862 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_862
+DROP VIEW IF EXISTS view_2_tab2_862 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_862
+DROP VIEW IF EXISTS view_3_tab2_862 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29852,13 +29852,13 @@ SELECT pk FROM tab3 WHERE (col1 >= 62.15)
 93 values hashing to e154680bf575837bc0291255e5147220
 
 statement ok
-DROP VIEW view_1_tab3_862
+DROP VIEW IF EXISTS view_1_tab3_862 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_862
+DROP VIEW IF EXISTS view_2_tab3_862 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_862
+DROP VIEW IF EXISTS view_3_tab3_862 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29949,13 +29949,13 @@ SELECT pk FROM tab4 WHERE (col1 >= 62.15)
 93 values hashing to e154680bf575837bc0291255e5147220
 
 statement ok
-DROP VIEW view_1_tab4_862
+DROP VIEW IF EXISTS view_1_tab4_862 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_862
+DROP VIEW IF EXISTS view_2_tab4_862 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_862
+DROP VIEW IF EXISTS view_3_tab4_862 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30041,13 +30041,13 @@ SELECT pk FROM tab0 WHERE col3 = 998
 ----
 
 statement ok
-DROP VIEW view_1_tab0_863
+DROP VIEW IF EXISTS view_1_tab0_863 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_863
+DROP VIEW IF EXISTS view_2_tab0_863 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_863
+DROP VIEW IF EXISTS view_3_tab0_863 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30133,13 +30133,13 @@ SELECT pk FROM tab1 WHERE col3 = 998
 ----
 
 statement ok
-DROP VIEW view_1_tab1_863
+DROP VIEW IF EXISTS view_1_tab1_863 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_863
+DROP VIEW IF EXISTS view_2_tab1_863 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_863
+DROP VIEW IF EXISTS view_3_tab1_863 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30225,13 +30225,13 @@ SELECT pk FROM tab2 WHERE col3 = 998
 ----
 
 statement ok
-DROP VIEW view_1_tab2_863
+DROP VIEW IF EXISTS view_1_tab2_863 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_863
+DROP VIEW IF EXISTS view_2_tab2_863 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_863
+DROP VIEW IF EXISTS view_3_tab2_863 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30317,13 +30317,13 @@ SELECT pk FROM tab3 WHERE col3 = 998
 ----
 
 statement ok
-DROP VIEW view_1_tab3_863
+DROP VIEW IF EXISTS view_1_tab3_863 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_863
+DROP VIEW IF EXISTS view_2_tab3_863 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_863
+DROP VIEW IF EXISTS view_3_tab3_863 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30409,13 +30409,13 @@ SELECT pk FROM tab4 WHERE col3 = 998
 ----
 
 statement ok
-DROP VIEW view_1_tab4_863
+DROP VIEW IF EXISTS view_1_tab4_863 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_863
+DROP VIEW IF EXISTS view_2_tab4_863 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_863
+DROP VIEW IF EXISTS view_3_tab4_863 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30506,13 +30506,13 @@ SELECT pk FROM tab0 WHERE (col0 <= 767 AND (col0 = 970) AND (col3 < 708) AND (co
 87 values hashing to 274cc82a6cde1732cc4d98fb22447e4f
 
 statement ok
-DROP VIEW view_1_tab0_864
+DROP VIEW IF EXISTS view_1_tab0_864 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_864
+DROP VIEW IF EXISTS view_2_tab0_864 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_864
+DROP VIEW IF EXISTS view_3_tab0_864 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30603,13 +30603,13 @@ SELECT pk FROM tab1 WHERE (col0 <= 767 AND (col0 = 970) AND (col3 < 708) AND (co
 87 values hashing to 274cc82a6cde1732cc4d98fb22447e4f
 
 statement ok
-DROP VIEW view_1_tab1_864
+DROP VIEW IF EXISTS view_1_tab1_864 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_864
+DROP VIEW IF EXISTS view_2_tab1_864 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_864
+DROP VIEW IF EXISTS view_3_tab1_864 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30700,13 +30700,13 @@ SELECT pk FROM tab2 WHERE (col0 <= 767 AND (col0 = 970) AND (col3 < 708) AND (co
 87 values hashing to 274cc82a6cde1732cc4d98fb22447e4f
 
 statement ok
-DROP VIEW view_1_tab2_864
+DROP VIEW IF EXISTS view_1_tab2_864 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_864
+DROP VIEW IF EXISTS view_2_tab2_864 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_864
+DROP VIEW IF EXISTS view_3_tab2_864 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30797,13 +30797,13 @@ SELECT pk FROM tab3 WHERE (col0 <= 767 AND (col0 = 970) AND (col3 < 708) AND (co
 87 values hashing to 274cc82a6cde1732cc4d98fb22447e4f
 
 statement ok
-DROP VIEW view_1_tab3_864
+DROP VIEW IF EXISTS view_1_tab3_864 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_864
+DROP VIEW IF EXISTS view_2_tab3_864 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_864
+DROP VIEW IF EXISTS view_3_tab3_864 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30894,13 +30894,13 @@ SELECT pk FROM tab4 WHERE (col0 <= 767 AND (col0 = 970) AND (col3 < 708) AND (co
 87 values hashing to 274cc82a6cde1732cc4d98fb22447e4f
 
 statement ok
-DROP VIEW view_1_tab4_864
+DROP VIEW IF EXISTS view_1_tab4_864 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_864
+DROP VIEW IF EXISTS view_2_tab4_864 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_864
+DROP VIEW IF EXISTS view_3_tab4_864 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30991,13 +30991,13 @@ SELECT pk FROM tab0 WHERE (col1 > 739.0)
 26 values hashing to bf9ac3ea76a7eab873747714c6b2c9ed
 
 statement ok
-DROP VIEW view_1_tab0_865
+DROP VIEW IF EXISTS view_1_tab0_865 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_865
+DROP VIEW IF EXISTS view_2_tab0_865 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_865
+DROP VIEW IF EXISTS view_3_tab0_865 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31088,13 +31088,13 @@ SELECT pk FROM tab1 WHERE (col1 > 739.0)
 26 values hashing to bf9ac3ea76a7eab873747714c6b2c9ed
 
 statement ok
-DROP VIEW view_1_tab1_865
+DROP VIEW IF EXISTS view_1_tab1_865 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_865
+DROP VIEW IF EXISTS view_2_tab1_865 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_865
+DROP VIEW IF EXISTS view_3_tab1_865 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31185,13 +31185,13 @@ SELECT pk FROM tab2 WHERE (col1 > 739.0)
 26 values hashing to bf9ac3ea76a7eab873747714c6b2c9ed
 
 statement ok
-DROP VIEW view_1_tab2_865
+DROP VIEW IF EXISTS view_1_tab2_865 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_865
+DROP VIEW IF EXISTS view_2_tab2_865 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_865
+DROP VIEW IF EXISTS view_3_tab2_865 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31282,13 +31282,13 @@ SELECT pk FROM tab3 WHERE (col1 > 739.0)
 26 values hashing to bf9ac3ea76a7eab873747714c6b2c9ed
 
 statement ok
-DROP VIEW view_1_tab3_865
+DROP VIEW IF EXISTS view_1_tab3_865 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_865
+DROP VIEW IF EXISTS view_2_tab3_865 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_865
+DROP VIEW IF EXISTS view_3_tab3_865 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31379,13 +31379,13 @@ SELECT pk FROM tab4 WHERE (col1 > 739.0)
 26 values hashing to bf9ac3ea76a7eab873747714c6b2c9ed
 
 statement ok
-DROP VIEW view_1_tab4_865
+DROP VIEW IF EXISTS view_1_tab4_865 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_865
+DROP VIEW IF EXISTS view_2_tab4_865 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_865
+DROP VIEW IF EXISTS view_3_tab4_865 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31476,13 +31476,13 @@ SELECT pk FROM tab0 WHERE col4 < 224.99
 27 values hashing to 24da08506d07c95f0498a8cf2e4bd97b
 
 statement ok
-DROP VIEW view_1_tab0_866
+DROP VIEW IF EXISTS view_1_tab0_866 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_866
+DROP VIEW IF EXISTS view_2_tab0_866 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_866
+DROP VIEW IF EXISTS view_3_tab0_866 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31573,13 +31573,13 @@ SELECT pk FROM tab1 WHERE col4 < 224.99
 27 values hashing to 24da08506d07c95f0498a8cf2e4bd97b
 
 statement ok
-DROP VIEW view_1_tab1_866
+DROP VIEW IF EXISTS view_1_tab1_866 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_866
+DROP VIEW IF EXISTS view_2_tab1_866 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_866
+DROP VIEW IF EXISTS view_3_tab1_866 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31670,13 +31670,13 @@ SELECT pk FROM tab2 WHERE col4 < 224.99
 27 values hashing to 24da08506d07c95f0498a8cf2e4bd97b
 
 statement ok
-DROP VIEW view_1_tab2_866
+DROP VIEW IF EXISTS view_1_tab2_866 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_866
+DROP VIEW IF EXISTS view_2_tab2_866 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_866
+DROP VIEW IF EXISTS view_3_tab2_866 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31767,13 +31767,13 @@ SELECT pk FROM tab3 WHERE col4 < 224.99
 27 values hashing to 24da08506d07c95f0498a8cf2e4bd97b
 
 statement ok
-DROP VIEW view_1_tab3_866
+DROP VIEW IF EXISTS view_1_tab3_866 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_866
+DROP VIEW IF EXISTS view_2_tab3_866 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_866
+DROP VIEW IF EXISTS view_3_tab3_866 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31864,13 +31864,13 @@ SELECT pk FROM tab4 WHERE col4 < 224.99
 27 values hashing to 24da08506d07c95f0498a8cf2e4bd97b
 
 statement ok
-DROP VIEW view_1_tab4_866
+DROP VIEW IF EXISTS view_1_tab4_866 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_866
+DROP VIEW IF EXISTS view_2_tab4_866 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_866
+DROP VIEW IF EXISTS view_3_tab4_866 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31963,13 +31963,13 @@ SELECT pk FROM tab0 WHERE col0 = 308
 78
 
 statement ok
-DROP VIEW view_1_tab0_867
+DROP VIEW IF EXISTS view_1_tab0_867 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_867
+DROP VIEW IF EXISTS view_2_tab0_867 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_867
+DROP VIEW IF EXISTS view_3_tab0_867 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32062,13 +32062,13 @@ SELECT pk FROM tab1 WHERE col0 = 308
 78
 
 statement ok
-DROP VIEW view_1_tab1_867
+DROP VIEW IF EXISTS view_1_tab1_867 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_867
+DROP VIEW IF EXISTS view_2_tab1_867 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_867
+DROP VIEW IF EXISTS view_3_tab1_867 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32161,13 +32161,13 @@ SELECT pk FROM tab2 WHERE col0 = 308
 78
 
 statement ok
-DROP VIEW view_1_tab2_867
+DROP VIEW IF EXISTS view_1_tab2_867 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_867
+DROP VIEW IF EXISTS view_2_tab2_867 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_867
+DROP VIEW IF EXISTS view_3_tab2_867 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32260,13 +32260,13 @@ SELECT pk FROM tab3 WHERE col0 = 308
 78
 
 statement ok
-DROP VIEW view_1_tab3_867
+DROP VIEW IF EXISTS view_1_tab3_867 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_867
+DROP VIEW IF EXISTS view_2_tab3_867 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_867
+DROP VIEW IF EXISTS view_3_tab3_867 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32359,13 +32359,13 @@ SELECT pk FROM tab4 WHERE col0 = 308
 78
 
 statement ok
-DROP VIEW view_1_tab4_867
+DROP VIEW IF EXISTS view_1_tab4_867 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_867
+DROP VIEW IF EXISTS view_2_tab4_867 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_867
+DROP VIEW IF EXISTS view_3_tab4_867 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32451,13 +32451,13 @@ SELECT pk FROM tab0 WHERE ((col4 > 771.52) AND col3 = 917)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_868
+DROP VIEW IF EXISTS view_1_tab0_868 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_868
+DROP VIEW IF EXISTS view_2_tab0_868 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_868
+DROP VIEW IF EXISTS view_3_tab0_868 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32543,13 +32543,13 @@ SELECT pk FROM tab1 WHERE ((col4 > 771.52) AND col3 = 917)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_868
+DROP VIEW IF EXISTS view_1_tab1_868 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_868
+DROP VIEW IF EXISTS view_2_tab1_868 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_868
+DROP VIEW IF EXISTS view_3_tab1_868 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32635,13 +32635,13 @@ SELECT pk FROM tab2 WHERE ((col4 > 771.52) AND col3 = 917)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_868
+DROP VIEW IF EXISTS view_1_tab2_868 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_868
+DROP VIEW IF EXISTS view_2_tab2_868 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_868
+DROP VIEW IF EXISTS view_3_tab2_868 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32727,13 +32727,13 @@ SELECT pk FROM tab3 WHERE ((col4 > 771.52) AND col3 = 917)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_868
+DROP VIEW IF EXISTS view_1_tab3_868 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_868
+DROP VIEW IF EXISTS view_2_tab3_868 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_868
+DROP VIEW IF EXISTS view_3_tab3_868 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32819,13 +32819,13 @@ SELECT pk FROM tab4 WHERE ((col4 > 771.52) AND col3 = 917)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_868
+DROP VIEW IF EXISTS view_1_tab4_868 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_868
+DROP VIEW IF EXISTS view_2_tab4_868 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_868
+DROP VIEW IF EXISTS view_3_tab4_868 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32916,13 +32916,13 @@ SELECT pk FROM tab0 WHERE (((col0 > 796 OR ((((col0 < 642)) AND (((((col1 < 435.
 55 values hashing to edc4fdd25a6d0ffc2942e63fc2198481
 
 statement ok
-DROP VIEW view_1_tab0_869
+DROP VIEW IF EXISTS view_1_tab0_869 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_869
+DROP VIEW IF EXISTS view_2_tab0_869 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_869
+DROP VIEW IF EXISTS view_3_tab0_869 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33013,13 +33013,13 @@ SELECT pk FROM tab1 WHERE (((col0 > 796 OR ((((col0 < 642)) AND (((((col1 < 435.
 55 values hashing to edc4fdd25a6d0ffc2942e63fc2198481
 
 statement ok
-DROP VIEW view_1_tab1_869
+DROP VIEW IF EXISTS view_1_tab1_869 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_869
+DROP VIEW IF EXISTS view_2_tab1_869 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_869
+DROP VIEW IF EXISTS view_3_tab1_869 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33110,13 +33110,13 @@ SELECT pk FROM tab2 WHERE (((col0 > 796 OR ((((col0 < 642)) AND (((((col1 < 435.
 55 values hashing to edc4fdd25a6d0ffc2942e63fc2198481
 
 statement ok
-DROP VIEW view_1_tab2_869
+DROP VIEW IF EXISTS view_1_tab2_869 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_869
+DROP VIEW IF EXISTS view_2_tab2_869 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_869
+DROP VIEW IF EXISTS view_3_tab2_869 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33207,13 +33207,13 @@ SELECT pk FROM tab3 WHERE (((col0 > 796 OR ((((col0 < 642)) AND (((((col1 < 435.
 55 values hashing to edc4fdd25a6d0ffc2942e63fc2198481
 
 statement ok
-DROP VIEW view_1_tab3_869
+DROP VIEW IF EXISTS view_1_tab3_869 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_869
+DROP VIEW IF EXISTS view_2_tab3_869 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_869
+DROP VIEW IF EXISTS view_3_tab3_869 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33304,11 +33304,11 @@ SELECT pk FROM tab4 WHERE (((col0 > 796 OR ((((col0 < 642)) AND (((((col1 < 435.
 55 values hashing to edc4fdd25a6d0ffc2942e63fc2198481
 
 statement ok
-DROP VIEW view_1_tab4_869
+DROP VIEW IF EXISTS view_1_tab4_869 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_869
+DROP VIEW IF EXISTS view_2_tab4_869 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_869
+DROP VIEW IF EXISTS view_3_tab4_869 CASCADE
 

--- a/test/index/view/100/slt_good_5.test
+++ b/test/index/view/100/slt_good_5.test
@@ -458,13 +458,13 @@ SELECT pk FROM tab0 WHERE ((((col4 > 698.8))) OR col0 <= 862 OR (col3 >= 952))
 92 values hashing to b1e745ce60cff4983836592609391463
 
 statement ok
-DROP VIEW view_1_tab0_870
+DROP VIEW IF EXISTS view_1_tab0_870 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_870
+DROP VIEW IF EXISTS view_2_tab0_870 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_870
+DROP VIEW IF EXISTS view_3_tab0_870 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -555,13 +555,13 @@ SELECT pk FROM tab1 WHERE ((((col4 > 698.8))) OR col0 <= 862 OR (col3 >= 952))
 92 values hashing to b1e745ce60cff4983836592609391463
 
 statement ok
-DROP VIEW view_1_tab1_870
+DROP VIEW IF EXISTS view_1_tab1_870 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_870
+DROP VIEW IF EXISTS view_2_tab1_870 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_870
+DROP VIEW IF EXISTS view_3_tab1_870 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -652,13 +652,13 @@ SELECT pk FROM tab2 WHERE ((((col4 > 698.8))) OR col0 <= 862 OR (col3 >= 952))
 92 values hashing to b1e745ce60cff4983836592609391463
 
 statement ok
-DROP VIEW view_1_tab2_870
+DROP VIEW IF EXISTS view_1_tab2_870 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_870
+DROP VIEW IF EXISTS view_2_tab2_870 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_870
+DROP VIEW IF EXISTS view_3_tab2_870 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -749,13 +749,13 @@ SELECT pk FROM tab3 WHERE ((((col4 > 698.8))) OR col0 <= 862 OR (col3 >= 952))
 92 values hashing to b1e745ce60cff4983836592609391463
 
 statement ok
-DROP VIEW view_1_tab3_870
+DROP VIEW IF EXISTS view_1_tab3_870 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_870
+DROP VIEW IF EXISTS view_2_tab3_870 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_870
+DROP VIEW IF EXISTS view_3_tab3_870 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -846,13 +846,13 @@ SELECT pk FROM tab4 WHERE ((((col4 > 698.8))) OR col0 <= 862 OR (col3 >= 952))
 92 values hashing to b1e745ce60cff4983836592609391463
 
 statement ok
-DROP VIEW view_1_tab4_870
+DROP VIEW IF EXISTS view_1_tab4_870 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_870
+DROP VIEW IF EXISTS view_2_tab4_870 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_870
+DROP VIEW IF EXISTS view_3_tab4_870 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -943,13 +943,13 @@ SELECT pk FROM tab0 WHERE (col3 > 439) AND col3 > 529
 46 values hashing to f238b5cb38f326d95a9b3df92c1be7ed
 
 statement ok
-DROP VIEW view_1_tab0_871
+DROP VIEW IF EXISTS view_1_tab0_871 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_871
+DROP VIEW IF EXISTS view_2_tab0_871 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_871
+DROP VIEW IF EXISTS view_3_tab0_871 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1040,13 +1040,13 @@ SELECT pk FROM tab1 WHERE (col3 > 439) AND col3 > 529
 46 values hashing to f238b5cb38f326d95a9b3df92c1be7ed
 
 statement ok
-DROP VIEW view_1_tab1_871
+DROP VIEW IF EXISTS view_1_tab1_871 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_871
+DROP VIEW IF EXISTS view_2_tab1_871 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_871
+DROP VIEW IF EXISTS view_3_tab1_871 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1137,13 +1137,13 @@ SELECT pk FROM tab2 WHERE (col3 > 439) AND col3 > 529
 46 values hashing to f238b5cb38f326d95a9b3df92c1be7ed
 
 statement ok
-DROP VIEW view_1_tab2_871
+DROP VIEW IF EXISTS view_1_tab2_871 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_871
+DROP VIEW IF EXISTS view_2_tab2_871 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_871
+DROP VIEW IF EXISTS view_3_tab2_871 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1234,13 +1234,13 @@ SELECT pk FROM tab3 WHERE (col3 > 439) AND col3 > 529
 46 values hashing to f238b5cb38f326d95a9b3df92c1be7ed
 
 statement ok
-DROP VIEW view_1_tab3_871
+DROP VIEW IF EXISTS view_1_tab3_871 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_871
+DROP VIEW IF EXISTS view_2_tab3_871 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_871
+DROP VIEW IF EXISTS view_3_tab3_871 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1331,13 +1331,13 @@ SELECT pk FROM tab4 WHERE (col3 > 439) AND col3 > 529
 46 values hashing to f238b5cb38f326d95a9b3df92c1be7ed
 
 statement ok
-DROP VIEW view_1_tab4_871
+DROP VIEW IF EXISTS view_1_tab4_871 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_871
+DROP VIEW IF EXISTS view_2_tab4_871 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_871
+DROP VIEW IF EXISTS view_3_tab4_871 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1428,13 +1428,13 @@ SELECT pk FROM tab0 WHERE col3 <= 588 OR (col1 <= 3.89)
 60 values hashing to 7d59b308c9f4e377f6369e4144bd24d2
 
 statement ok
-DROP VIEW view_1_tab0_872
+DROP VIEW IF EXISTS view_1_tab0_872 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_872
+DROP VIEW IF EXISTS view_2_tab0_872 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_872
+DROP VIEW IF EXISTS view_3_tab0_872 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1525,13 +1525,13 @@ SELECT pk FROM tab1 WHERE col3 <= 588 OR (col1 <= 3.89)
 60 values hashing to 7d59b308c9f4e377f6369e4144bd24d2
 
 statement ok
-DROP VIEW view_1_tab1_872
+DROP VIEW IF EXISTS view_1_tab1_872 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_872
+DROP VIEW IF EXISTS view_2_tab1_872 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_872
+DROP VIEW IF EXISTS view_3_tab1_872 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1622,13 +1622,13 @@ SELECT pk FROM tab2 WHERE col3 <= 588 OR (col1 <= 3.89)
 60 values hashing to 7d59b308c9f4e377f6369e4144bd24d2
 
 statement ok
-DROP VIEW view_1_tab2_872
+DROP VIEW IF EXISTS view_1_tab2_872 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_872
+DROP VIEW IF EXISTS view_2_tab2_872 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_872
+DROP VIEW IF EXISTS view_3_tab2_872 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1719,13 +1719,13 @@ SELECT pk FROM tab3 WHERE col3 <= 588 OR (col1 <= 3.89)
 60 values hashing to 7d59b308c9f4e377f6369e4144bd24d2
 
 statement ok
-DROP VIEW view_1_tab3_872
+DROP VIEW IF EXISTS view_1_tab3_872 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_872
+DROP VIEW IF EXISTS view_2_tab3_872 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_872
+DROP VIEW IF EXISTS view_3_tab3_872 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1816,13 +1816,13 @@ SELECT pk FROM tab4 WHERE col3 <= 588 OR (col1 <= 3.89)
 60 values hashing to 7d59b308c9f4e377f6369e4144bd24d2
 
 statement ok
-DROP VIEW view_1_tab4_872
+DROP VIEW IF EXISTS view_1_tab4_872 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_872
+DROP VIEW IF EXISTS view_2_tab4_872 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_872
+DROP VIEW IF EXISTS view_3_tab4_872 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -1913,13 +1913,13 @@ SELECT pk FROM tab0 WHERE col0 > 649
 40 values hashing to 9c8b56e8c08fb7a96735dc48f20e81f8
 
 statement ok
-DROP VIEW view_1_tab0_873
+DROP VIEW IF EXISTS view_1_tab0_873 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_873
+DROP VIEW IF EXISTS view_2_tab0_873 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_873
+DROP VIEW IF EXISTS view_3_tab0_873 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2010,13 +2010,13 @@ SELECT pk FROM tab1 WHERE col0 > 649
 40 values hashing to 9c8b56e8c08fb7a96735dc48f20e81f8
 
 statement ok
-DROP VIEW view_1_tab1_873
+DROP VIEW IF EXISTS view_1_tab1_873 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_873
+DROP VIEW IF EXISTS view_2_tab1_873 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_873
+DROP VIEW IF EXISTS view_3_tab1_873 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2107,13 +2107,13 @@ SELECT pk FROM tab2 WHERE col0 > 649
 40 values hashing to 9c8b56e8c08fb7a96735dc48f20e81f8
 
 statement ok
-DROP VIEW view_1_tab2_873
+DROP VIEW IF EXISTS view_1_tab2_873 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_873
+DROP VIEW IF EXISTS view_2_tab2_873 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_873
+DROP VIEW IF EXISTS view_3_tab2_873 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2204,13 +2204,13 @@ SELECT pk FROM tab3 WHERE col0 > 649
 40 values hashing to 9c8b56e8c08fb7a96735dc48f20e81f8
 
 statement ok
-DROP VIEW view_1_tab3_873
+DROP VIEW IF EXISTS view_1_tab3_873 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_873
+DROP VIEW IF EXISTS view_2_tab3_873 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_873
+DROP VIEW IF EXISTS view_3_tab3_873 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2301,13 +2301,13 @@ SELECT pk FROM tab4 WHERE col0 > 649
 40 values hashing to 9c8b56e8c08fb7a96735dc48f20e81f8
 
 statement ok
-DROP VIEW view_1_tab4_873
+DROP VIEW IF EXISTS view_1_tab4_873 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_873
+DROP VIEW IF EXISTS view_2_tab4_873 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_873
+DROP VIEW IF EXISTS view_3_tab4_873 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2398,13 +2398,13 @@ SELECT pk FROM tab0 WHERE col0 > 528
 54 values hashing to 3a65448d8469474da37dd9c8f4b02879
 
 statement ok
-DROP VIEW view_1_tab0_874
+DROP VIEW IF EXISTS view_1_tab0_874 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_874
+DROP VIEW IF EXISTS view_2_tab0_874 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_874
+DROP VIEW IF EXISTS view_3_tab0_874 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2495,13 +2495,13 @@ SELECT pk FROM tab1 WHERE col0 > 528
 54 values hashing to 3a65448d8469474da37dd9c8f4b02879
 
 statement ok
-DROP VIEW view_1_tab1_874
+DROP VIEW IF EXISTS view_1_tab1_874 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_874
+DROP VIEW IF EXISTS view_2_tab1_874 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_874
+DROP VIEW IF EXISTS view_3_tab1_874 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2592,13 +2592,13 @@ SELECT pk FROM tab2 WHERE col0 > 528
 54 values hashing to 3a65448d8469474da37dd9c8f4b02879
 
 statement ok
-DROP VIEW view_1_tab2_874
+DROP VIEW IF EXISTS view_1_tab2_874 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_874
+DROP VIEW IF EXISTS view_2_tab2_874 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_874
+DROP VIEW IF EXISTS view_3_tab2_874 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2689,13 +2689,13 @@ SELECT pk FROM tab3 WHERE col0 > 528
 54 values hashing to 3a65448d8469474da37dd9c8f4b02879
 
 statement ok
-DROP VIEW view_1_tab3_874
+DROP VIEW IF EXISTS view_1_tab3_874 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_874
+DROP VIEW IF EXISTS view_2_tab3_874 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_874
+DROP VIEW IF EXISTS view_3_tab3_874 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2786,13 +2786,13 @@ SELECT pk FROM tab4 WHERE col0 > 528
 54 values hashing to 3a65448d8469474da37dd9c8f4b02879
 
 statement ok
-DROP VIEW view_1_tab4_874
+DROP VIEW IF EXISTS view_1_tab4_874 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_874
+DROP VIEW IF EXISTS view_2_tab4_874 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_874
+DROP VIEW IF EXISTS view_3_tab4_874 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2883,13 +2883,13 @@ SELECT pk FROM tab0 WHERE col4 < 247.66 OR col4 IS NULL
 31 values hashing to 8c154aaa2025133fa0c050e832ccc9e1
 
 statement ok
-DROP VIEW view_1_tab0_875
+DROP VIEW IF EXISTS view_1_tab0_875 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_875
+DROP VIEW IF EXISTS view_2_tab0_875 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_875
+DROP VIEW IF EXISTS view_3_tab0_875 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -2980,13 +2980,13 @@ SELECT pk FROM tab1 WHERE col4 < 247.66 OR col4 IS NULL
 31 values hashing to 8c154aaa2025133fa0c050e832ccc9e1
 
 statement ok
-DROP VIEW view_1_tab1_875
+DROP VIEW IF EXISTS view_1_tab1_875 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_875
+DROP VIEW IF EXISTS view_2_tab1_875 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_875
+DROP VIEW IF EXISTS view_3_tab1_875 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3077,13 +3077,13 @@ SELECT pk FROM tab2 WHERE col4 < 247.66 OR col4 IS NULL
 31 values hashing to 8c154aaa2025133fa0c050e832ccc9e1
 
 statement ok
-DROP VIEW view_1_tab2_875
+DROP VIEW IF EXISTS view_1_tab2_875 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_875
+DROP VIEW IF EXISTS view_2_tab2_875 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_875
+DROP VIEW IF EXISTS view_3_tab2_875 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3174,13 +3174,13 @@ SELECT pk FROM tab3 WHERE col4 < 247.66 OR col4 IS NULL
 31 values hashing to 8c154aaa2025133fa0c050e832ccc9e1
 
 statement ok
-DROP VIEW view_1_tab3_875
+DROP VIEW IF EXISTS view_1_tab3_875 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_875
+DROP VIEW IF EXISTS view_2_tab3_875 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_875
+DROP VIEW IF EXISTS view_3_tab3_875 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3271,13 +3271,13 @@ SELECT pk FROM tab4 WHERE col4 < 247.66 OR col4 IS NULL
 31 values hashing to 8c154aaa2025133fa0c050e832ccc9e1
 
 statement ok
-DROP VIEW view_1_tab4_875
+DROP VIEW IF EXISTS view_1_tab4_875 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_875
+DROP VIEW IF EXISTS view_2_tab4_875 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_875
+DROP VIEW IF EXISTS view_3_tab4_875 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3386,13 +3386,13 @@ SELECT pk FROM tab0 WHERE ((((col0 > 796))) AND col4 < 334.48)
 75
 
 statement ok
-DROP VIEW view_1_tab0_876
+DROP VIEW IF EXISTS view_1_tab0_876 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_876
+DROP VIEW IF EXISTS view_2_tab0_876 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_876
+DROP VIEW IF EXISTS view_3_tab0_876 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3501,13 +3501,13 @@ SELECT pk FROM tab1 WHERE ((((col0 > 796))) AND col4 < 334.48)
 75
 
 statement ok
-DROP VIEW view_1_tab1_876
+DROP VIEW IF EXISTS view_1_tab1_876 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_876
+DROP VIEW IF EXISTS view_2_tab1_876 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_876
+DROP VIEW IF EXISTS view_3_tab1_876 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3616,13 +3616,13 @@ SELECT pk FROM tab2 WHERE ((((col0 > 796))) AND col4 < 334.48)
 75
 
 statement ok
-DROP VIEW view_1_tab2_876
+DROP VIEW IF EXISTS view_1_tab2_876 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_876
+DROP VIEW IF EXISTS view_2_tab2_876 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_876
+DROP VIEW IF EXISTS view_3_tab2_876 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3731,13 +3731,13 @@ SELECT pk FROM tab3 WHERE ((((col0 > 796))) AND col4 < 334.48)
 75
 
 statement ok
-DROP VIEW view_1_tab3_876
+DROP VIEW IF EXISTS view_1_tab3_876 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_876
+DROP VIEW IF EXISTS view_2_tab3_876 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_876
+DROP VIEW IF EXISTS view_3_tab3_876 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3846,13 +3846,13 @@ SELECT pk FROM tab4 WHERE ((((col0 > 796))) AND col4 < 334.48)
 75
 
 statement ok
-DROP VIEW view_1_tab4_876
+DROP VIEW IF EXISTS view_1_tab4_876 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_876
+DROP VIEW IF EXISTS view_2_tab4_876 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_876
+DROP VIEW IF EXISTS view_3_tab4_876 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3938,13 +3938,13 @@ SELECT pk FROM tab0 WHERE ((col4 = 82.92) AND (col4 > 233.70 AND col1 > 258.21) 
 ----
 
 statement ok
-DROP VIEW view_1_tab0_877
+DROP VIEW IF EXISTS view_1_tab0_877 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_877
+DROP VIEW IF EXISTS view_2_tab0_877 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_877
+DROP VIEW IF EXISTS view_3_tab0_877 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4030,13 +4030,13 @@ SELECT pk FROM tab1 WHERE ((col4 = 82.92) AND (col4 > 233.70 AND col1 > 258.21) 
 ----
 
 statement ok
-DROP VIEW view_1_tab1_877
+DROP VIEW IF EXISTS view_1_tab1_877 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_877
+DROP VIEW IF EXISTS view_2_tab1_877 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_877
+DROP VIEW IF EXISTS view_3_tab1_877 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4122,13 +4122,13 @@ SELECT pk FROM tab2 WHERE ((col4 = 82.92) AND (col4 > 233.70 AND col1 > 258.21) 
 ----
 
 statement ok
-DROP VIEW view_1_tab2_877
+DROP VIEW IF EXISTS view_1_tab2_877 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_877
+DROP VIEW IF EXISTS view_2_tab2_877 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_877
+DROP VIEW IF EXISTS view_3_tab2_877 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4214,13 +4214,13 @@ SELECT pk FROM tab3 WHERE ((col4 = 82.92) AND (col4 > 233.70 AND col1 > 258.21) 
 ----
 
 statement ok
-DROP VIEW view_1_tab3_877
+DROP VIEW IF EXISTS view_1_tab3_877 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_877
+DROP VIEW IF EXISTS view_2_tab3_877 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_877
+DROP VIEW IF EXISTS view_3_tab3_877 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4306,13 +4306,13 @@ SELECT pk FROM tab4 WHERE ((col4 = 82.92) AND (col4 > 233.70 AND col1 > 258.21) 
 ----
 
 statement ok
-DROP VIEW view_1_tab4_877
+DROP VIEW IF EXISTS view_1_tab4_877 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_877
+DROP VIEW IF EXISTS view_2_tab4_877 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_877
+DROP VIEW IF EXISTS view_3_tab4_877 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4426,13 +4426,13 @@ SELECT pk FROM tab0 WHERE col1 <= 33.2
 51
 
 statement ok
-DROP VIEW view_1_tab0_879
+DROP VIEW IF EXISTS view_1_tab0_879 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_879
+DROP VIEW IF EXISTS view_2_tab0_879 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_879
+DROP VIEW IF EXISTS view_3_tab0_879 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4546,13 +4546,13 @@ SELECT pk FROM tab1 WHERE col1 <= 33.2
 51
 
 statement ok
-DROP VIEW view_1_tab1_879
+DROP VIEW IF EXISTS view_1_tab1_879 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_879
+DROP VIEW IF EXISTS view_2_tab1_879 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_879
+DROP VIEW IF EXISTS view_3_tab1_879 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4666,13 +4666,13 @@ SELECT pk FROM tab2 WHERE col1 <= 33.2
 51
 
 statement ok
-DROP VIEW view_1_tab2_879
+DROP VIEW IF EXISTS view_1_tab2_879 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_879
+DROP VIEW IF EXISTS view_2_tab2_879 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_879
+DROP VIEW IF EXISTS view_3_tab2_879 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4786,13 +4786,13 @@ SELECT pk FROM tab3 WHERE col1 <= 33.2
 51
 
 statement ok
-DROP VIEW view_1_tab3_879
+DROP VIEW IF EXISTS view_1_tab3_879 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_879
+DROP VIEW IF EXISTS view_2_tab3_879 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_879
+DROP VIEW IF EXISTS view_3_tab3_879 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4906,13 +4906,13 @@ SELECT pk FROM tab4 WHERE col1 <= 33.2
 51
 
 statement ok
-DROP VIEW view_1_tab4_879
+DROP VIEW IF EXISTS view_1_tab4_879 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_879
+DROP VIEW IF EXISTS view_2_tab4_879 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_879
+DROP VIEW IF EXISTS view_3_tab4_879 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4998,13 +4998,13 @@ SELECT pk FROM tab0 WHERE col3 = 962
 ----
 
 statement ok
-DROP VIEW view_1_tab0_880
+DROP VIEW IF EXISTS view_1_tab0_880 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_880
+DROP VIEW IF EXISTS view_2_tab0_880 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_880
+DROP VIEW IF EXISTS view_3_tab0_880 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5090,13 +5090,13 @@ SELECT pk FROM tab1 WHERE col3 = 962
 ----
 
 statement ok
-DROP VIEW view_1_tab1_880
+DROP VIEW IF EXISTS view_1_tab1_880 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_880
+DROP VIEW IF EXISTS view_2_tab1_880 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_880
+DROP VIEW IF EXISTS view_3_tab1_880 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5182,13 +5182,13 @@ SELECT pk FROM tab2 WHERE col3 = 962
 ----
 
 statement ok
-DROP VIEW view_1_tab2_880
+DROP VIEW IF EXISTS view_1_tab2_880 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_880
+DROP VIEW IF EXISTS view_2_tab2_880 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_880
+DROP VIEW IF EXISTS view_3_tab2_880 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5274,13 +5274,13 @@ SELECT pk FROM tab3 WHERE col3 = 962
 ----
 
 statement ok
-DROP VIEW view_1_tab3_880
+DROP VIEW IF EXISTS view_1_tab3_880 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_880
+DROP VIEW IF EXISTS view_2_tab3_880 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_880
+DROP VIEW IF EXISTS view_3_tab3_880 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5366,13 +5366,13 @@ SELECT pk FROM tab4 WHERE col3 = 962
 ----
 
 statement ok
-DROP VIEW view_1_tab4_880
+DROP VIEW IF EXISTS view_1_tab4_880 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_880
+DROP VIEW IF EXISTS view_2_tab4_880 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_880
+DROP VIEW IF EXISTS view_3_tab4_880 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5463,13 +5463,13 @@ SELECT pk FROM tab0 WHERE col3 > 987 OR col3 < 249
 28 values hashing to 09592e6e8a16e1deb4b110b6908e98e5
 
 statement ok
-DROP VIEW view_1_tab0_881
+DROP VIEW IF EXISTS view_1_tab0_881 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_881
+DROP VIEW IF EXISTS view_2_tab0_881 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_881
+DROP VIEW IF EXISTS view_3_tab0_881 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5560,13 +5560,13 @@ SELECT pk FROM tab1 WHERE col3 > 987 OR col3 < 249
 28 values hashing to 09592e6e8a16e1deb4b110b6908e98e5
 
 statement ok
-DROP VIEW view_1_tab1_881
+DROP VIEW IF EXISTS view_1_tab1_881 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_881
+DROP VIEW IF EXISTS view_2_tab1_881 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_881
+DROP VIEW IF EXISTS view_3_tab1_881 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5657,13 +5657,13 @@ SELECT pk FROM tab2 WHERE col3 > 987 OR col3 < 249
 28 values hashing to 09592e6e8a16e1deb4b110b6908e98e5
 
 statement ok
-DROP VIEW view_1_tab2_881
+DROP VIEW IF EXISTS view_1_tab2_881 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_881
+DROP VIEW IF EXISTS view_2_tab2_881 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_881
+DROP VIEW IF EXISTS view_3_tab2_881 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5754,13 +5754,13 @@ SELECT pk FROM tab3 WHERE col3 > 987 OR col3 < 249
 28 values hashing to 09592e6e8a16e1deb4b110b6908e98e5
 
 statement ok
-DROP VIEW view_1_tab3_881
+DROP VIEW IF EXISTS view_1_tab3_881 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_881
+DROP VIEW IF EXISTS view_2_tab3_881 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_881
+DROP VIEW IF EXISTS view_3_tab3_881 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5851,13 +5851,13 @@ SELECT pk FROM tab4 WHERE col3 > 987 OR col3 < 249
 28 values hashing to 09592e6e8a16e1deb4b110b6908e98e5
 
 statement ok
-DROP VIEW view_1_tab4_881
+DROP VIEW IF EXISTS view_1_tab4_881 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_881
+DROP VIEW IF EXISTS view_2_tab4_881 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_881
+DROP VIEW IF EXISTS view_3_tab4_881 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5943,13 +5943,13 @@ SELECT pk FROM tab0 WHERE col3 IN (756,339,745,487)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_882
+DROP VIEW IF EXISTS view_1_tab0_882 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_882
+DROP VIEW IF EXISTS view_2_tab0_882 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_882
+DROP VIEW IF EXISTS view_3_tab0_882 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6035,13 +6035,13 @@ SELECT pk FROM tab1 WHERE col3 IN (756,339,745,487)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_882
+DROP VIEW IF EXISTS view_1_tab1_882 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_882
+DROP VIEW IF EXISTS view_2_tab1_882 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_882
+DROP VIEW IF EXISTS view_3_tab1_882 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6127,13 +6127,13 @@ SELECT pk FROM tab2 WHERE col3 IN (756,339,745,487)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_882
+DROP VIEW IF EXISTS view_1_tab2_882 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_882
+DROP VIEW IF EXISTS view_2_tab2_882 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_882
+DROP VIEW IF EXISTS view_3_tab2_882 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6219,13 +6219,13 @@ SELECT pk FROM tab3 WHERE col3 IN (756,339,745,487)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_882
+DROP VIEW IF EXISTS view_1_tab3_882 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_882
+DROP VIEW IF EXISTS view_2_tab3_882 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_882
+DROP VIEW IF EXISTS view_3_tab3_882 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6311,13 +6311,13 @@ SELECT pk FROM tab4 WHERE col3 IN (756,339,745,487)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_882
+DROP VIEW IF EXISTS view_1_tab4_882 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_882
+DROP VIEW IF EXISTS view_2_tab4_882 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_882
+DROP VIEW IF EXISTS view_3_tab4_882 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6403,13 +6403,13 @@ SELECT pk FROM tab0 WHERE col4 = 31.39
 ----
 
 statement ok
-DROP VIEW view_1_tab0_883
+DROP VIEW IF EXISTS view_1_tab0_883 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_883
+DROP VIEW IF EXISTS view_2_tab0_883 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_883
+DROP VIEW IF EXISTS view_3_tab0_883 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6495,13 +6495,13 @@ SELECT pk FROM tab1 WHERE col4 = 31.39
 ----
 
 statement ok
-DROP VIEW view_1_tab1_883
+DROP VIEW IF EXISTS view_1_tab1_883 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_883
+DROP VIEW IF EXISTS view_2_tab1_883 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_883
+DROP VIEW IF EXISTS view_3_tab1_883 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6587,13 +6587,13 @@ SELECT pk FROM tab2 WHERE col4 = 31.39
 ----
 
 statement ok
-DROP VIEW view_1_tab2_883
+DROP VIEW IF EXISTS view_1_tab2_883 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_883
+DROP VIEW IF EXISTS view_2_tab2_883 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_883
+DROP VIEW IF EXISTS view_3_tab2_883 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6679,13 +6679,13 @@ SELECT pk FROM tab3 WHERE col4 = 31.39
 ----
 
 statement ok
-DROP VIEW view_1_tab3_883
+DROP VIEW IF EXISTS view_1_tab3_883 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_883
+DROP VIEW IF EXISTS view_2_tab3_883 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_883
+DROP VIEW IF EXISTS view_3_tab3_883 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6771,13 +6771,13 @@ SELECT pk FROM tab4 WHERE col4 = 31.39
 ----
 
 statement ok
-DROP VIEW view_1_tab4_883
+DROP VIEW IF EXISTS view_1_tab4_883 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_883
+DROP VIEW IF EXISTS view_2_tab4_883 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_883
+DROP VIEW IF EXISTS view_3_tab4_883 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6866,13 +6866,13 @@ SELECT pk FROM tab0 WHERE ((col1 <= 723.96)) OR col1 > 109.52 OR (col4 > 664.40)
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab0_884
+DROP VIEW IF EXISTS view_1_tab0_884 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_884
+DROP VIEW IF EXISTS view_2_tab0_884 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_884
+DROP VIEW IF EXISTS view_3_tab0_884 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6961,13 +6961,13 @@ SELECT pk FROM tab1 WHERE ((col1 <= 723.96)) OR col1 > 109.52 OR (col4 > 664.40)
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab1_884
+DROP VIEW IF EXISTS view_1_tab1_884 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_884
+DROP VIEW IF EXISTS view_2_tab1_884 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_884
+DROP VIEW IF EXISTS view_3_tab1_884 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7056,13 +7056,13 @@ SELECT pk FROM tab2 WHERE ((col1 <= 723.96)) OR col1 > 109.52 OR (col4 > 664.40)
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab2_884
+DROP VIEW IF EXISTS view_1_tab2_884 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_884
+DROP VIEW IF EXISTS view_2_tab2_884 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_884
+DROP VIEW IF EXISTS view_3_tab2_884 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7151,13 +7151,13 @@ SELECT pk FROM tab3 WHERE ((col1 <= 723.96)) OR col1 > 109.52 OR (col4 > 664.40)
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab3_884
+DROP VIEW IF EXISTS view_1_tab3_884 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_884
+DROP VIEW IF EXISTS view_2_tab3_884 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_884
+DROP VIEW IF EXISTS view_3_tab3_884 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7246,13 +7246,13 @@ SELECT pk FROM tab4 WHERE ((col1 <= 723.96)) OR col1 > 109.52 OR (col4 > 664.40)
 100 values hashing to d7fd31c3916c207fd3117332326c3f37
 
 statement ok
-DROP VIEW view_1_tab4_884
+DROP VIEW IF EXISTS view_1_tab4_884 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_884
+DROP VIEW IF EXISTS view_2_tab4_884 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_884
+DROP VIEW IF EXISTS view_3_tab4_884 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7343,13 +7343,13 @@ SELECT pk FROM tab0 WHERE col3 < 419
 48 values hashing to 5401d4840718c0fe51deb0a80516444a
 
 statement ok
-DROP VIEW view_1_tab0_885
+DROP VIEW IF EXISTS view_1_tab0_885 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_885
+DROP VIEW IF EXISTS view_2_tab0_885 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_885
+DROP VIEW IF EXISTS view_3_tab0_885 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7440,13 +7440,13 @@ SELECT pk FROM tab1 WHERE col3 < 419
 48 values hashing to 5401d4840718c0fe51deb0a80516444a
 
 statement ok
-DROP VIEW view_1_tab1_885
+DROP VIEW IF EXISTS view_1_tab1_885 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_885
+DROP VIEW IF EXISTS view_2_tab1_885 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_885
+DROP VIEW IF EXISTS view_3_tab1_885 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7537,13 +7537,13 @@ SELECT pk FROM tab2 WHERE col3 < 419
 48 values hashing to 5401d4840718c0fe51deb0a80516444a
 
 statement ok
-DROP VIEW view_1_tab2_885
+DROP VIEW IF EXISTS view_1_tab2_885 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_885
+DROP VIEW IF EXISTS view_2_tab2_885 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_885
+DROP VIEW IF EXISTS view_3_tab2_885 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7634,13 +7634,13 @@ SELECT pk FROM tab3 WHERE col3 < 419
 48 values hashing to 5401d4840718c0fe51deb0a80516444a
 
 statement ok
-DROP VIEW view_1_tab3_885
+DROP VIEW IF EXISTS view_1_tab3_885 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_885
+DROP VIEW IF EXISTS view_2_tab3_885 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_885
+DROP VIEW IF EXISTS view_3_tab3_885 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7731,13 +7731,13 @@ SELECT pk FROM tab4 WHERE col3 < 419
 48 values hashing to 5401d4840718c0fe51deb0a80516444a
 
 statement ok
-DROP VIEW view_1_tab4_885
+DROP VIEW IF EXISTS view_1_tab4_885 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_885
+DROP VIEW IF EXISTS view_2_tab4_885 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_885
+DROP VIEW IF EXISTS view_3_tab4_885 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7828,13 +7828,13 @@ SELECT pk FROM tab0 WHERE col1 < 85.65 OR col0 <= 401 AND col1 > 37.94 OR (col3 
 44 values hashing to cc29967398752ecb8720ba863f645332
 
 statement ok
-DROP VIEW view_1_tab0_886
+DROP VIEW IF EXISTS view_1_tab0_886 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_886
+DROP VIEW IF EXISTS view_2_tab0_886 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_886
+DROP VIEW IF EXISTS view_3_tab0_886 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7925,13 +7925,13 @@ SELECT pk FROM tab1 WHERE col1 < 85.65 OR col0 <= 401 AND col1 > 37.94 OR (col3 
 44 values hashing to cc29967398752ecb8720ba863f645332
 
 statement ok
-DROP VIEW view_1_tab1_886
+DROP VIEW IF EXISTS view_1_tab1_886 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_886
+DROP VIEW IF EXISTS view_2_tab1_886 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_886
+DROP VIEW IF EXISTS view_3_tab1_886 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8022,13 +8022,13 @@ SELECT pk FROM tab2 WHERE col1 < 85.65 OR col0 <= 401 AND col1 > 37.94 OR (col3 
 44 values hashing to cc29967398752ecb8720ba863f645332
 
 statement ok
-DROP VIEW view_1_tab2_886
+DROP VIEW IF EXISTS view_1_tab2_886 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_886
+DROP VIEW IF EXISTS view_2_tab2_886 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_886
+DROP VIEW IF EXISTS view_3_tab2_886 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8119,13 +8119,13 @@ SELECT pk FROM tab3 WHERE col1 < 85.65 OR col0 <= 401 AND col1 > 37.94 OR (col3 
 44 values hashing to cc29967398752ecb8720ba863f645332
 
 statement ok
-DROP VIEW view_1_tab3_886
+DROP VIEW IF EXISTS view_1_tab3_886 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_886
+DROP VIEW IF EXISTS view_2_tab3_886 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_886
+DROP VIEW IF EXISTS view_3_tab3_886 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8216,13 +8216,13 @@ SELECT pk FROM tab4 WHERE col1 < 85.65 OR col0 <= 401 AND col1 > 37.94 OR (col3 
 44 values hashing to cc29967398752ecb8720ba863f645332
 
 statement ok
-DROP VIEW view_1_tab4_886
+DROP VIEW IF EXISTS view_1_tab4_886 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_886
+DROP VIEW IF EXISTS view_2_tab4_886 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_886
+DROP VIEW IF EXISTS view_3_tab4_886 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8308,13 +8308,13 @@ SELECT pk FROM tab0 WHERE ((((col3 > 391 AND col4 > 703.53))) AND (col3 >= 109) 
 ----
 
 statement ok
-DROP VIEW view_1_tab0_887
+DROP VIEW IF EXISTS view_1_tab0_887 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_887
+DROP VIEW IF EXISTS view_2_tab0_887 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_887
+DROP VIEW IF EXISTS view_3_tab0_887 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8400,13 +8400,13 @@ SELECT pk FROM tab1 WHERE ((((col3 > 391 AND col4 > 703.53))) AND (col3 >= 109) 
 ----
 
 statement ok
-DROP VIEW view_1_tab1_887
+DROP VIEW IF EXISTS view_1_tab1_887 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_887
+DROP VIEW IF EXISTS view_2_tab1_887 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_887
+DROP VIEW IF EXISTS view_3_tab1_887 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8492,13 +8492,13 @@ SELECT pk FROM tab2 WHERE ((((col3 > 391 AND col4 > 703.53))) AND (col3 >= 109) 
 ----
 
 statement ok
-DROP VIEW view_1_tab2_887
+DROP VIEW IF EXISTS view_1_tab2_887 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_887
+DROP VIEW IF EXISTS view_2_tab2_887 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_887
+DROP VIEW IF EXISTS view_3_tab2_887 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8584,13 +8584,13 @@ SELECT pk FROM tab3 WHERE ((((col3 > 391 AND col4 > 703.53))) AND (col3 >= 109) 
 ----
 
 statement ok
-DROP VIEW view_1_tab3_887
+DROP VIEW IF EXISTS view_1_tab3_887 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_887
+DROP VIEW IF EXISTS view_2_tab3_887 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_887
+DROP VIEW IF EXISTS view_3_tab3_887 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8676,13 +8676,13 @@ SELECT pk FROM tab4 WHERE ((((col3 > 391 AND col4 > 703.53))) AND (col3 >= 109) 
 ----
 
 statement ok
-DROP VIEW view_1_tab4_887
+DROP VIEW IF EXISTS view_1_tab4_887 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_887
+DROP VIEW IF EXISTS view_2_tab4_887 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_887
+DROP VIEW IF EXISTS view_3_tab4_887 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8773,13 +8773,13 @@ SELECT pk FROM tab0 WHERE col0 >= 192
 83 values hashing to 203a0d98eee0ba1feb7969031086031c
 
 statement ok
-DROP VIEW view_1_tab0_888
+DROP VIEW IF EXISTS view_1_tab0_888 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_888
+DROP VIEW IF EXISTS view_2_tab0_888 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_888
+DROP VIEW IF EXISTS view_3_tab0_888 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8870,13 +8870,13 @@ SELECT pk FROM tab1 WHERE col0 >= 192
 83 values hashing to 203a0d98eee0ba1feb7969031086031c
 
 statement ok
-DROP VIEW view_1_tab1_888
+DROP VIEW IF EXISTS view_1_tab1_888 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_888
+DROP VIEW IF EXISTS view_2_tab1_888 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_888
+DROP VIEW IF EXISTS view_3_tab1_888 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8967,13 +8967,13 @@ SELECT pk FROM tab2 WHERE col0 >= 192
 83 values hashing to 203a0d98eee0ba1feb7969031086031c
 
 statement ok
-DROP VIEW view_1_tab2_888
+DROP VIEW IF EXISTS view_1_tab2_888 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_888
+DROP VIEW IF EXISTS view_2_tab2_888 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_888
+DROP VIEW IF EXISTS view_3_tab2_888 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9064,13 +9064,13 @@ SELECT pk FROM tab3 WHERE col0 >= 192
 83 values hashing to 203a0d98eee0ba1feb7969031086031c
 
 statement ok
-DROP VIEW view_1_tab3_888
+DROP VIEW IF EXISTS view_1_tab3_888 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_888
+DROP VIEW IF EXISTS view_2_tab3_888 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_888
+DROP VIEW IF EXISTS view_3_tab3_888 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9161,13 +9161,13 @@ SELECT pk FROM tab4 WHERE col0 >= 192
 83 values hashing to 203a0d98eee0ba1feb7969031086031c
 
 statement ok
-DROP VIEW view_1_tab4_888
+DROP VIEW IF EXISTS view_1_tab4_888 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_888
+DROP VIEW IF EXISTS view_2_tab4_888 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_888
+DROP VIEW IF EXISTS view_3_tab4_888 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9258,13 +9258,13 @@ SELECT pk FROM tab0 WHERE (col0 < 813) AND col0 < 594 AND (col4 > 398.52) OR (co
 54 values hashing to e83e2d6386ffd9c35b584b3774081b72
 
 statement ok
-DROP VIEW view_1_tab0_889
+DROP VIEW IF EXISTS view_1_tab0_889 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_889
+DROP VIEW IF EXISTS view_2_tab0_889 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_889
+DROP VIEW IF EXISTS view_3_tab0_889 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9355,13 +9355,13 @@ SELECT pk FROM tab1 WHERE (col0 < 813) AND col0 < 594 AND (col4 > 398.52) OR (co
 54 values hashing to e83e2d6386ffd9c35b584b3774081b72
 
 statement ok
-DROP VIEW view_1_tab1_889
+DROP VIEW IF EXISTS view_1_tab1_889 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_889
+DROP VIEW IF EXISTS view_2_tab1_889 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_889
+DROP VIEW IF EXISTS view_3_tab1_889 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9452,13 +9452,13 @@ SELECT pk FROM tab2 WHERE (col0 < 813) AND col0 < 594 AND (col4 > 398.52) OR (co
 54 values hashing to e83e2d6386ffd9c35b584b3774081b72
 
 statement ok
-DROP VIEW view_1_tab2_889
+DROP VIEW IF EXISTS view_1_tab2_889 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_889
+DROP VIEW IF EXISTS view_2_tab2_889 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_889
+DROP VIEW IF EXISTS view_3_tab2_889 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9549,13 +9549,13 @@ SELECT pk FROM tab3 WHERE (col0 < 813) AND col0 < 594 AND (col4 > 398.52) OR (co
 54 values hashing to e83e2d6386ffd9c35b584b3774081b72
 
 statement ok
-DROP VIEW view_1_tab3_889
+DROP VIEW IF EXISTS view_1_tab3_889 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_889
+DROP VIEW IF EXISTS view_2_tab3_889 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_889
+DROP VIEW IF EXISTS view_3_tab3_889 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9646,13 +9646,13 @@ SELECT pk FROM tab4 WHERE (col0 < 813) AND col0 < 594 AND (col4 > 398.52) OR (co
 54 values hashing to e83e2d6386ffd9c35b584b3774081b72
 
 statement ok
-DROP VIEW view_1_tab4_889
+DROP VIEW IF EXISTS view_1_tab4_889 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_889
+DROP VIEW IF EXISTS view_2_tab4_889 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_889
+DROP VIEW IF EXISTS view_3_tab4_889 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9738,13 +9738,13 @@ SELECT pk FROM tab0 WHERE ((((((col0 = 969) AND (col3 < 198)))))) AND col3 < 61
 ----
 
 statement ok
-DROP VIEW view_1_tab0_890
+DROP VIEW IF EXISTS view_1_tab0_890 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_890
+DROP VIEW IF EXISTS view_2_tab0_890 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_890
+DROP VIEW IF EXISTS view_3_tab0_890 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9830,13 +9830,13 @@ SELECT pk FROM tab1 WHERE ((((((col0 = 969) AND (col3 < 198)))))) AND col3 < 61
 ----
 
 statement ok
-DROP VIEW view_1_tab1_890
+DROP VIEW IF EXISTS view_1_tab1_890 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_890
+DROP VIEW IF EXISTS view_2_tab1_890 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_890
+DROP VIEW IF EXISTS view_3_tab1_890 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9922,13 +9922,13 @@ SELECT pk FROM tab2 WHERE ((((((col0 = 969) AND (col3 < 198)))))) AND col3 < 61
 ----
 
 statement ok
-DROP VIEW view_1_tab2_890
+DROP VIEW IF EXISTS view_1_tab2_890 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_890
+DROP VIEW IF EXISTS view_2_tab2_890 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_890
+DROP VIEW IF EXISTS view_3_tab2_890 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10014,13 +10014,13 @@ SELECT pk FROM tab3 WHERE ((((((col0 = 969) AND (col3 < 198)))))) AND col3 < 61
 ----
 
 statement ok
-DROP VIEW view_1_tab3_890
+DROP VIEW IF EXISTS view_1_tab3_890 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_890
+DROP VIEW IF EXISTS view_2_tab3_890 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_890
+DROP VIEW IF EXISTS view_3_tab3_890 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10106,13 +10106,13 @@ SELECT pk FROM tab4 WHERE ((((((col0 = 969) AND (col3 < 198)))))) AND col3 < 61
 ----
 
 statement ok
-DROP VIEW view_1_tab4_890
+DROP VIEW IF EXISTS view_1_tab4_890 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_890
+DROP VIEW IF EXISTS view_2_tab4_890 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_890
+DROP VIEW IF EXISTS view_3_tab4_890 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10198,13 +10198,13 @@ SELECT pk FROM tab0 WHERE col4 = 495.61
 ----
 
 statement ok
-DROP VIEW view_1_tab0_891
+DROP VIEW IF EXISTS view_1_tab0_891 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_891
+DROP VIEW IF EXISTS view_2_tab0_891 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_891
+DROP VIEW IF EXISTS view_3_tab0_891 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10290,13 +10290,13 @@ SELECT pk FROM tab1 WHERE col4 = 495.61
 ----
 
 statement ok
-DROP VIEW view_1_tab1_891
+DROP VIEW IF EXISTS view_1_tab1_891 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_891
+DROP VIEW IF EXISTS view_2_tab1_891 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_891
+DROP VIEW IF EXISTS view_3_tab1_891 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10382,13 +10382,13 @@ SELECT pk FROM tab2 WHERE col4 = 495.61
 ----
 
 statement ok
-DROP VIEW view_1_tab2_891
+DROP VIEW IF EXISTS view_1_tab2_891 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_891
+DROP VIEW IF EXISTS view_2_tab2_891 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_891
+DROP VIEW IF EXISTS view_3_tab2_891 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10474,13 +10474,13 @@ SELECT pk FROM tab3 WHERE col4 = 495.61
 ----
 
 statement ok
-DROP VIEW view_1_tab3_891
+DROP VIEW IF EXISTS view_1_tab3_891 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_891
+DROP VIEW IF EXISTS view_2_tab3_891 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_891
+DROP VIEW IF EXISTS view_3_tab3_891 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10566,13 +10566,13 @@ SELECT pk FROM tab4 WHERE col4 = 495.61
 ----
 
 statement ok
-DROP VIEW view_1_tab4_891
+DROP VIEW IF EXISTS view_1_tab4_891 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_891
+DROP VIEW IF EXISTS view_2_tab4_891 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_891
+DROP VIEW IF EXISTS view_3_tab4_891 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10663,13 +10663,13 @@ SELECT pk FROM tab0 WHERE (col3 < 661) OR (col0 IS NULL)
 67 values hashing to 1ae557516b643c17ad02f5d0e41f6c73
 
 statement ok
-DROP VIEW view_1_tab0_892
+DROP VIEW IF EXISTS view_1_tab0_892 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_892
+DROP VIEW IF EXISTS view_2_tab0_892 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_892
+DROP VIEW IF EXISTS view_3_tab0_892 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10760,13 +10760,13 @@ SELECT pk FROM tab1 WHERE (col3 < 661) OR (col0 IS NULL)
 67 values hashing to 1ae557516b643c17ad02f5d0e41f6c73
 
 statement ok
-DROP VIEW view_1_tab1_892
+DROP VIEW IF EXISTS view_1_tab1_892 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_892
+DROP VIEW IF EXISTS view_2_tab1_892 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_892
+DROP VIEW IF EXISTS view_3_tab1_892 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10857,13 +10857,13 @@ SELECT pk FROM tab2 WHERE (col3 < 661) OR (col0 IS NULL)
 67 values hashing to 1ae557516b643c17ad02f5d0e41f6c73
 
 statement ok
-DROP VIEW view_1_tab2_892
+DROP VIEW IF EXISTS view_1_tab2_892 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_892
+DROP VIEW IF EXISTS view_2_tab2_892 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_892
+DROP VIEW IF EXISTS view_3_tab2_892 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10954,13 +10954,13 @@ SELECT pk FROM tab3 WHERE (col3 < 661) OR (col0 IS NULL)
 67 values hashing to 1ae557516b643c17ad02f5d0e41f6c73
 
 statement ok
-DROP VIEW view_1_tab3_892
+DROP VIEW IF EXISTS view_1_tab3_892 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_892
+DROP VIEW IF EXISTS view_2_tab3_892 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_892
+DROP VIEW IF EXISTS view_3_tab3_892 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11051,13 +11051,13 @@ SELECT pk FROM tab4 WHERE (col3 < 661) OR (col0 IS NULL)
 67 values hashing to 1ae557516b643c17ad02f5d0e41f6c73
 
 statement ok
-DROP VIEW view_1_tab4_892
+DROP VIEW IF EXISTS view_1_tab4_892 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_892
+DROP VIEW IF EXISTS view_2_tab4_892 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_892
+DROP VIEW IF EXISTS view_3_tab4_892 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11148,13 +11148,13 @@ SELECT pk FROM tab0 WHERE ((((col0 = 348 OR (col3 >= 649 AND (col4 = 215.89)) OR
 93 values hashing to 872c8005e3d539779b5031fe794022c4
 
 statement ok
-DROP VIEW view_1_tab0_893
+DROP VIEW IF EXISTS view_1_tab0_893 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_893
+DROP VIEW IF EXISTS view_2_tab0_893 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_893
+DROP VIEW IF EXISTS view_3_tab0_893 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11245,13 +11245,13 @@ SELECT pk FROM tab1 WHERE ((((col0 = 348 OR (col3 >= 649 AND (col4 = 215.89)) OR
 93 values hashing to 872c8005e3d539779b5031fe794022c4
 
 statement ok
-DROP VIEW view_1_tab1_893
+DROP VIEW IF EXISTS view_1_tab1_893 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_893
+DROP VIEW IF EXISTS view_2_tab1_893 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_893
+DROP VIEW IF EXISTS view_3_tab1_893 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11342,13 +11342,13 @@ SELECT pk FROM tab2 WHERE ((((col0 = 348 OR (col3 >= 649 AND (col4 = 215.89)) OR
 93 values hashing to 872c8005e3d539779b5031fe794022c4
 
 statement ok
-DROP VIEW view_1_tab2_893
+DROP VIEW IF EXISTS view_1_tab2_893 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_893
+DROP VIEW IF EXISTS view_2_tab2_893 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_893
+DROP VIEW IF EXISTS view_3_tab2_893 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11439,13 +11439,13 @@ SELECT pk FROM tab3 WHERE ((((col0 = 348 OR (col3 >= 649 AND (col4 = 215.89)) OR
 93 values hashing to 872c8005e3d539779b5031fe794022c4
 
 statement ok
-DROP VIEW view_1_tab3_893
+DROP VIEW IF EXISTS view_1_tab3_893 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_893
+DROP VIEW IF EXISTS view_2_tab3_893 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_893
+DROP VIEW IF EXISTS view_3_tab3_893 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11536,13 +11536,13 @@ SELECT pk FROM tab4 WHERE ((((col0 = 348 OR (col3 >= 649 AND (col4 = 215.89)) OR
 93 values hashing to 872c8005e3d539779b5031fe794022c4
 
 statement ok
-DROP VIEW view_1_tab4_893
+DROP VIEW IF EXISTS view_1_tab4_893 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_893
+DROP VIEW IF EXISTS view_2_tab4_893 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_893
+DROP VIEW IF EXISTS view_3_tab4_893 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11633,13 +11633,13 @@ SELECT pk FROM tab0 WHERE (((col1 > 357.12)))
 65 values hashing to 0247fada3c7106f6e51bff35f3d74e32
 
 statement ok
-DROP VIEW view_1_tab0_894
+DROP VIEW IF EXISTS view_1_tab0_894 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_894
+DROP VIEW IF EXISTS view_2_tab0_894 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_894
+DROP VIEW IF EXISTS view_3_tab0_894 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11730,13 +11730,13 @@ SELECT pk FROM tab1 WHERE (((col1 > 357.12)))
 65 values hashing to 0247fada3c7106f6e51bff35f3d74e32
 
 statement ok
-DROP VIEW view_1_tab1_894
+DROP VIEW IF EXISTS view_1_tab1_894 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_894
+DROP VIEW IF EXISTS view_2_tab1_894 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_894
+DROP VIEW IF EXISTS view_3_tab1_894 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11827,13 +11827,13 @@ SELECT pk FROM tab2 WHERE (((col1 > 357.12)))
 65 values hashing to 0247fada3c7106f6e51bff35f3d74e32
 
 statement ok
-DROP VIEW view_1_tab2_894
+DROP VIEW IF EXISTS view_1_tab2_894 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_894
+DROP VIEW IF EXISTS view_2_tab2_894 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_894
+DROP VIEW IF EXISTS view_3_tab2_894 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11924,13 +11924,13 @@ SELECT pk FROM tab3 WHERE (((col1 > 357.12)))
 65 values hashing to 0247fada3c7106f6e51bff35f3d74e32
 
 statement ok
-DROP VIEW view_1_tab3_894
+DROP VIEW IF EXISTS view_1_tab3_894 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_894
+DROP VIEW IF EXISTS view_2_tab3_894 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_894
+DROP VIEW IF EXISTS view_3_tab3_894 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12021,13 +12021,13 @@ SELECT pk FROM tab4 WHERE (((col1 > 357.12)))
 65 values hashing to 0247fada3c7106f6e51bff35f3d74e32
 
 statement ok
-DROP VIEW view_1_tab4_894
+DROP VIEW IF EXISTS view_1_tab4_894 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_894
+DROP VIEW IF EXISTS view_2_tab4_894 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_894
+DROP VIEW IF EXISTS view_3_tab4_894 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12118,13 +12118,13 @@ SELECT pk FROM tab0 WHERE (col0 < 625)
 58 values hashing to 8a1a89abf6841aa16b6293f75b86da49
 
 statement ok
-DROP VIEW view_1_tab0_895
+DROP VIEW IF EXISTS view_1_tab0_895 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_895
+DROP VIEW IF EXISTS view_2_tab0_895 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_895
+DROP VIEW IF EXISTS view_3_tab0_895 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12215,13 +12215,13 @@ SELECT pk FROM tab1 WHERE (col0 < 625)
 58 values hashing to 8a1a89abf6841aa16b6293f75b86da49
 
 statement ok
-DROP VIEW view_1_tab1_895
+DROP VIEW IF EXISTS view_1_tab1_895 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_895
+DROP VIEW IF EXISTS view_2_tab1_895 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_895
+DROP VIEW IF EXISTS view_3_tab1_895 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12312,13 +12312,13 @@ SELECT pk FROM tab2 WHERE (col0 < 625)
 58 values hashing to 8a1a89abf6841aa16b6293f75b86da49
 
 statement ok
-DROP VIEW view_1_tab2_895
+DROP VIEW IF EXISTS view_1_tab2_895 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_895
+DROP VIEW IF EXISTS view_2_tab2_895 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_895
+DROP VIEW IF EXISTS view_3_tab2_895 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12409,13 +12409,13 @@ SELECT pk FROM tab3 WHERE (col0 < 625)
 58 values hashing to 8a1a89abf6841aa16b6293f75b86da49
 
 statement ok
-DROP VIEW view_1_tab3_895
+DROP VIEW IF EXISTS view_1_tab3_895 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_895
+DROP VIEW IF EXISTS view_2_tab3_895 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_895
+DROP VIEW IF EXISTS view_3_tab3_895 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12506,13 +12506,13 @@ SELECT pk FROM tab4 WHERE (col0 < 625)
 58 values hashing to 8a1a89abf6841aa16b6293f75b86da49
 
 statement ok
-DROP VIEW view_1_tab4_895
+DROP VIEW IF EXISTS view_1_tab4_895 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_895
+DROP VIEW IF EXISTS view_2_tab4_895 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_895
+DROP VIEW IF EXISTS view_3_tab4_895 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12603,13 +12603,13 @@ SELECT pk FROM tab0 WHERE col1 >= 879.30
 10 values hashing to 363c836dbbbaa32ccb40262764ce2006
 
 statement ok
-DROP VIEW view_1_tab0_896
+DROP VIEW IF EXISTS view_1_tab0_896 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_896
+DROP VIEW IF EXISTS view_2_tab0_896 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_896
+DROP VIEW IF EXISTS view_3_tab0_896 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12700,13 +12700,13 @@ SELECT pk FROM tab1 WHERE col1 >= 879.30
 10 values hashing to 363c836dbbbaa32ccb40262764ce2006
 
 statement ok
-DROP VIEW view_1_tab1_896
+DROP VIEW IF EXISTS view_1_tab1_896 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_896
+DROP VIEW IF EXISTS view_2_tab1_896 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_896
+DROP VIEW IF EXISTS view_3_tab1_896 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12797,13 +12797,13 @@ SELECT pk FROM tab2 WHERE col1 >= 879.30
 10 values hashing to 363c836dbbbaa32ccb40262764ce2006
 
 statement ok
-DROP VIEW view_1_tab2_896
+DROP VIEW IF EXISTS view_1_tab2_896 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_896
+DROP VIEW IF EXISTS view_2_tab2_896 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_896
+DROP VIEW IF EXISTS view_3_tab2_896 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12894,13 +12894,13 @@ SELECT pk FROM tab3 WHERE col1 >= 879.30
 10 values hashing to 363c836dbbbaa32ccb40262764ce2006
 
 statement ok
-DROP VIEW view_1_tab3_896
+DROP VIEW IF EXISTS view_1_tab3_896 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_896
+DROP VIEW IF EXISTS view_2_tab3_896 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_896
+DROP VIEW IF EXISTS view_3_tab3_896 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12991,13 +12991,13 @@ SELECT pk FROM tab4 WHERE col1 >= 879.30
 10 values hashing to 363c836dbbbaa32ccb40262764ce2006
 
 statement ok
-DROP VIEW view_1_tab4_896
+DROP VIEW IF EXISTS view_1_tab4_896 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_896
+DROP VIEW IF EXISTS view_2_tab4_896 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_896
+DROP VIEW IF EXISTS view_3_tab4_896 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13088,13 +13088,13 @@ SELECT pk FROM tab0 WHERE (col4 > 651.20)
 29 values hashing to 6dbfcb55ed9e910235a6c924f950dc71
 
 statement ok
-DROP VIEW view_1_tab0_897
+DROP VIEW IF EXISTS view_1_tab0_897 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_897
+DROP VIEW IF EXISTS view_2_tab0_897 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_897
+DROP VIEW IF EXISTS view_3_tab0_897 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13185,13 +13185,13 @@ SELECT pk FROM tab1 WHERE (col4 > 651.20)
 29 values hashing to 6dbfcb55ed9e910235a6c924f950dc71
 
 statement ok
-DROP VIEW view_1_tab1_897
+DROP VIEW IF EXISTS view_1_tab1_897 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_897
+DROP VIEW IF EXISTS view_2_tab1_897 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_897
+DROP VIEW IF EXISTS view_3_tab1_897 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13282,13 +13282,13 @@ SELECT pk FROM tab2 WHERE (col4 > 651.20)
 29 values hashing to 6dbfcb55ed9e910235a6c924f950dc71
 
 statement ok
-DROP VIEW view_1_tab2_897
+DROP VIEW IF EXISTS view_1_tab2_897 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_897
+DROP VIEW IF EXISTS view_2_tab2_897 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_897
+DROP VIEW IF EXISTS view_3_tab2_897 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13379,13 +13379,13 @@ SELECT pk FROM tab3 WHERE (col4 > 651.20)
 29 values hashing to 6dbfcb55ed9e910235a6c924f950dc71
 
 statement ok
-DROP VIEW view_1_tab3_897
+DROP VIEW IF EXISTS view_1_tab3_897 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_897
+DROP VIEW IF EXISTS view_2_tab3_897 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_897
+DROP VIEW IF EXISTS view_3_tab3_897 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13476,13 +13476,13 @@ SELECT pk FROM tab4 WHERE (col4 > 651.20)
 29 values hashing to 6dbfcb55ed9e910235a6c924f950dc71
 
 statement ok
-DROP VIEW view_1_tab4_897
+DROP VIEW IF EXISTS view_1_tab4_897 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_897
+DROP VIEW IF EXISTS view_2_tab4_897 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_897
+DROP VIEW IF EXISTS view_3_tab4_897 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13573,13 +13573,13 @@ SELECT pk FROM tab0 WHERE (col0 > 830)
 17 values hashing to 4ec52848dc9bb2e016157c8dd39bb282
 
 statement ok
-DROP VIEW view_1_tab0_898
+DROP VIEW IF EXISTS view_1_tab0_898 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_898
+DROP VIEW IF EXISTS view_2_tab0_898 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_898
+DROP VIEW IF EXISTS view_3_tab0_898 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13670,13 +13670,13 @@ SELECT pk FROM tab1 WHERE (col0 > 830)
 17 values hashing to 4ec52848dc9bb2e016157c8dd39bb282
 
 statement ok
-DROP VIEW view_1_tab1_898
+DROP VIEW IF EXISTS view_1_tab1_898 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_898
+DROP VIEW IF EXISTS view_2_tab1_898 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_898
+DROP VIEW IF EXISTS view_3_tab1_898 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13767,13 +13767,13 @@ SELECT pk FROM tab2 WHERE (col0 > 830)
 17 values hashing to 4ec52848dc9bb2e016157c8dd39bb282
 
 statement ok
-DROP VIEW view_1_tab2_898
+DROP VIEW IF EXISTS view_1_tab2_898 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_898
+DROP VIEW IF EXISTS view_2_tab2_898 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_898
+DROP VIEW IF EXISTS view_3_tab2_898 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13864,13 +13864,13 @@ SELECT pk FROM tab3 WHERE (col0 > 830)
 17 values hashing to 4ec52848dc9bb2e016157c8dd39bb282
 
 statement ok
-DROP VIEW view_1_tab3_898
+DROP VIEW IF EXISTS view_1_tab3_898 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_898
+DROP VIEW IF EXISTS view_2_tab3_898 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_898
+DROP VIEW IF EXISTS view_3_tab3_898 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13961,13 +13961,13 @@ SELECT pk FROM tab4 WHERE (col0 > 830)
 17 values hashing to 4ec52848dc9bb2e016157c8dd39bb282
 
 statement ok
-DROP VIEW view_1_tab4_898
+DROP VIEW IF EXISTS view_1_tab4_898 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_898
+DROP VIEW IF EXISTS view_2_tab4_898 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_898
+DROP VIEW IF EXISTS view_3_tab4_898 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14058,13 +14058,13 @@ SELECT pk FROM tab0 WHERE col3 > 475
 49 values hashing to 8c3e4bcebb338e1f215a9d6392a2b5a1
 
 statement ok
-DROP VIEW view_1_tab0_899
+DROP VIEW IF EXISTS view_1_tab0_899 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_899
+DROP VIEW IF EXISTS view_2_tab0_899 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_899
+DROP VIEW IF EXISTS view_3_tab0_899 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14155,13 +14155,13 @@ SELECT pk FROM tab1 WHERE col3 > 475
 49 values hashing to 8c3e4bcebb338e1f215a9d6392a2b5a1
 
 statement ok
-DROP VIEW view_1_tab1_899
+DROP VIEW IF EXISTS view_1_tab1_899 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_899
+DROP VIEW IF EXISTS view_2_tab1_899 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_899
+DROP VIEW IF EXISTS view_3_tab1_899 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14252,13 +14252,13 @@ SELECT pk FROM tab2 WHERE col3 > 475
 49 values hashing to 8c3e4bcebb338e1f215a9d6392a2b5a1
 
 statement ok
-DROP VIEW view_1_tab2_899
+DROP VIEW IF EXISTS view_1_tab2_899 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_899
+DROP VIEW IF EXISTS view_2_tab2_899 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_899
+DROP VIEW IF EXISTS view_3_tab2_899 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14349,13 +14349,13 @@ SELECT pk FROM tab3 WHERE col3 > 475
 49 values hashing to 8c3e4bcebb338e1f215a9d6392a2b5a1
 
 statement ok
-DROP VIEW view_1_tab3_899
+DROP VIEW IF EXISTS view_1_tab3_899 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_899
+DROP VIEW IF EXISTS view_2_tab3_899 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_899
+DROP VIEW IF EXISTS view_3_tab3_899 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14446,13 +14446,13 @@ SELECT pk FROM tab4 WHERE col3 > 475
 49 values hashing to 8c3e4bcebb338e1f215a9d6392a2b5a1
 
 statement ok
-DROP VIEW view_1_tab4_899
+DROP VIEW IF EXISTS view_1_tab4_899 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_899
+DROP VIEW IF EXISTS view_2_tab4_899 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_899
+DROP VIEW IF EXISTS view_3_tab4_899 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14543,13 +14543,13 @@ SELECT pk FROM tab0 WHERE col4 > 857.31
 13 values hashing to 259e2f30fd941d29c425a1fc9cb1df43
 
 statement ok
-DROP VIEW view_1_tab0_900
+DROP VIEW IF EXISTS view_1_tab0_900 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_900
+DROP VIEW IF EXISTS view_2_tab0_900 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_900
+DROP VIEW IF EXISTS view_3_tab0_900 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14640,13 +14640,13 @@ SELECT pk FROM tab1 WHERE col4 > 857.31
 13 values hashing to 259e2f30fd941d29c425a1fc9cb1df43
 
 statement ok
-DROP VIEW view_1_tab1_900
+DROP VIEW IF EXISTS view_1_tab1_900 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_900
+DROP VIEW IF EXISTS view_2_tab1_900 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_900
+DROP VIEW IF EXISTS view_3_tab1_900 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14737,13 +14737,13 @@ SELECT pk FROM tab2 WHERE col4 > 857.31
 13 values hashing to 259e2f30fd941d29c425a1fc9cb1df43
 
 statement ok
-DROP VIEW view_1_tab2_900
+DROP VIEW IF EXISTS view_1_tab2_900 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_900
+DROP VIEW IF EXISTS view_2_tab2_900 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_900
+DROP VIEW IF EXISTS view_3_tab2_900 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14834,13 +14834,13 @@ SELECT pk FROM tab3 WHERE col4 > 857.31
 13 values hashing to 259e2f30fd941d29c425a1fc9cb1df43
 
 statement ok
-DROP VIEW view_1_tab3_900
+DROP VIEW IF EXISTS view_1_tab3_900 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_900
+DROP VIEW IF EXISTS view_2_tab3_900 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_900
+DROP VIEW IF EXISTS view_3_tab3_900 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14931,13 +14931,13 @@ SELECT pk FROM tab4 WHERE col4 > 857.31
 13 values hashing to 259e2f30fd941d29c425a1fc9cb1df43
 
 statement ok
-DROP VIEW view_1_tab4_900
+DROP VIEW IF EXISTS view_1_tab4_900 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_900
+DROP VIEW IF EXISTS view_2_tab4_900 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_900
+DROP VIEW IF EXISTS view_3_tab4_900 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15028,13 +15028,13 @@ SELECT pk FROM tab0 WHERE col4 BETWEEN 290.87 AND 700.72 AND col3 IS NULL AND co
 9 values hashing to 17645e17578b39eb0e8a1735ad17eced
 
 statement ok
-DROP VIEW view_1_tab0_901
+DROP VIEW IF EXISTS view_1_tab0_901 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_901
+DROP VIEW IF EXISTS view_2_tab0_901 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_901
+DROP VIEW IF EXISTS view_3_tab0_901 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15125,13 +15125,13 @@ SELECT pk FROM tab1 WHERE col4 BETWEEN 290.87 AND 700.72 AND col3 IS NULL AND co
 9 values hashing to 17645e17578b39eb0e8a1735ad17eced
 
 statement ok
-DROP VIEW view_1_tab1_901
+DROP VIEW IF EXISTS view_1_tab1_901 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_901
+DROP VIEW IF EXISTS view_2_tab1_901 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_901
+DROP VIEW IF EXISTS view_3_tab1_901 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15222,13 +15222,13 @@ SELECT pk FROM tab2 WHERE col4 BETWEEN 290.87 AND 700.72 AND col3 IS NULL AND co
 9 values hashing to 17645e17578b39eb0e8a1735ad17eced
 
 statement ok
-DROP VIEW view_1_tab2_901
+DROP VIEW IF EXISTS view_1_tab2_901 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_901
+DROP VIEW IF EXISTS view_2_tab2_901 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_901
+DROP VIEW IF EXISTS view_3_tab2_901 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15319,13 +15319,13 @@ SELECT pk FROM tab3 WHERE col4 BETWEEN 290.87 AND 700.72 AND col3 IS NULL AND co
 9 values hashing to 17645e17578b39eb0e8a1735ad17eced
 
 statement ok
-DROP VIEW view_1_tab3_901
+DROP VIEW IF EXISTS view_1_tab3_901 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_901
+DROP VIEW IF EXISTS view_2_tab3_901 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_901
+DROP VIEW IF EXISTS view_3_tab3_901 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15416,13 +15416,13 @@ SELECT pk FROM tab4 WHERE col4 BETWEEN 290.87 AND 700.72 AND col3 IS NULL AND co
 9 values hashing to 17645e17578b39eb0e8a1735ad17eced
 
 statement ok
-DROP VIEW view_1_tab4_901
+DROP VIEW IF EXISTS view_1_tab4_901 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_901
+DROP VIEW IF EXISTS view_2_tab4_901 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_901
+DROP VIEW IF EXISTS view_3_tab4_901 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15513,13 +15513,13 @@ SELECT pk FROM tab0 WHERE col0 < 487
 43 values hashing to 6dbba989911e394a8c89c6ded68c8ae5
 
 statement ok
-DROP VIEW view_1_tab0_902
+DROP VIEW IF EXISTS view_1_tab0_902 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_902
+DROP VIEW IF EXISTS view_2_tab0_902 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_902
+DROP VIEW IF EXISTS view_3_tab0_902 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15610,13 +15610,13 @@ SELECT pk FROM tab1 WHERE col0 < 487
 43 values hashing to 6dbba989911e394a8c89c6ded68c8ae5
 
 statement ok
-DROP VIEW view_1_tab1_902
+DROP VIEW IF EXISTS view_1_tab1_902 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_902
+DROP VIEW IF EXISTS view_2_tab1_902 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_902
+DROP VIEW IF EXISTS view_3_tab1_902 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15707,13 +15707,13 @@ SELECT pk FROM tab2 WHERE col0 < 487
 43 values hashing to 6dbba989911e394a8c89c6ded68c8ae5
 
 statement ok
-DROP VIEW view_1_tab2_902
+DROP VIEW IF EXISTS view_1_tab2_902 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_902
+DROP VIEW IF EXISTS view_2_tab2_902 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_902
+DROP VIEW IF EXISTS view_3_tab2_902 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15804,13 +15804,13 @@ SELECT pk FROM tab3 WHERE col0 < 487
 43 values hashing to 6dbba989911e394a8c89c6ded68c8ae5
 
 statement ok
-DROP VIEW view_1_tab3_902
+DROP VIEW IF EXISTS view_1_tab3_902 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_902
+DROP VIEW IF EXISTS view_2_tab3_902 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_902
+DROP VIEW IF EXISTS view_3_tab3_902 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15901,13 +15901,13 @@ SELECT pk FROM tab4 WHERE col0 < 487
 43 values hashing to 6dbba989911e394a8c89c6ded68c8ae5
 
 statement ok
-DROP VIEW view_1_tab4_902
+DROP VIEW IF EXISTS view_1_tab4_902 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_902
+DROP VIEW IF EXISTS view_2_tab4_902 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_902
+DROP VIEW IF EXISTS view_3_tab4_902 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15993,13 +15993,13 @@ SELECT pk FROM tab0 WHERE (col0 < 151 AND col0 > 630 AND col0 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_903
+DROP VIEW IF EXISTS view_1_tab0_903 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_903
+DROP VIEW IF EXISTS view_2_tab0_903 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_903
+DROP VIEW IF EXISTS view_3_tab0_903 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16085,13 +16085,13 @@ SELECT pk FROM tab1 WHERE (col0 < 151 AND col0 > 630 AND col0 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_903
+DROP VIEW IF EXISTS view_1_tab1_903 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_903
+DROP VIEW IF EXISTS view_2_tab1_903 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_903
+DROP VIEW IF EXISTS view_3_tab1_903 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16177,13 +16177,13 @@ SELECT pk FROM tab2 WHERE (col0 < 151 AND col0 > 630 AND col0 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_903
+DROP VIEW IF EXISTS view_1_tab2_903 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_903
+DROP VIEW IF EXISTS view_2_tab2_903 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_903
+DROP VIEW IF EXISTS view_3_tab2_903 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16269,13 +16269,13 @@ SELECT pk FROM tab3 WHERE (col0 < 151 AND col0 > 630 AND col0 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_903
+DROP VIEW IF EXISTS view_1_tab3_903 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_903
+DROP VIEW IF EXISTS view_2_tab3_903 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_903
+DROP VIEW IF EXISTS view_3_tab3_903 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16361,13 +16361,13 @@ SELECT pk FROM tab4 WHERE (col0 < 151 AND col0 > 630 AND col0 IS NULL)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_903
+DROP VIEW IF EXISTS view_1_tab4_903 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_903
+DROP VIEW IF EXISTS view_2_tab4_903 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_903
+DROP VIEW IF EXISTS view_3_tab4_903 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16458,13 +16458,13 @@ SELECT pk FROM tab0 WHERE col4 < 196.2
 24 values hashing to 67dc1133759a7a5b663a46b645c21a33
 
 statement ok
-DROP VIEW view_1_tab0_904
+DROP VIEW IF EXISTS view_1_tab0_904 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_904
+DROP VIEW IF EXISTS view_2_tab0_904 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_904
+DROP VIEW IF EXISTS view_3_tab0_904 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16555,13 +16555,13 @@ SELECT pk FROM tab1 WHERE col4 < 196.2
 24 values hashing to 67dc1133759a7a5b663a46b645c21a33
 
 statement ok
-DROP VIEW view_1_tab1_904
+DROP VIEW IF EXISTS view_1_tab1_904 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_904
+DROP VIEW IF EXISTS view_2_tab1_904 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_904
+DROP VIEW IF EXISTS view_3_tab1_904 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16652,13 +16652,13 @@ SELECT pk FROM tab2 WHERE col4 < 196.2
 24 values hashing to 67dc1133759a7a5b663a46b645c21a33
 
 statement ok
-DROP VIEW view_1_tab2_904
+DROP VIEW IF EXISTS view_1_tab2_904 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_904
+DROP VIEW IF EXISTS view_2_tab2_904 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_904
+DROP VIEW IF EXISTS view_3_tab2_904 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16749,13 +16749,13 @@ SELECT pk FROM tab3 WHERE col4 < 196.2
 24 values hashing to 67dc1133759a7a5b663a46b645c21a33
 
 statement ok
-DROP VIEW view_1_tab3_904
+DROP VIEW IF EXISTS view_1_tab3_904 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_904
+DROP VIEW IF EXISTS view_2_tab3_904 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_904
+DROP VIEW IF EXISTS view_3_tab3_904 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16846,13 +16846,13 @@ SELECT pk FROM tab4 WHERE col4 < 196.2
 24 values hashing to 67dc1133759a7a5b663a46b645c21a33
 
 statement ok
-DROP VIEW view_1_tab4_904
+DROP VIEW IF EXISTS view_1_tab4_904 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_904
+DROP VIEW IF EXISTS view_2_tab4_904 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_904
+DROP VIEW IF EXISTS view_3_tab4_904 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16943,13 +16943,13 @@ SELECT pk FROM tab0 WHERE (col0 > 490)
 57 values hashing to 08ab48659bf55b5f0a9362746a0e31ed
 
 statement ok
-DROP VIEW view_1_tab0_905
+DROP VIEW IF EXISTS view_1_tab0_905 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_905
+DROP VIEW IF EXISTS view_2_tab0_905 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_905
+DROP VIEW IF EXISTS view_3_tab0_905 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17040,13 +17040,13 @@ SELECT pk FROM tab1 WHERE (col0 > 490)
 57 values hashing to 08ab48659bf55b5f0a9362746a0e31ed
 
 statement ok
-DROP VIEW view_1_tab1_905
+DROP VIEW IF EXISTS view_1_tab1_905 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_905
+DROP VIEW IF EXISTS view_2_tab1_905 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_905
+DROP VIEW IF EXISTS view_3_tab1_905 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17137,13 +17137,13 @@ SELECT pk FROM tab2 WHERE (col0 > 490)
 57 values hashing to 08ab48659bf55b5f0a9362746a0e31ed
 
 statement ok
-DROP VIEW view_1_tab2_905
+DROP VIEW IF EXISTS view_1_tab2_905 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_905
+DROP VIEW IF EXISTS view_2_tab2_905 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_905
+DROP VIEW IF EXISTS view_3_tab2_905 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17234,13 +17234,13 @@ SELECT pk FROM tab3 WHERE (col0 > 490)
 57 values hashing to 08ab48659bf55b5f0a9362746a0e31ed
 
 statement ok
-DROP VIEW view_1_tab3_905
+DROP VIEW IF EXISTS view_1_tab3_905 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_905
+DROP VIEW IF EXISTS view_2_tab3_905 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_905
+DROP VIEW IF EXISTS view_3_tab3_905 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17331,13 +17331,13 @@ SELECT pk FROM tab4 WHERE (col0 > 490)
 57 values hashing to 08ab48659bf55b5f0a9362746a0e31ed
 
 statement ok
-DROP VIEW view_1_tab4_905
+DROP VIEW IF EXISTS view_1_tab4_905 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_905
+DROP VIEW IF EXISTS view_2_tab4_905 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_905
+DROP VIEW IF EXISTS view_3_tab4_905 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17442,13 +17442,13 @@ SELECT pk FROM tab0 WHERE col0 < 91 OR ((col3 = 449 OR col0 > 722 AND col0 > 678
 96 values hashing to 7cb25a46d9cd9ea63d9e5e4be0c3d0a1
 
 statement ok
-DROP VIEW view_1_tab0_906
+DROP VIEW IF EXISTS view_1_tab0_906 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_906
+DROP VIEW IF EXISTS view_2_tab0_906 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_906
+DROP VIEW IF EXISTS view_3_tab0_906 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17553,13 +17553,13 @@ SELECT pk FROM tab1 WHERE col0 < 91 OR ((col3 = 449 OR col0 > 722 AND col0 > 678
 96 values hashing to 7cb25a46d9cd9ea63d9e5e4be0c3d0a1
 
 statement ok
-DROP VIEW view_1_tab1_906
+DROP VIEW IF EXISTS view_1_tab1_906 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_906
+DROP VIEW IF EXISTS view_2_tab1_906 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_906
+DROP VIEW IF EXISTS view_3_tab1_906 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17664,13 +17664,13 @@ SELECT pk FROM tab2 WHERE col0 < 91 OR ((col3 = 449 OR col0 > 722 AND col0 > 678
 96 values hashing to 7cb25a46d9cd9ea63d9e5e4be0c3d0a1
 
 statement ok
-DROP VIEW view_1_tab2_906
+DROP VIEW IF EXISTS view_1_tab2_906 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_906
+DROP VIEW IF EXISTS view_2_tab2_906 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_906
+DROP VIEW IF EXISTS view_3_tab2_906 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17775,13 +17775,13 @@ SELECT pk FROM tab3 WHERE col0 < 91 OR ((col3 = 449 OR col0 > 722 AND col0 > 678
 96 values hashing to 7cb25a46d9cd9ea63d9e5e4be0c3d0a1
 
 statement ok
-DROP VIEW view_1_tab3_906
+DROP VIEW IF EXISTS view_1_tab3_906 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_906
+DROP VIEW IF EXISTS view_2_tab3_906 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_906
+DROP VIEW IF EXISTS view_3_tab3_906 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17886,13 +17886,13 @@ SELECT pk FROM tab4 WHERE col0 < 91 OR ((col3 = 449 OR col0 > 722 AND col0 > 678
 96 values hashing to 7cb25a46d9cd9ea63d9e5e4be0c3d0a1
 
 statement ok
-DROP VIEW view_1_tab4_906
+DROP VIEW IF EXISTS view_1_tab4_906 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_906
+DROP VIEW IF EXISTS view_2_tab4_906 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_906
+DROP VIEW IF EXISTS view_3_tab4_906 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17997,13 +17997,13 @@ SELECT pk FROM tab0 WHERE col0 >= 79
 96 values hashing to 8cf2530cac5029692c8a0b3655d5bd6a
 
 statement ok
-DROP VIEW view_1_tab0_907
+DROP VIEW IF EXISTS view_1_tab0_907 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_907
+DROP VIEW IF EXISTS view_2_tab0_907 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_907
+DROP VIEW IF EXISTS view_3_tab0_907 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18108,13 +18108,13 @@ SELECT pk FROM tab1 WHERE col0 >= 79
 96 values hashing to 8cf2530cac5029692c8a0b3655d5bd6a
 
 statement ok
-DROP VIEW view_1_tab1_907
+DROP VIEW IF EXISTS view_1_tab1_907 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_907
+DROP VIEW IF EXISTS view_2_tab1_907 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_907
+DROP VIEW IF EXISTS view_3_tab1_907 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18219,13 +18219,13 @@ SELECT pk FROM tab2 WHERE col0 >= 79
 96 values hashing to 8cf2530cac5029692c8a0b3655d5bd6a
 
 statement ok
-DROP VIEW view_1_tab2_907
+DROP VIEW IF EXISTS view_1_tab2_907 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_907
+DROP VIEW IF EXISTS view_2_tab2_907 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_907
+DROP VIEW IF EXISTS view_3_tab2_907 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18330,13 +18330,13 @@ SELECT pk FROM tab3 WHERE col0 >= 79
 96 values hashing to 8cf2530cac5029692c8a0b3655d5bd6a
 
 statement ok
-DROP VIEW view_1_tab3_907
+DROP VIEW IF EXISTS view_1_tab3_907 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_907
+DROP VIEW IF EXISTS view_2_tab3_907 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_907
+DROP VIEW IF EXISTS view_3_tab3_907 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18441,13 +18441,13 @@ SELECT pk FROM tab4 WHERE col0 >= 79
 96 values hashing to 8cf2530cac5029692c8a0b3655d5bd6a
 
 statement ok
-DROP VIEW view_1_tab4_907
+DROP VIEW IF EXISTS view_1_tab4_907 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_907
+DROP VIEW IF EXISTS view_2_tab4_907 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_907
+DROP VIEW IF EXISTS view_3_tab4_907 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18538,13 +18538,13 @@ SELECT pk FROM tab0 WHERE col4 >= 834.24
 14 values hashing to 12a0617e7b5113d8566c906144c40c14
 
 statement ok
-DROP VIEW view_1_tab0_908
+DROP VIEW IF EXISTS view_1_tab0_908 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_908
+DROP VIEW IF EXISTS view_2_tab0_908 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_908
+DROP VIEW IF EXISTS view_3_tab0_908 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18635,13 +18635,13 @@ SELECT pk FROM tab1 WHERE col4 >= 834.24
 14 values hashing to 12a0617e7b5113d8566c906144c40c14
 
 statement ok
-DROP VIEW view_1_tab1_908
+DROP VIEW IF EXISTS view_1_tab1_908 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_908
+DROP VIEW IF EXISTS view_2_tab1_908 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_908
+DROP VIEW IF EXISTS view_3_tab1_908 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18732,13 +18732,13 @@ SELECT pk FROM tab2 WHERE col4 >= 834.24
 14 values hashing to 12a0617e7b5113d8566c906144c40c14
 
 statement ok
-DROP VIEW view_1_tab2_908
+DROP VIEW IF EXISTS view_1_tab2_908 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_908
+DROP VIEW IF EXISTS view_2_tab2_908 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_908
+DROP VIEW IF EXISTS view_3_tab2_908 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18829,13 +18829,13 @@ SELECT pk FROM tab3 WHERE col4 >= 834.24
 14 values hashing to 12a0617e7b5113d8566c906144c40c14
 
 statement ok
-DROP VIEW view_1_tab3_908
+DROP VIEW IF EXISTS view_1_tab3_908 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_908
+DROP VIEW IF EXISTS view_2_tab3_908 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_908
+DROP VIEW IF EXISTS view_3_tab3_908 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18926,13 +18926,13 @@ SELECT pk FROM tab4 WHERE col4 >= 834.24
 14 values hashing to 12a0617e7b5113d8566c906144c40c14
 
 statement ok
-DROP VIEW view_1_tab4_908
+DROP VIEW IF EXISTS view_1_tab4_908 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_908
+DROP VIEW IF EXISTS view_2_tab4_908 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_908
+DROP VIEW IF EXISTS view_3_tab4_908 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19023,13 +19023,13 @@ SELECT pk FROM tab0 WHERE col1 > 493.44
 52 values hashing to 8a4cf7cf036b3cfbf8498c2daf925a20
 
 statement ok
-DROP VIEW view_1_tab0_909
+DROP VIEW IF EXISTS view_1_tab0_909 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_909
+DROP VIEW IF EXISTS view_2_tab0_909 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_909
+DROP VIEW IF EXISTS view_3_tab0_909 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19120,13 +19120,13 @@ SELECT pk FROM tab1 WHERE col1 > 493.44
 52 values hashing to 8a4cf7cf036b3cfbf8498c2daf925a20
 
 statement ok
-DROP VIEW view_1_tab1_909
+DROP VIEW IF EXISTS view_1_tab1_909 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_909
+DROP VIEW IF EXISTS view_2_tab1_909 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_909
+DROP VIEW IF EXISTS view_3_tab1_909 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19217,13 +19217,13 @@ SELECT pk FROM tab2 WHERE col1 > 493.44
 52 values hashing to 8a4cf7cf036b3cfbf8498c2daf925a20
 
 statement ok
-DROP VIEW view_1_tab2_909
+DROP VIEW IF EXISTS view_1_tab2_909 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_909
+DROP VIEW IF EXISTS view_2_tab2_909 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_909
+DROP VIEW IF EXISTS view_3_tab2_909 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19314,13 +19314,13 @@ SELECT pk FROM tab3 WHERE col1 > 493.44
 52 values hashing to 8a4cf7cf036b3cfbf8498c2daf925a20
 
 statement ok
-DROP VIEW view_1_tab3_909
+DROP VIEW IF EXISTS view_1_tab3_909 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_909
+DROP VIEW IF EXISTS view_2_tab3_909 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_909
+DROP VIEW IF EXISTS view_3_tab3_909 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19411,13 +19411,13 @@ SELECT pk FROM tab4 WHERE col1 > 493.44
 52 values hashing to 8a4cf7cf036b3cfbf8498c2daf925a20
 
 statement ok
-DROP VIEW view_1_tab4_909
+DROP VIEW IF EXISTS view_1_tab4_909 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_909
+DROP VIEW IF EXISTS view_2_tab4_909 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_909
+DROP VIEW IF EXISTS view_3_tab4_909 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19508,13 +19508,13 @@ SELECT pk FROM tab0 WHERE col4 <= 798.35
 83 values hashing to c9f113bbf3848de36ed8db60c5f7bf20
 
 statement ok
-DROP VIEW view_1_tab0_910
+DROP VIEW IF EXISTS view_1_tab0_910 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_910
+DROP VIEW IF EXISTS view_2_tab0_910 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_910
+DROP VIEW IF EXISTS view_3_tab0_910 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19605,13 +19605,13 @@ SELECT pk FROM tab1 WHERE col4 <= 798.35
 83 values hashing to c9f113bbf3848de36ed8db60c5f7bf20
 
 statement ok
-DROP VIEW view_1_tab1_910
+DROP VIEW IF EXISTS view_1_tab1_910 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_910
+DROP VIEW IF EXISTS view_2_tab1_910 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_910
+DROP VIEW IF EXISTS view_3_tab1_910 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19702,13 +19702,13 @@ SELECT pk FROM tab2 WHERE col4 <= 798.35
 83 values hashing to c9f113bbf3848de36ed8db60c5f7bf20
 
 statement ok
-DROP VIEW view_1_tab2_910
+DROP VIEW IF EXISTS view_1_tab2_910 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_910
+DROP VIEW IF EXISTS view_2_tab2_910 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_910
+DROP VIEW IF EXISTS view_3_tab2_910 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19799,13 +19799,13 @@ SELECT pk FROM tab3 WHERE col4 <= 798.35
 83 values hashing to c9f113bbf3848de36ed8db60c5f7bf20
 
 statement ok
-DROP VIEW view_1_tab3_910
+DROP VIEW IF EXISTS view_1_tab3_910 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_910
+DROP VIEW IF EXISTS view_2_tab3_910 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_910
+DROP VIEW IF EXISTS view_3_tab3_910 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19896,13 +19896,13 @@ SELECT pk FROM tab4 WHERE col4 <= 798.35
 83 values hashing to c9f113bbf3848de36ed8db60c5f7bf20
 
 statement ok
-DROP VIEW view_1_tab4_910
+DROP VIEW IF EXISTS view_1_tab4_910 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_910
+DROP VIEW IF EXISTS view_2_tab4_910 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_910
+DROP VIEW IF EXISTS view_3_tab4_910 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19993,13 +19993,13 @@ SELECT pk FROM tab0 WHERE col1 >= 604.65
 40 values hashing to 0205e9e01e97465f9a5993a814b7db55
 
 statement ok
-DROP VIEW view_1_tab0_911
+DROP VIEW IF EXISTS view_1_tab0_911 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_911
+DROP VIEW IF EXISTS view_2_tab0_911 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_911
+DROP VIEW IF EXISTS view_3_tab0_911 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20090,13 +20090,13 @@ SELECT pk FROM tab1 WHERE col1 >= 604.65
 40 values hashing to 0205e9e01e97465f9a5993a814b7db55
 
 statement ok
-DROP VIEW view_1_tab1_911
+DROP VIEW IF EXISTS view_1_tab1_911 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_911
+DROP VIEW IF EXISTS view_2_tab1_911 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_911
+DROP VIEW IF EXISTS view_3_tab1_911 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20187,13 +20187,13 @@ SELECT pk FROM tab2 WHERE col1 >= 604.65
 40 values hashing to 0205e9e01e97465f9a5993a814b7db55
 
 statement ok
-DROP VIEW view_1_tab2_911
+DROP VIEW IF EXISTS view_1_tab2_911 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_911
+DROP VIEW IF EXISTS view_2_tab2_911 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_911
+DROP VIEW IF EXISTS view_3_tab2_911 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20284,13 +20284,13 @@ SELECT pk FROM tab3 WHERE col1 >= 604.65
 40 values hashing to 0205e9e01e97465f9a5993a814b7db55
 
 statement ok
-DROP VIEW view_1_tab3_911
+DROP VIEW IF EXISTS view_1_tab3_911 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_911
+DROP VIEW IF EXISTS view_2_tab3_911 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_911
+DROP VIEW IF EXISTS view_3_tab3_911 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20381,13 +20381,13 @@ SELECT pk FROM tab4 WHERE col1 >= 604.65
 40 values hashing to 0205e9e01e97465f9a5993a814b7db55
 
 statement ok
-DROP VIEW view_1_tab4_911
+DROP VIEW IF EXISTS view_1_tab4_911 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_911
+DROP VIEW IF EXISTS view_2_tab4_911 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_911
+DROP VIEW IF EXISTS view_3_tab4_911 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20478,13 +20478,13 @@ SELECT pk FROM tab0 WHERE (col4 >= 519.79 AND (col3 BETWEEN 191 AND 743 AND col1
 43 values hashing to 5bad256ad163e15382dc8966cb2addc1
 
 statement ok
-DROP VIEW view_1_tab0_912
+DROP VIEW IF EXISTS view_1_tab0_912 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_912
+DROP VIEW IF EXISTS view_2_tab0_912 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_912
+DROP VIEW IF EXISTS view_3_tab0_912 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20575,13 +20575,13 @@ SELECT pk FROM tab1 WHERE (col4 >= 519.79 AND (col3 BETWEEN 191 AND 743 AND col1
 43 values hashing to 5bad256ad163e15382dc8966cb2addc1
 
 statement ok
-DROP VIEW view_1_tab1_912
+DROP VIEW IF EXISTS view_1_tab1_912 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_912
+DROP VIEW IF EXISTS view_2_tab1_912 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_912
+DROP VIEW IF EXISTS view_3_tab1_912 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20672,13 +20672,13 @@ SELECT pk FROM tab2 WHERE (col4 >= 519.79 AND (col3 BETWEEN 191 AND 743 AND col1
 43 values hashing to 5bad256ad163e15382dc8966cb2addc1
 
 statement ok
-DROP VIEW view_1_tab2_912
+DROP VIEW IF EXISTS view_1_tab2_912 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_912
+DROP VIEW IF EXISTS view_2_tab2_912 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_912
+DROP VIEW IF EXISTS view_3_tab2_912 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20769,13 +20769,13 @@ SELECT pk FROM tab3 WHERE (col4 >= 519.79 AND (col3 BETWEEN 191 AND 743 AND col1
 43 values hashing to 5bad256ad163e15382dc8966cb2addc1
 
 statement ok
-DROP VIEW view_1_tab3_912
+DROP VIEW IF EXISTS view_1_tab3_912 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_912
+DROP VIEW IF EXISTS view_2_tab3_912 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_912
+DROP VIEW IF EXISTS view_3_tab3_912 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20866,13 +20866,13 @@ SELECT pk FROM tab4 WHERE (col4 >= 519.79 AND (col3 BETWEEN 191 AND 743 AND col1
 43 values hashing to 5bad256ad163e15382dc8966cb2addc1
 
 statement ok
-DROP VIEW view_1_tab4_912
+DROP VIEW IF EXISTS view_1_tab4_912 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_912
+DROP VIEW IF EXISTS view_2_tab4_912 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_912
+DROP VIEW IF EXISTS view_3_tab4_912 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20963,13 +20963,13 @@ SELECT pk FROM tab0 WHERE (((col3 >= 500)))
 46 values hashing to f238b5cb38f326d95a9b3df92c1be7ed
 
 statement ok
-DROP VIEW view_1_tab0_913
+DROP VIEW IF EXISTS view_1_tab0_913 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_913
+DROP VIEW IF EXISTS view_2_tab0_913 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_913
+DROP VIEW IF EXISTS view_3_tab0_913 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21060,13 +21060,13 @@ SELECT pk FROM tab1 WHERE (((col3 >= 500)))
 46 values hashing to f238b5cb38f326d95a9b3df92c1be7ed
 
 statement ok
-DROP VIEW view_1_tab1_913
+DROP VIEW IF EXISTS view_1_tab1_913 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_913
+DROP VIEW IF EXISTS view_2_tab1_913 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_913
+DROP VIEW IF EXISTS view_3_tab1_913 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21157,13 +21157,13 @@ SELECT pk FROM tab2 WHERE (((col3 >= 500)))
 46 values hashing to f238b5cb38f326d95a9b3df92c1be7ed
 
 statement ok
-DROP VIEW view_1_tab2_913
+DROP VIEW IF EXISTS view_1_tab2_913 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_913
+DROP VIEW IF EXISTS view_2_tab2_913 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_913
+DROP VIEW IF EXISTS view_3_tab2_913 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21254,13 +21254,13 @@ SELECT pk FROM tab3 WHERE (((col3 >= 500)))
 46 values hashing to f238b5cb38f326d95a9b3df92c1be7ed
 
 statement ok
-DROP VIEW view_1_tab3_913
+DROP VIEW IF EXISTS view_1_tab3_913 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_913
+DROP VIEW IF EXISTS view_2_tab3_913 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_913
+DROP VIEW IF EXISTS view_3_tab3_913 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21351,13 +21351,13 @@ SELECT pk FROM tab4 WHERE (((col3 >= 500)))
 46 values hashing to f238b5cb38f326d95a9b3df92c1be7ed
 
 statement ok
-DROP VIEW view_1_tab4_913
+DROP VIEW IF EXISTS view_1_tab4_913 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_913
+DROP VIEW IF EXISTS view_2_tab4_913 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_913
+DROP VIEW IF EXISTS view_3_tab4_913 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21454,13 +21454,13 @@ SELECT pk FROM tab0 WHERE (col1 < 475.85) AND col4 >= 839.81 AND col0 IN (310,91
 98 values hashing to bfd77715d2e69542679a832b87a711b6
 
 statement ok
-DROP VIEW view_1_tab0_915
+DROP VIEW IF EXISTS view_1_tab0_915 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_915
+DROP VIEW IF EXISTS view_2_tab0_915 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_915
+DROP VIEW IF EXISTS view_3_tab0_915 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21557,13 +21557,13 @@ SELECT pk FROM tab1 WHERE (col1 < 475.85) AND col4 >= 839.81 AND col0 IN (310,91
 98 values hashing to bfd77715d2e69542679a832b87a711b6
 
 statement ok
-DROP VIEW view_1_tab1_915
+DROP VIEW IF EXISTS view_1_tab1_915 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_915
+DROP VIEW IF EXISTS view_2_tab1_915 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_915
+DROP VIEW IF EXISTS view_3_tab1_915 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21660,13 +21660,13 @@ SELECT pk FROM tab2 WHERE (col1 < 475.85) AND col4 >= 839.81 AND col0 IN (310,91
 98 values hashing to bfd77715d2e69542679a832b87a711b6
 
 statement ok
-DROP VIEW view_1_tab2_915
+DROP VIEW IF EXISTS view_1_tab2_915 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_915
+DROP VIEW IF EXISTS view_2_tab2_915 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_915
+DROP VIEW IF EXISTS view_3_tab2_915 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21763,13 +21763,13 @@ SELECT pk FROM tab3 WHERE (col1 < 475.85) AND col4 >= 839.81 AND col0 IN (310,91
 98 values hashing to bfd77715d2e69542679a832b87a711b6
 
 statement ok
-DROP VIEW view_1_tab3_915
+DROP VIEW IF EXISTS view_1_tab3_915 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_915
+DROP VIEW IF EXISTS view_2_tab3_915 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_915
+DROP VIEW IF EXISTS view_3_tab3_915 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21866,13 +21866,13 @@ SELECT pk FROM tab4 WHERE (col1 < 475.85) AND col4 >= 839.81 AND col0 IN (310,91
 98 values hashing to bfd77715d2e69542679a832b87a711b6
 
 statement ok
-DROP VIEW view_1_tab4_915
+DROP VIEW IF EXISTS view_1_tab4_915 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_915
+DROP VIEW IF EXISTS view_2_tab4_915 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_915
+DROP VIEW IF EXISTS view_3_tab4_915 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21963,13 +21963,13 @@ SELECT pk FROM tab0 WHERE (col3 > 750) OR ((col1 > 794.61) AND (col0 <= 322 AND 
 24 values hashing to 1e16193d2dadec8168fd6551b8b74702
 
 statement ok
-DROP VIEW view_1_tab0_916
+DROP VIEW IF EXISTS view_1_tab0_916 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_916
+DROP VIEW IF EXISTS view_2_tab0_916 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_916
+DROP VIEW IF EXISTS view_3_tab0_916 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22060,13 +22060,13 @@ SELECT pk FROM tab1 WHERE (col3 > 750) OR ((col1 > 794.61) AND (col0 <= 322 AND 
 24 values hashing to 1e16193d2dadec8168fd6551b8b74702
 
 statement ok
-DROP VIEW view_1_tab1_916
+DROP VIEW IF EXISTS view_1_tab1_916 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_916
+DROP VIEW IF EXISTS view_2_tab1_916 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_916
+DROP VIEW IF EXISTS view_3_tab1_916 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22157,13 +22157,13 @@ SELECT pk FROM tab2 WHERE (col3 > 750) OR ((col1 > 794.61) AND (col0 <= 322 AND 
 24 values hashing to 1e16193d2dadec8168fd6551b8b74702
 
 statement ok
-DROP VIEW view_1_tab2_916
+DROP VIEW IF EXISTS view_1_tab2_916 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_916
+DROP VIEW IF EXISTS view_2_tab2_916 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_916
+DROP VIEW IF EXISTS view_3_tab2_916 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22254,13 +22254,13 @@ SELECT pk FROM tab3 WHERE (col3 > 750) OR ((col1 > 794.61) AND (col0 <= 322 AND 
 24 values hashing to 1e16193d2dadec8168fd6551b8b74702
 
 statement ok
-DROP VIEW view_1_tab3_916
+DROP VIEW IF EXISTS view_1_tab3_916 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_916
+DROP VIEW IF EXISTS view_2_tab3_916 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_916
+DROP VIEW IF EXISTS view_3_tab3_916 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22351,13 +22351,13 @@ SELECT pk FROM tab4 WHERE (col3 > 750) OR ((col1 > 794.61) AND (col0 <= 322 AND 
 24 values hashing to 1e16193d2dadec8168fd6551b8b74702
 
 statement ok
-DROP VIEW view_1_tab4_916
+DROP VIEW IF EXISTS view_1_tab4_916 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_916
+DROP VIEW IF EXISTS view_2_tab4_916 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_916
+DROP VIEW IF EXISTS view_3_tab4_916 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22448,13 +22448,13 @@ SELECT pk FROM tab0 WHERE col3 < 292
 33 values hashing to efe65200e977c042916910e3c27ad7f5
 
 statement ok
-DROP VIEW view_1_tab0_917
+DROP VIEW IF EXISTS view_1_tab0_917 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_917
+DROP VIEW IF EXISTS view_2_tab0_917 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_917
+DROP VIEW IF EXISTS view_3_tab0_917 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22545,13 +22545,13 @@ SELECT pk FROM tab1 WHERE col3 < 292
 33 values hashing to efe65200e977c042916910e3c27ad7f5
 
 statement ok
-DROP VIEW view_1_tab1_917
+DROP VIEW IF EXISTS view_1_tab1_917 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_917
+DROP VIEW IF EXISTS view_2_tab1_917 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_917
+DROP VIEW IF EXISTS view_3_tab1_917 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22642,13 +22642,13 @@ SELECT pk FROM tab2 WHERE col3 < 292
 33 values hashing to efe65200e977c042916910e3c27ad7f5
 
 statement ok
-DROP VIEW view_1_tab2_917
+DROP VIEW IF EXISTS view_1_tab2_917 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_917
+DROP VIEW IF EXISTS view_2_tab2_917 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_917
+DROP VIEW IF EXISTS view_3_tab2_917 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22739,13 +22739,13 @@ SELECT pk FROM tab3 WHERE col3 < 292
 33 values hashing to efe65200e977c042916910e3c27ad7f5
 
 statement ok
-DROP VIEW view_1_tab3_917
+DROP VIEW IF EXISTS view_1_tab3_917 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_917
+DROP VIEW IF EXISTS view_2_tab3_917 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_917
+DROP VIEW IF EXISTS view_3_tab3_917 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22836,13 +22836,13 @@ SELECT pk FROM tab4 WHERE col3 < 292
 33 values hashing to efe65200e977c042916910e3c27ad7f5
 
 statement ok
-DROP VIEW view_1_tab4_917
+DROP VIEW IF EXISTS view_1_tab4_917 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_917
+DROP VIEW IF EXISTS view_2_tab4_917 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_917
+DROP VIEW IF EXISTS view_3_tab4_917 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22933,13 +22933,13 @@ SELECT pk FROM tab0 WHERE (col1 > 862.52)
 14 values hashing to a05c585baac87e53efe2bf03fe59e470
 
 statement ok
-DROP VIEW view_1_tab0_919
+DROP VIEW IF EXISTS view_1_tab0_919 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_919
+DROP VIEW IF EXISTS view_2_tab0_919 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_919
+DROP VIEW IF EXISTS view_3_tab0_919 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23030,13 +23030,13 @@ SELECT pk FROM tab1 WHERE (col1 > 862.52)
 14 values hashing to a05c585baac87e53efe2bf03fe59e470
 
 statement ok
-DROP VIEW view_1_tab1_919
+DROP VIEW IF EXISTS view_1_tab1_919 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_919
+DROP VIEW IF EXISTS view_2_tab1_919 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_919
+DROP VIEW IF EXISTS view_3_tab1_919 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23127,13 +23127,13 @@ SELECT pk FROM tab2 WHERE (col1 > 862.52)
 14 values hashing to a05c585baac87e53efe2bf03fe59e470
 
 statement ok
-DROP VIEW view_1_tab2_919
+DROP VIEW IF EXISTS view_1_tab2_919 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_919
+DROP VIEW IF EXISTS view_2_tab2_919 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_919
+DROP VIEW IF EXISTS view_3_tab2_919 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23224,13 +23224,13 @@ SELECT pk FROM tab3 WHERE (col1 > 862.52)
 14 values hashing to a05c585baac87e53efe2bf03fe59e470
 
 statement ok
-DROP VIEW view_1_tab3_919
+DROP VIEW IF EXISTS view_1_tab3_919 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_919
+DROP VIEW IF EXISTS view_2_tab3_919 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_919
+DROP VIEW IF EXISTS view_3_tab3_919 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23321,13 +23321,13 @@ SELECT pk FROM tab4 WHERE (col1 > 862.52)
 14 values hashing to a05c585baac87e53efe2bf03fe59e470
 
 statement ok
-DROP VIEW view_1_tab4_919
+DROP VIEW IF EXISTS view_1_tab4_919 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_919
+DROP VIEW IF EXISTS view_2_tab4_919 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_919
+DROP VIEW IF EXISTS view_3_tab4_919 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23418,13 +23418,13 @@ SELECT pk FROM tab0 WHERE col4 >= 913.54 OR (col1 < 0.76)
 9 values hashing to 1cdf9620609bedcf6d89df39a6288199
 
 statement ok
-DROP VIEW view_1_tab0_920
+DROP VIEW IF EXISTS view_1_tab0_920 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_920
+DROP VIEW IF EXISTS view_2_tab0_920 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_920
+DROP VIEW IF EXISTS view_3_tab0_920 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23515,13 +23515,13 @@ SELECT pk FROM tab1 WHERE col4 >= 913.54 OR (col1 < 0.76)
 9 values hashing to 1cdf9620609bedcf6d89df39a6288199
 
 statement ok
-DROP VIEW view_1_tab1_920
+DROP VIEW IF EXISTS view_1_tab1_920 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_920
+DROP VIEW IF EXISTS view_2_tab1_920 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_920
+DROP VIEW IF EXISTS view_3_tab1_920 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23612,13 +23612,13 @@ SELECT pk FROM tab2 WHERE col4 >= 913.54 OR (col1 < 0.76)
 9 values hashing to 1cdf9620609bedcf6d89df39a6288199
 
 statement ok
-DROP VIEW view_1_tab2_920
+DROP VIEW IF EXISTS view_1_tab2_920 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_920
+DROP VIEW IF EXISTS view_2_tab2_920 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_920
+DROP VIEW IF EXISTS view_3_tab2_920 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23709,13 +23709,13 @@ SELECT pk FROM tab3 WHERE col4 >= 913.54 OR (col1 < 0.76)
 9 values hashing to 1cdf9620609bedcf6d89df39a6288199
 
 statement ok
-DROP VIEW view_1_tab3_920
+DROP VIEW IF EXISTS view_1_tab3_920 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_920
+DROP VIEW IF EXISTS view_2_tab3_920 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_920
+DROP VIEW IF EXISTS view_3_tab3_920 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23806,13 +23806,13 @@ SELECT pk FROM tab4 WHERE col4 >= 913.54 OR (col1 < 0.76)
 9 values hashing to 1cdf9620609bedcf6d89df39a6288199
 
 statement ok
-DROP VIEW view_1_tab4_920
+DROP VIEW IF EXISTS view_1_tab4_920 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_920
+DROP VIEW IF EXISTS view_2_tab4_920 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_920
+DROP VIEW IF EXISTS view_3_tab4_920 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23898,13 +23898,13 @@ SELECT pk FROM tab0 WHERE (col0 = 185)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_921
+DROP VIEW IF EXISTS view_1_tab0_921 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_921
+DROP VIEW IF EXISTS view_2_tab0_921 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_921
+DROP VIEW IF EXISTS view_3_tab0_921 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23990,13 +23990,13 @@ SELECT pk FROM tab1 WHERE (col0 = 185)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_921
+DROP VIEW IF EXISTS view_1_tab1_921 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_921
+DROP VIEW IF EXISTS view_2_tab1_921 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_921
+DROP VIEW IF EXISTS view_3_tab1_921 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24082,13 +24082,13 @@ SELECT pk FROM tab2 WHERE (col0 = 185)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_921
+DROP VIEW IF EXISTS view_1_tab2_921 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_921
+DROP VIEW IF EXISTS view_2_tab2_921 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_921
+DROP VIEW IF EXISTS view_3_tab2_921 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24174,13 +24174,13 @@ SELECT pk FROM tab3 WHERE (col0 = 185)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_921
+DROP VIEW IF EXISTS view_1_tab3_921 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_921
+DROP VIEW IF EXISTS view_2_tab3_921 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_921
+DROP VIEW IF EXISTS view_3_tab3_921 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24266,13 +24266,13 @@ SELECT pk FROM tab4 WHERE (col0 = 185)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_921
+DROP VIEW IF EXISTS view_1_tab4_921 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_921
+DROP VIEW IF EXISTS view_2_tab4_921 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_921
+DROP VIEW IF EXISTS view_3_tab4_921 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24363,13 +24363,13 @@ SELECT pk FROM tab0 WHERE col4 < 174.43
 20 values hashing to d0d6d438c0138167e2acb94d95bf6707
 
 statement ok
-DROP VIEW view_1_tab0_922
+DROP VIEW IF EXISTS view_1_tab0_922 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_922
+DROP VIEW IF EXISTS view_2_tab0_922 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_922
+DROP VIEW IF EXISTS view_3_tab0_922 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24460,13 +24460,13 @@ SELECT pk FROM tab1 WHERE col4 < 174.43
 20 values hashing to d0d6d438c0138167e2acb94d95bf6707
 
 statement ok
-DROP VIEW view_1_tab1_922
+DROP VIEW IF EXISTS view_1_tab1_922 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_922
+DROP VIEW IF EXISTS view_2_tab1_922 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_922
+DROP VIEW IF EXISTS view_3_tab1_922 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24557,13 +24557,13 @@ SELECT pk FROM tab2 WHERE col4 < 174.43
 20 values hashing to d0d6d438c0138167e2acb94d95bf6707
 
 statement ok
-DROP VIEW view_1_tab2_922
+DROP VIEW IF EXISTS view_1_tab2_922 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_922
+DROP VIEW IF EXISTS view_2_tab2_922 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_922
+DROP VIEW IF EXISTS view_3_tab2_922 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24654,13 +24654,13 @@ SELECT pk FROM tab3 WHERE col4 < 174.43
 20 values hashing to d0d6d438c0138167e2acb94d95bf6707
 
 statement ok
-DROP VIEW view_1_tab3_922
+DROP VIEW IF EXISTS view_1_tab3_922 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_922
+DROP VIEW IF EXISTS view_2_tab3_922 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_922
+DROP VIEW IF EXISTS view_3_tab3_922 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24751,13 +24751,13 @@ SELECT pk FROM tab4 WHERE col4 < 174.43
 20 values hashing to d0d6d438c0138167e2acb94d95bf6707
 
 statement ok
-DROP VIEW view_1_tab4_922
+DROP VIEW IF EXISTS view_1_tab4_922 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_922
+DROP VIEW IF EXISTS view_2_tab4_922 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_922
+DROP VIEW IF EXISTS view_3_tab4_922 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24850,13 +24850,13 @@ SELECT pk FROM tab0 WHERE col3 >= 981
 35
 
 statement ok
-DROP VIEW view_1_tab0_923
+DROP VIEW IF EXISTS view_1_tab0_923 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_923
+DROP VIEW IF EXISTS view_2_tab0_923 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_923
+DROP VIEW IF EXISTS view_3_tab0_923 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24949,13 +24949,13 @@ SELECT pk FROM tab1 WHERE col3 >= 981
 35
 
 statement ok
-DROP VIEW view_1_tab1_923
+DROP VIEW IF EXISTS view_1_tab1_923 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_923
+DROP VIEW IF EXISTS view_2_tab1_923 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_923
+DROP VIEW IF EXISTS view_3_tab1_923 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25048,13 +25048,13 @@ SELECT pk FROM tab2 WHERE col3 >= 981
 35
 
 statement ok
-DROP VIEW view_1_tab2_923
+DROP VIEW IF EXISTS view_1_tab2_923 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_923
+DROP VIEW IF EXISTS view_2_tab2_923 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_923
+DROP VIEW IF EXISTS view_3_tab2_923 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25147,13 +25147,13 @@ SELECT pk FROM tab3 WHERE col3 >= 981
 35
 
 statement ok
-DROP VIEW view_1_tab3_923
+DROP VIEW IF EXISTS view_1_tab3_923 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_923
+DROP VIEW IF EXISTS view_2_tab3_923 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_923
+DROP VIEW IF EXISTS view_3_tab3_923 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25246,13 +25246,13 @@ SELECT pk FROM tab4 WHERE col3 >= 981
 35
 
 statement ok
-DROP VIEW view_1_tab4_923
+DROP VIEW IF EXISTS view_1_tab4_923 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_923
+DROP VIEW IF EXISTS view_2_tab4_923 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_923
+DROP VIEW IF EXISTS view_3_tab4_923 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25343,13 +25343,13 @@ SELECT pk FROM tab0 WHERE ((col4 >= 877.43 AND col0 >= 110))
 11 values hashing to 38040a09288e2b82b9d880b53534d7ec
 
 statement ok
-DROP VIEW view_1_tab0_924
+DROP VIEW IF EXISTS view_1_tab0_924 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_924
+DROP VIEW IF EXISTS view_2_tab0_924 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_924
+DROP VIEW IF EXISTS view_3_tab0_924 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25440,13 +25440,13 @@ SELECT pk FROM tab1 WHERE ((col4 >= 877.43 AND col0 >= 110))
 11 values hashing to 38040a09288e2b82b9d880b53534d7ec
 
 statement ok
-DROP VIEW view_1_tab1_924
+DROP VIEW IF EXISTS view_1_tab1_924 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_924
+DROP VIEW IF EXISTS view_2_tab1_924 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_924
+DROP VIEW IF EXISTS view_3_tab1_924 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25537,13 +25537,13 @@ SELECT pk FROM tab2 WHERE ((col4 >= 877.43 AND col0 >= 110))
 11 values hashing to 38040a09288e2b82b9d880b53534d7ec
 
 statement ok
-DROP VIEW view_1_tab2_924
+DROP VIEW IF EXISTS view_1_tab2_924 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_924
+DROP VIEW IF EXISTS view_2_tab2_924 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_924
+DROP VIEW IF EXISTS view_3_tab2_924 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25634,13 +25634,13 @@ SELECT pk FROM tab3 WHERE ((col4 >= 877.43 AND col0 >= 110))
 11 values hashing to 38040a09288e2b82b9d880b53534d7ec
 
 statement ok
-DROP VIEW view_1_tab3_924
+DROP VIEW IF EXISTS view_1_tab3_924 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_924
+DROP VIEW IF EXISTS view_2_tab3_924 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_924
+DROP VIEW IF EXISTS view_3_tab3_924 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25731,13 +25731,13 @@ SELECT pk FROM tab4 WHERE ((col4 >= 877.43 AND col0 >= 110))
 11 values hashing to 38040a09288e2b82b9d880b53534d7ec
 
 statement ok
-DROP VIEW view_1_tab4_924
+DROP VIEW IF EXISTS view_1_tab4_924 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_924
+DROP VIEW IF EXISTS view_2_tab4_924 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_924
+DROP VIEW IF EXISTS view_3_tab4_924 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25828,13 +25828,13 @@ SELECT pk FROM tab0 WHERE col1 < 792.60
 78 values hashing to 8e24963e49b3b2ad9531c140e8da084a
 
 statement ok
-DROP VIEW view_1_tab0_925
+DROP VIEW IF EXISTS view_1_tab0_925 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_925
+DROP VIEW IF EXISTS view_2_tab0_925 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_925
+DROP VIEW IF EXISTS view_3_tab0_925 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25925,13 +25925,13 @@ SELECT pk FROM tab1 WHERE col1 < 792.60
 78 values hashing to 8e24963e49b3b2ad9531c140e8da084a
 
 statement ok
-DROP VIEW view_1_tab1_925
+DROP VIEW IF EXISTS view_1_tab1_925 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_925
+DROP VIEW IF EXISTS view_2_tab1_925 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_925
+DROP VIEW IF EXISTS view_3_tab1_925 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26022,13 +26022,13 @@ SELECT pk FROM tab2 WHERE col1 < 792.60
 78 values hashing to 8e24963e49b3b2ad9531c140e8da084a
 
 statement ok
-DROP VIEW view_1_tab2_925
+DROP VIEW IF EXISTS view_1_tab2_925 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_925
+DROP VIEW IF EXISTS view_2_tab2_925 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_925
+DROP VIEW IF EXISTS view_3_tab2_925 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26119,13 +26119,13 @@ SELECT pk FROM tab3 WHERE col1 < 792.60
 78 values hashing to 8e24963e49b3b2ad9531c140e8da084a
 
 statement ok
-DROP VIEW view_1_tab3_925
+DROP VIEW IF EXISTS view_1_tab3_925 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_925
+DROP VIEW IF EXISTS view_2_tab3_925 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_925
+DROP VIEW IF EXISTS view_3_tab3_925 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26216,13 +26216,13 @@ SELECT pk FROM tab4 WHERE col1 < 792.60
 78 values hashing to 8e24963e49b3b2ad9531c140e8da084a
 
 statement ok
-DROP VIEW view_1_tab4_925
+DROP VIEW IF EXISTS view_1_tab4_925 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_925
+DROP VIEW IF EXISTS view_2_tab4_925 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_925
+DROP VIEW IF EXISTS view_3_tab4_925 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26308,13 +26308,13 @@ SELECT pk FROM tab0 WHERE col3 >= 264 AND col4 IN (651.96,956.25,874.76,464.30,2
 ----
 
 statement ok
-DROP VIEW view_1_tab0_926
+DROP VIEW IF EXISTS view_1_tab0_926 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_926
+DROP VIEW IF EXISTS view_2_tab0_926 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_926
+DROP VIEW IF EXISTS view_3_tab0_926 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26400,13 +26400,13 @@ SELECT pk FROM tab1 WHERE col3 >= 264 AND col4 IN (651.96,956.25,874.76,464.30,2
 ----
 
 statement ok
-DROP VIEW view_1_tab1_926
+DROP VIEW IF EXISTS view_1_tab1_926 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_926
+DROP VIEW IF EXISTS view_2_tab1_926 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_926
+DROP VIEW IF EXISTS view_3_tab1_926 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26492,13 +26492,13 @@ SELECT pk FROM tab2 WHERE col3 >= 264 AND col4 IN (651.96,956.25,874.76,464.30,2
 ----
 
 statement ok
-DROP VIEW view_1_tab2_926
+DROP VIEW IF EXISTS view_1_tab2_926 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_926
+DROP VIEW IF EXISTS view_2_tab2_926 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_926
+DROP VIEW IF EXISTS view_3_tab2_926 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26584,13 +26584,13 @@ SELECT pk FROM tab3 WHERE col3 >= 264 AND col4 IN (651.96,956.25,874.76,464.30,2
 ----
 
 statement ok
-DROP VIEW view_1_tab3_926
+DROP VIEW IF EXISTS view_1_tab3_926 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_926
+DROP VIEW IF EXISTS view_2_tab3_926 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_926
+DROP VIEW IF EXISTS view_3_tab3_926 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26676,13 +26676,13 @@ SELECT pk FROM tab4 WHERE col3 >= 264 AND col4 IN (651.96,956.25,874.76,464.30,2
 ----
 
 statement ok
-DROP VIEW view_1_tab4_926
+DROP VIEW IF EXISTS view_1_tab4_926 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_926
+DROP VIEW IF EXISTS view_2_tab4_926 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_926
+DROP VIEW IF EXISTS view_3_tab4_926 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26782,13 +26782,13 @@ SELECT pk FROM tab0 WHERE ((((col3 < 617 OR (col0 IS NULL OR (((col1 < 182.89 AN
 35
 
 statement ok
-DROP VIEW view_1_tab0_927
+DROP VIEW IF EXISTS view_1_tab0_927 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_927
+DROP VIEW IF EXISTS view_2_tab0_927 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_927
+DROP VIEW IF EXISTS view_3_tab0_927 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26888,13 +26888,13 @@ SELECT pk FROM tab1 WHERE ((((col3 < 617 OR (col0 IS NULL OR (((col1 < 182.89 AN
 35
 
 statement ok
-DROP VIEW view_1_tab1_927
+DROP VIEW IF EXISTS view_1_tab1_927 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_927
+DROP VIEW IF EXISTS view_2_tab1_927 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_927
+DROP VIEW IF EXISTS view_3_tab1_927 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26994,13 +26994,13 @@ SELECT pk FROM tab2 WHERE ((((col3 < 617 OR (col0 IS NULL OR (((col1 < 182.89 AN
 35
 
 statement ok
-DROP VIEW view_1_tab2_927
+DROP VIEW IF EXISTS view_1_tab2_927 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_927
+DROP VIEW IF EXISTS view_2_tab2_927 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_927
+DROP VIEW IF EXISTS view_3_tab2_927 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27100,13 +27100,13 @@ SELECT pk FROM tab3 WHERE ((((col3 < 617 OR (col0 IS NULL OR (((col1 < 182.89 AN
 35
 
 statement ok
-DROP VIEW view_1_tab3_927
+DROP VIEW IF EXISTS view_1_tab3_927 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_927
+DROP VIEW IF EXISTS view_2_tab3_927 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_927
+DROP VIEW IF EXISTS view_3_tab3_927 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27206,13 +27206,13 @@ SELECT pk FROM tab4 WHERE ((((col3 < 617 OR (col0 IS NULL OR (((col1 < 182.89 AN
 35
 
 statement ok
-DROP VIEW view_1_tab4_927
+DROP VIEW IF EXISTS view_1_tab4_927 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_927
+DROP VIEW IF EXISTS view_2_tab4_927 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_927
+DROP VIEW IF EXISTS view_3_tab4_927 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27298,13 +27298,13 @@ SELECT pk FROM tab0 WHERE col4 IN (402.10,610.41,438.86,448.19,101.25)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_928
+DROP VIEW IF EXISTS view_1_tab0_928 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_928
+DROP VIEW IF EXISTS view_2_tab0_928 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_928
+DROP VIEW IF EXISTS view_3_tab0_928 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27390,13 +27390,13 @@ SELECT pk FROM tab1 WHERE col4 IN (402.10,610.41,438.86,448.19,101.25)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_928
+DROP VIEW IF EXISTS view_1_tab1_928 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_928
+DROP VIEW IF EXISTS view_2_tab1_928 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_928
+DROP VIEW IF EXISTS view_3_tab1_928 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27482,13 +27482,13 @@ SELECT pk FROM tab2 WHERE col4 IN (402.10,610.41,438.86,448.19,101.25)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_928
+DROP VIEW IF EXISTS view_1_tab2_928 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_928
+DROP VIEW IF EXISTS view_2_tab2_928 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_928
+DROP VIEW IF EXISTS view_3_tab2_928 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27574,13 +27574,13 @@ SELECT pk FROM tab3 WHERE col4 IN (402.10,610.41,438.86,448.19,101.25)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_928
+DROP VIEW IF EXISTS view_1_tab3_928 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_928
+DROP VIEW IF EXISTS view_2_tab3_928 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_928
+DROP VIEW IF EXISTS view_3_tab3_928 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27666,13 +27666,13 @@ SELECT pk FROM tab4 WHERE col4 IN (402.10,610.41,438.86,448.19,101.25)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_928
+DROP VIEW IF EXISTS view_1_tab4_928 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_928
+DROP VIEW IF EXISTS view_2_tab4_928 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_928
+DROP VIEW IF EXISTS view_3_tab4_928 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27763,13 +27763,13 @@ SELECT pk FROM tab0 WHERE col3 <= 654
 66 values hashing to f5c4c529422f2043b908bd808f63d70e
 
 statement ok
-DROP VIEW view_1_tab0_929
+DROP VIEW IF EXISTS view_1_tab0_929 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_929
+DROP VIEW IF EXISTS view_2_tab0_929 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_929
+DROP VIEW IF EXISTS view_3_tab0_929 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27860,13 +27860,13 @@ SELECT pk FROM tab1 WHERE col3 <= 654
 66 values hashing to f5c4c529422f2043b908bd808f63d70e
 
 statement ok
-DROP VIEW view_1_tab1_929
+DROP VIEW IF EXISTS view_1_tab1_929 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_929
+DROP VIEW IF EXISTS view_2_tab1_929 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_929
+DROP VIEW IF EXISTS view_3_tab1_929 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27957,13 +27957,13 @@ SELECT pk FROM tab2 WHERE col3 <= 654
 66 values hashing to f5c4c529422f2043b908bd808f63d70e
 
 statement ok
-DROP VIEW view_1_tab2_929
+DROP VIEW IF EXISTS view_1_tab2_929 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_929
+DROP VIEW IF EXISTS view_2_tab2_929 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_929
+DROP VIEW IF EXISTS view_3_tab2_929 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28054,13 +28054,13 @@ SELECT pk FROM tab3 WHERE col3 <= 654
 66 values hashing to f5c4c529422f2043b908bd808f63d70e
 
 statement ok
-DROP VIEW view_1_tab3_929
+DROP VIEW IF EXISTS view_1_tab3_929 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_929
+DROP VIEW IF EXISTS view_2_tab3_929 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_929
+DROP VIEW IF EXISTS view_3_tab3_929 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28151,13 +28151,13 @@ SELECT pk FROM tab4 WHERE col3 <= 654
 66 values hashing to f5c4c529422f2043b908bd808f63d70e
 
 statement ok
-DROP VIEW view_1_tab4_929
+DROP VIEW IF EXISTS view_1_tab4_929 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_929
+DROP VIEW IF EXISTS view_2_tab4_929 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_929
+DROP VIEW IF EXISTS view_3_tab4_929 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28258,13 +28258,13 @@ SELECT pk FROM tab0 WHERE col4 < 943.67
 97 values hashing to 2201acd1b6fe4ee123eab69201bb7d38
 
 statement ok
-DROP VIEW view_1_tab0_930
+DROP VIEW IF EXISTS view_1_tab0_930 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_930
+DROP VIEW IF EXISTS view_2_tab0_930 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_930
+DROP VIEW IF EXISTS view_3_tab0_930 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28365,13 +28365,13 @@ SELECT pk FROM tab1 WHERE col4 < 943.67
 97 values hashing to 2201acd1b6fe4ee123eab69201bb7d38
 
 statement ok
-DROP VIEW view_1_tab1_930
+DROP VIEW IF EXISTS view_1_tab1_930 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_930
+DROP VIEW IF EXISTS view_2_tab1_930 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_930
+DROP VIEW IF EXISTS view_3_tab1_930 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28472,13 +28472,13 @@ SELECT pk FROM tab2 WHERE col4 < 943.67
 97 values hashing to 2201acd1b6fe4ee123eab69201bb7d38
 
 statement ok
-DROP VIEW view_1_tab2_930
+DROP VIEW IF EXISTS view_1_tab2_930 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_930
+DROP VIEW IF EXISTS view_2_tab2_930 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_930
+DROP VIEW IF EXISTS view_3_tab2_930 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28579,13 +28579,13 @@ SELECT pk FROM tab3 WHERE col4 < 943.67
 97 values hashing to 2201acd1b6fe4ee123eab69201bb7d38
 
 statement ok
-DROP VIEW view_1_tab3_930
+DROP VIEW IF EXISTS view_1_tab3_930 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_930
+DROP VIEW IF EXISTS view_2_tab3_930 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_930
+DROP VIEW IF EXISTS view_3_tab3_930 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28686,13 +28686,13 @@ SELECT pk FROM tab4 WHERE col4 < 943.67
 97 values hashing to 2201acd1b6fe4ee123eab69201bb7d38
 
 statement ok
-DROP VIEW view_1_tab4_930
+DROP VIEW IF EXISTS view_1_tab4_930 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_930
+DROP VIEW IF EXISTS view_2_tab4_930 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_930
+DROP VIEW IF EXISTS view_3_tab4_930 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28783,13 +28783,13 @@ SELECT pk FROM tab0 WHERE (col0 < 305)
 25 values hashing to 63c70dceacb145e15e46d0d4a04a0623
 
 statement ok
-DROP VIEW view_1_tab0_931
+DROP VIEW IF EXISTS view_1_tab0_931 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_931
+DROP VIEW IF EXISTS view_2_tab0_931 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_931
+DROP VIEW IF EXISTS view_3_tab0_931 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28880,13 +28880,13 @@ SELECT pk FROM tab1 WHERE (col0 < 305)
 25 values hashing to 63c70dceacb145e15e46d0d4a04a0623
 
 statement ok
-DROP VIEW view_1_tab1_931
+DROP VIEW IF EXISTS view_1_tab1_931 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_931
+DROP VIEW IF EXISTS view_2_tab1_931 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_931
+DROP VIEW IF EXISTS view_3_tab1_931 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28977,13 +28977,13 @@ SELECT pk FROM tab2 WHERE (col0 < 305)
 25 values hashing to 63c70dceacb145e15e46d0d4a04a0623
 
 statement ok
-DROP VIEW view_1_tab2_931
+DROP VIEW IF EXISTS view_1_tab2_931 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_931
+DROP VIEW IF EXISTS view_2_tab2_931 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_931
+DROP VIEW IF EXISTS view_3_tab2_931 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29074,13 +29074,13 @@ SELECT pk FROM tab3 WHERE (col0 < 305)
 25 values hashing to 63c70dceacb145e15e46d0d4a04a0623
 
 statement ok
-DROP VIEW view_1_tab3_931
+DROP VIEW IF EXISTS view_1_tab3_931 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_931
+DROP VIEW IF EXISTS view_2_tab3_931 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_931
+DROP VIEW IF EXISTS view_3_tab3_931 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29171,13 +29171,13 @@ SELECT pk FROM tab4 WHERE (col0 < 305)
 25 values hashing to 63c70dceacb145e15e46d0d4a04a0623
 
 statement ok
-DROP VIEW view_1_tab4_931
+DROP VIEW IF EXISTS view_1_tab4_931 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_931
+DROP VIEW IF EXISTS view_2_tab4_931 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_931
+DROP VIEW IF EXISTS view_3_tab4_931 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29268,13 +29268,13 @@ SELECT pk FROM tab0 WHERE col3 <= 903 AND col0 > 452 AND (col0 >= 146) AND col3 
 15 values hashing to 1f61f118bc2e5bb7d2415a0083f75e0a
 
 statement ok
-DROP VIEW view_1_tab0_932
+DROP VIEW IF EXISTS view_1_tab0_932 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_932
+DROP VIEW IF EXISTS view_2_tab0_932 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_932
+DROP VIEW IF EXISTS view_3_tab0_932 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29365,13 +29365,13 @@ SELECT pk FROM tab1 WHERE col3 <= 903 AND col0 > 452 AND (col0 >= 146) AND col3 
 15 values hashing to 1f61f118bc2e5bb7d2415a0083f75e0a
 
 statement ok
-DROP VIEW view_1_tab1_932
+DROP VIEW IF EXISTS view_1_tab1_932 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_932
+DROP VIEW IF EXISTS view_2_tab1_932 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_932
+DROP VIEW IF EXISTS view_3_tab1_932 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29462,13 +29462,13 @@ SELECT pk FROM tab2 WHERE col3 <= 903 AND col0 > 452 AND (col0 >= 146) AND col3 
 15 values hashing to 1f61f118bc2e5bb7d2415a0083f75e0a
 
 statement ok
-DROP VIEW view_1_tab2_932
+DROP VIEW IF EXISTS view_1_tab2_932 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_932
+DROP VIEW IF EXISTS view_2_tab2_932 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_932
+DROP VIEW IF EXISTS view_3_tab2_932 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29559,13 +29559,13 @@ SELECT pk FROM tab3 WHERE col3 <= 903 AND col0 > 452 AND (col0 >= 146) AND col3 
 15 values hashing to 1f61f118bc2e5bb7d2415a0083f75e0a
 
 statement ok
-DROP VIEW view_1_tab3_932
+DROP VIEW IF EXISTS view_1_tab3_932 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_932
+DROP VIEW IF EXISTS view_2_tab3_932 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_932
+DROP VIEW IF EXISTS view_3_tab3_932 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29656,13 +29656,13 @@ SELECT pk FROM tab4 WHERE col3 <= 903 AND col0 > 452 AND (col0 >= 146) AND col3 
 15 values hashing to 1f61f118bc2e5bb7d2415a0083f75e0a
 
 statement ok
-DROP VIEW view_1_tab4_932
+DROP VIEW IF EXISTS view_1_tab4_932 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_932
+DROP VIEW IF EXISTS view_2_tab4_932 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_932
+DROP VIEW IF EXISTS view_3_tab4_932 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29753,13 +29753,13 @@ SELECT pk FROM tab0 WHERE col1 < 137.74
 15 values hashing to 4dc86439b3e68eff48ac15e2a3e2c88d
 
 statement ok
-DROP VIEW view_1_tab0_933
+DROP VIEW IF EXISTS view_1_tab0_933 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_933
+DROP VIEW IF EXISTS view_2_tab0_933 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_933
+DROP VIEW IF EXISTS view_3_tab0_933 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29850,13 +29850,13 @@ SELECT pk FROM tab1 WHERE col1 < 137.74
 15 values hashing to 4dc86439b3e68eff48ac15e2a3e2c88d
 
 statement ok
-DROP VIEW view_1_tab1_933
+DROP VIEW IF EXISTS view_1_tab1_933 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_933
+DROP VIEW IF EXISTS view_2_tab1_933 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_933
+DROP VIEW IF EXISTS view_3_tab1_933 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29947,13 +29947,13 @@ SELECT pk FROM tab2 WHERE col1 < 137.74
 15 values hashing to 4dc86439b3e68eff48ac15e2a3e2c88d
 
 statement ok
-DROP VIEW view_1_tab2_933
+DROP VIEW IF EXISTS view_1_tab2_933 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_933
+DROP VIEW IF EXISTS view_2_tab2_933 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_933
+DROP VIEW IF EXISTS view_3_tab2_933 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30044,13 +30044,13 @@ SELECT pk FROM tab3 WHERE col1 < 137.74
 15 values hashing to 4dc86439b3e68eff48ac15e2a3e2c88d
 
 statement ok
-DROP VIEW view_1_tab3_933
+DROP VIEW IF EXISTS view_1_tab3_933 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_933
+DROP VIEW IF EXISTS view_2_tab3_933 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_933
+DROP VIEW IF EXISTS view_3_tab3_933 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30141,13 +30141,13 @@ SELECT pk FROM tab4 WHERE col1 < 137.74
 15 values hashing to 4dc86439b3e68eff48ac15e2a3e2c88d
 
 statement ok
-DROP VIEW view_1_tab4_933
+DROP VIEW IF EXISTS view_1_tab4_933 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_933
+DROP VIEW IF EXISTS view_2_tab4_933 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_933
+DROP VIEW IF EXISTS view_3_tab4_933 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30250,13 +30250,13 @@ SELECT pk FROM tab0 WHERE col0 > 951
 83
 
 statement ok
-DROP VIEW view_1_tab0_934
+DROP VIEW IF EXISTS view_1_tab0_934 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_934
+DROP VIEW IF EXISTS view_2_tab0_934 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_934
+DROP VIEW IF EXISTS view_3_tab0_934 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30359,13 +30359,13 @@ SELECT pk FROM tab1 WHERE col0 > 951
 83
 
 statement ok
-DROP VIEW view_1_tab1_934
+DROP VIEW IF EXISTS view_1_tab1_934 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_934
+DROP VIEW IF EXISTS view_2_tab1_934 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_934
+DROP VIEW IF EXISTS view_3_tab1_934 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30468,13 +30468,13 @@ SELECT pk FROM tab2 WHERE col0 > 951
 83
 
 statement ok
-DROP VIEW view_1_tab2_934
+DROP VIEW IF EXISTS view_1_tab2_934 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_934
+DROP VIEW IF EXISTS view_2_tab2_934 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_934
+DROP VIEW IF EXISTS view_3_tab2_934 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30577,13 +30577,13 @@ SELECT pk FROM tab3 WHERE col0 > 951
 83
 
 statement ok
-DROP VIEW view_1_tab3_934
+DROP VIEW IF EXISTS view_1_tab3_934 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_934
+DROP VIEW IF EXISTS view_2_tab3_934 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_934
+DROP VIEW IF EXISTS view_3_tab3_934 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30686,13 +30686,13 @@ SELECT pk FROM tab4 WHERE col0 > 951
 83
 
 statement ok
-DROP VIEW view_1_tab4_934
+DROP VIEW IF EXISTS view_1_tab4_934 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_934
+DROP VIEW IF EXISTS view_2_tab4_934 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_934
+DROP VIEW IF EXISTS view_3_tab4_934 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30785,13 +30785,13 @@ SELECT pk FROM tab0 WHERE (col0 < 1)
 28
 
 statement ok
-DROP VIEW view_1_tab0_935
+DROP VIEW IF EXISTS view_1_tab0_935 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_935
+DROP VIEW IF EXISTS view_2_tab0_935 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_935
+DROP VIEW IF EXISTS view_3_tab0_935 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30884,13 +30884,13 @@ SELECT pk FROM tab1 WHERE (col0 < 1)
 28
 
 statement ok
-DROP VIEW view_1_tab1_935
+DROP VIEW IF EXISTS view_1_tab1_935 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_935
+DROP VIEW IF EXISTS view_2_tab1_935 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_935
+DROP VIEW IF EXISTS view_3_tab1_935 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30983,13 +30983,13 @@ SELECT pk FROM tab2 WHERE (col0 < 1)
 28
 
 statement ok
-DROP VIEW view_1_tab2_935
+DROP VIEW IF EXISTS view_1_tab2_935 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_935
+DROP VIEW IF EXISTS view_2_tab2_935 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_935
+DROP VIEW IF EXISTS view_3_tab2_935 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31082,13 +31082,13 @@ SELECT pk FROM tab3 WHERE (col0 < 1)
 28
 
 statement ok
-DROP VIEW view_1_tab3_935
+DROP VIEW IF EXISTS view_1_tab3_935 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_935
+DROP VIEW IF EXISTS view_2_tab3_935 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_935
+DROP VIEW IF EXISTS view_3_tab3_935 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31181,13 +31181,13 @@ SELECT pk FROM tab4 WHERE (col0 < 1)
 28
 
 statement ok
-DROP VIEW view_1_tab4_935
+DROP VIEW IF EXISTS view_1_tab4_935 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_935
+DROP VIEW IF EXISTS view_2_tab4_935 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_935
+DROP VIEW IF EXISTS view_3_tab4_935 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31292,13 +31292,13 @@ SELECT pk FROM tab0 WHERE col4 <= 463.77 AND ((col0 >= 658 OR col4 > 223.8)) OR 
 96 values hashing to 8910953ce45c607981a097847f164140
 
 statement ok
-DROP VIEW view_1_tab0_936
+DROP VIEW IF EXISTS view_1_tab0_936 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_936
+DROP VIEW IF EXISTS view_2_tab0_936 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_936
+DROP VIEW IF EXISTS view_3_tab0_936 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31403,13 +31403,13 @@ SELECT pk FROM tab1 WHERE col4 <= 463.77 AND ((col0 >= 658 OR col4 > 223.8)) OR 
 96 values hashing to 8910953ce45c607981a097847f164140
 
 statement ok
-DROP VIEW view_1_tab1_936
+DROP VIEW IF EXISTS view_1_tab1_936 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_936
+DROP VIEW IF EXISTS view_2_tab1_936 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_936
+DROP VIEW IF EXISTS view_3_tab1_936 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31514,13 +31514,13 @@ SELECT pk FROM tab2 WHERE col4 <= 463.77 AND ((col0 >= 658 OR col4 > 223.8)) OR 
 96 values hashing to 8910953ce45c607981a097847f164140
 
 statement ok
-DROP VIEW view_1_tab2_936
+DROP VIEW IF EXISTS view_1_tab2_936 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_936
+DROP VIEW IF EXISTS view_2_tab2_936 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_936
+DROP VIEW IF EXISTS view_3_tab2_936 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31625,13 +31625,13 @@ SELECT pk FROM tab3 WHERE col4 <= 463.77 AND ((col0 >= 658 OR col4 > 223.8)) OR 
 96 values hashing to 8910953ce45c607981a097847f164140
 
 statement ok
-DROP VIEW view_1_tab3_936
+DROP VIEW IF EXISTS view_1_tab3_936 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_936
+DROP VIEW IF EXISTS view_2_tab3_936 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_936
+DROP VIEW IF EXISTS view_3_tab3_936 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31736,13 +31736,13 @@ SELECT pk FROM tab4 WHERE col4 <= 463.77 AND ((col0 >= 658 OR col4 > 223.8)) OR 
 96 values hashing to 8910953ce45c607981a097847f164140
 
 statement ok
-DROP VIEW view_1_tab4_936
+DROP VIEW IF EXISTS view_1_tab4_936 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_936
+DROP VIEW IF EXISTS view_2_tab4_936 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_936
+DROP VIEW IF EXISTS view_3_tab4_936 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31848,13 +31848,13 @@ SELECT pk FROM tab0 WHERE col4 <= 113.35 AND col3 BETWEEN 529 AND 924
 94
 
 statement ok
-DROP VIEW view_1_tab0_938
+DROP VIEW IF EXISTS view_1_tab0_938 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_938
+DROP VIEW IF EXISTS view_2_tab0_938 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_938
+DROP VIEW IF EXISTS view_3_tab0_938 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31960,13 +31960,13 @@ SELECT pk FROM tab1 WHERE col4 <= 113.35 AND col3 BETWEEN 529 AND 924
 94
 
 statement ok
-DROP VIEW view_1_tab1_938
+DROP VIEW IF EXISTS view_1_tab1_938 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_938
+DROP VIEW IF EXISTS view_2_tab1_938 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_938
+DROP VIEW IF EXISTS view_3_tab1_938 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32072,13 +32072,13 @@ SELECT pk FROM tab2 WHERE col4 <= 113.35 AND col3 BETWEEN 529 AND 924
 94
 
 statement ok
-DROP VIEW view_1_tab2_938
+DROP VIEW IF EXISTS view_1_tab2_938 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_938
+DROP VIEW IF EXISTS view_2_tab2_938 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_938
+DROP VIEW IF EXISTS view_3_tab2_938 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32184,13 +32184,13 @@ SELECT pk FROM tab3 WHERE col4 <= 113.35 AND col3 BETWEEN 529 AND 924
 94
 
 statement ok
-DROP VIEW view_1_tab3_938
+DROP VIEW IF EXISTS view_1_tab3_938 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_938
+DROP VIEW IF EXISTS view_2_tab3_938 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_938
+DROP VIEW IF EXISTS view_3_tab3_938 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32296,13 +32296,13 @@ SELECT pk FROM tab4 WHERE col4 <= 113.35 AND col3 BETWEEN 529 AND 924
 94
 
 statement ok
-DROP VIEW view_1_tab4_938
+DROP VIEW IF EXISTS view_1_tab4_938 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_938
+DROP VIEW IF EXISTS view_2_tab4_938 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_938
+DROP VIEW IF EXISTS view_3_tab4_938 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32393,13 +32393,13 @@ SELECT pk FROM tab0 WHERE col0 >= 128
 93 values hashing to 33ec9b63f2c5ceb09e06900cf1cd9f3d
 
 statement ok
-DROP VIEW view_1_tab0_939
+DROP VIEW IF EXISTS view_1_tab0_939 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_939
+DROP VIEW IF EXISTS view_2_tab0_939 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_939
+DROP VIEW IF EXISTS view_3_tab0_939 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32490,13 +32490,13 @@ SELECT pk FROM tab1 WHERE col0 >= 128
 93 values hashing to 33ec9b63f2c5ceb09e06900cf1cd9f3d
 
 statement ok
-DROP VIEW view_1_tab1_939
+DROP VIEW IF EXISTS view_1_tab1_939 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_939
+DROP VIEW IF EXISTS view_2_tab1_939 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_939
+DROP VIEW IF EXISTS view_3_tab1_939 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32587,13 +32587,13 @@ SELECT pk FROM tab2 WHERE col0 >= 128
 93 values hashing to 33ec9b63f2c5ceb09e06900cf1cd9f3d
 
 statement ok
-DROP VIEW view_1_tab2_939
+DROP VIEW IF EXISTS view_1_tab2_939 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_939
+DROP VIEW IF EXISTS view_2_tab2_939 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_939
+DROP VIEW IF EXISTS view_3_tab2_939 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32684,13 +32684,13 @@ SELECT pk FROM tab3 WHERE col0 >= 128
 93 values hashing to 33ec9b63f2c5ceb09e06900cf1cd9f3d
 
 statement ok
-DROP VIEW view_1_tab3_939
+DROP VIEW IF EXISTS view_1_tab3_939 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_939
+DROP VIEW IF EXISTS view_2_tab3_939 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_939
+DROP VIEW IF EXISTS view_3_tab3_939 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32781,13 +32781,13 @@ SELECT pk FROM tab4 WHERE col0 >= 128
 93 values hashing to 33ec9b63f2c5ceb09e06900cf1cd9f3d
 
 statement ok
-DROP VIEW view_1_tab4_939
+DROP VIEW IF EXISTS view_1_tab4_939 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_939
+DROP VIEW IF EXISTS view_2_tab4_939 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_939
+DROP VIEW IF EXISTS view_3_tab4_939 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32894,13 +32894,13 @@ SELECT pk FROM tab0 WHERE (col4 > 944.11)
 9
 
 statement ok
-DROP VIEW view_1_tab0_940
+DROP VIEW IF EXISTS view_1_tab0_940 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_940
+DROP VIEW IF EXISTS view_2_tab0_940 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_940
+DROP VIEW IF EXISTS view_3_tab0_940 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33007,13 +33007,13 @@ SELECT pk FROM tab1 WHERE (col4 > 944.11)
 9
 
 statement ok
-DROP VIEW view_1_tab1_940
+DROP VIEW IF EXISTS view_1_tab1_940 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_940
+DROP VIEW IF EXISTS view_2_tab1_940 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_940
+DROP VIEW IF EXISTS view_3_tab1_940 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33120,13 +33120,13 @@ SELECT pk FROM tab2 WHERE (col4 > 944.11)
 9
 
 statement ok
-DROP VIEW view_1_tab2_940
+DROP VIEW IF EXISTS view_1_tab2_940 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_940
+DROP VIEW IF EXISTS view_2_tab2_940 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_940
+DROP VIEW IF EXISTS view_3_tab2_940 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33233,13 +33233,13 @@ SELECT pk FROM tab3 WHERE (col4 > 944.11)
 9
 
 statement ok
-DROP VIEW view_1_tab3_940
+DROP VIEW IF EXISTS view_1_tab3_940 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_940
+DROP VIEW IF EXISTS view_2_tab3_940 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_940
+DROP VIEW IF EXISTS view_3_tab3_940 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33346,13 +33346,13 @@ SELECT pk FROM tab4 WHERE (col4 > 944.11)
 9
 
 statement ok
-DROP VIEW view_1_tab4_940
+DROP VIEW IF EXISTS view_1_tab4_940 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_940
+DROP VIEW IF EXISTS view_2_tab4_940 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_940
+DROP VIEW IF EXISTS view_3_tab4_940 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33443,13 +33443,13 @@ SELECT pk FROM tab0 WHERE (((col0 > 339 AND (col1 >= 430.28) AND (col0 >= 404 AN
 33 values hashing to effc16a2539fcb5f6bd7c3da24824fd6
 
 statement ok
-DROP VIEW view_1_tab0_941
+DROP VIEW IF EXISTS view_1_tab0_941 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_941
+DROP VIEW IF EXISTS view_2_tab0_941 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_941
+DROP VIEW IF EXISTS view_3_tab0_941 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33540,13 +33540,13 @@ SELECT pk FROM tab1 WHERE (((col0 > 339 AND (col1 >= 430.28) AND (col0 >= 404 AN
 33 values hashing to effc16a2539fcb5f6bd7c3da24824fd6
 
 statement ok
-DROP VIEW view_1_tab1_941
+DROP VIEW IF EXISTS view_1_tab1_941 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_941
+DROP VIEW IF EXISTS view_2_tab1_941 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_941
+DROP VIEW IF EXISTS view_3_tab1_941 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33637,13 +33637,13 @@ SELECT pk FROM tab2 WHERE (((col0 > 339 AND (col1 >= 430.28) AND (col0 >= 404 AN
 33 values hashing to effc16a2539fcb5f6bd7c3da24824fd6
 
 statement ok
-DROP VIEW view_1_tab2_941
+DROP VIEW IF EXISTS view_1_tab2_941 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_941
+DROP VIEW IF EXISTS view_2_tab2_941 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_941
+DROP VIEW IF EXISTS view_3_tab2_941 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33734,13 +33734,13 @@ SELECT pk FROM tab3 WHERE (((col0 > 339 AND (col1 >= 430.28) AND (col0 >= 404 AN
 33 values hashing to effc16a2539fcb5f6bd7c3da24824fd6
 
 statement ok
-DROP VIEW view_1_tab3_941
+DROP VIEW IF EXISTS view_1_tab3_941 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_941
+DROP VIEW IF EXISTS view_2_tab3_941 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_941
+DROP VIEW IF EXISTS view_3_tab3_941 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33831,13 +33831,13 @@ SELECT pk FROM tab4 WHERE (((col0 > 339 AND (col1 >= 430.28) AND (col0 >= 404 AN
 33 values hashing to effc16a2539fcb5f6bd7c3da24824fd6
 
 statement ok
-DROP VIEW view_1_tab4_941
+DROP VIEW IF EXISTS view_1_tab4_941 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_941
+DROP VIEW IF EXISTS view_2_tab4_941 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_941
+DROP VIEW IF EXISTS view_3_tab4_941 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -33934,13 +33934,13 @@ SELECT pk FROM tab0 WHERE col0 > 16
 98 values hashing to 4752549f84d9be34b5b5ead669a24341
 
 statement ok
-DROP VIEW view_1_tab0_942
+DROP VIEW IF EXISTS view_1_tab0_942 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_942
+DROP VIEW IF EXISTS view_2_tab0_942 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_942
+DROP VIEW IF EXISTS view_3_tab0_942 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34037,13 +34037,13 @@ SELECT pk FROM tab1 WHERE col0 > 16
 98 values hashing to 4752549f84d9be34b5b5ead669a24341
 
 statement ok
-DROP VIEW view_1_tab1_942
+DROP VIEW IF EXISTS view_1_tab1_942 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_942
+DROP VIEW IF EXISTS view_2_tab1_942 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_942
+DROP VIEW IF EXISTS view_3_tab1_942 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34140,13 +34140,13 @@ SELECT pk FROM tab2 WHERE col0 > 16
 98 values hashing to 4752549f84d9be34b5b5ead669a24341
 
 statement ok
-DROP VIEW view_1_tab2_942
+DROP VIEW IF EXISTS view_1_tab2_942 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_942
+DROP VIEW IF EXISTS view_2_tab2_942 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_942
+DROP VIEW IF EXISTS view_3_tab2_942 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34243,13 +34243,13 @@ SELECT pk FROM tab3 WHERE col0 > 16
 98 values hashing to 4752549f84d9be34b5b5ead669a24341
 
 statement ok
-DROP VIEW view_1_tab3_942
+DROP VIEW IF EXISTS view_1_tab3_942 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_942
+DROP VIEW IF EXISTS view_2_tab3_942 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_942
+DROP VIEW IF EXISTS view_3_tab3_942 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34346,13 +34346,13 @@ SELECT pk FROM tab4 WHERE col0 > 16
 98 values hashing to 4752549f84d9be34b5b5ead669a24341
 
 statement ok
-DROP VIEW view_1_tab4_942
+DROP VIEW IF EXISTS view_1_tab4_942 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_942
+DROP VIEW IF EXISTS view_2_tab4_942 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_942
+DROP VIEW IF EXISTS view_3_tab4_942 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34443,13 +34443,13 @@ SELECT pk FROM tab0 WHERE ((col3 >= 982)) OR (col0 > 522)
 56 values hashing to 6ee9e1c0c83906ea83467f7d502ca09b
 
 statement ok
-DROP VIEW view_1_tab0_943
+DROP VIEW IF EXISTS view_1_tab0_943 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_943
+DROP VIEW IF EXISTS view_2_tab0_943 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_943
+DROP VIEW IF EXISTS view_3_tab0_943 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34540,13 +34540,13 @@ SELECT pk FROM tab1 WHERE ((col3 >= 982)) OR (col0 > 522)
 56 values hashing to 6ee9e1c0c83906ea83467f7d502ca09b
 
 statement ok
-DROP VIEW view_1_tab1_943
+DROP VIEW IF EXISTS view_1_tab1_943 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_943
+DROP VIEW IF EXISTS view_2_tab1_943 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_943
+DROP VIEW IF EXISTS view_3_tab1_943 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34637,13 +34637,13 @@ SELECT pk FROM tab2 WHERE ((col3 >= 982)) OR (col0 > 522)
 56 values hashing to 6ee9e1c0c83906ea83467f7d502ca09b
 
 statement ok
-DROP VIEW view_1_tab2_943
+DROP VIEW IF EXISTS view_1_tab2_943 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_943
+DROP VIEW IF EXISTS view_2_tab2_943 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_943
+DROP VIEW IF EXISTS view_3_tab2_943 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34734,13 +34734,13 @@ SELECT pk FROM tab3 WHERE ((col3 >= 982)) OR (col0 > 522)
 56 values hashing to 6ee9e1c0c83906ea83467f7d502ca09b
 
 statement ok
-DROP VIEW view_1_tab3_943
+DROP VIEW IF EXISTS view_1_tab3_943 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_943
+DROP VIEW IF EXISTS view_2_tab3_943 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_943
+DROP VIEW IF EXISTS view_3_tab3_943 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34831,13 +34831,13 @@ SELECT pk FROM tab4 WHERE ((col3 >= 982)) OR (col0 > 522)
 56 values hashing to 6ee9e1c0c83906ea83467f7d502ca09b
 
 statement ok
-DROP VIEW view_1_tab4_943
+DROP VIEW IF EXISTS view_1_tab4_943 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_943
+DROP VIEW IF EXISTS view_2_tab4_943 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_943
+DROP VIEW IF EXISTS view_3_tab4_943 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -34923,13 +34923,13 @@ SELECT pk FROM tab0 WHERE col1 < 588.74 AND ((((col4 = 278.77 AND col4 < 697.53)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_944
+DROP VIEW IF EXISTS view_1_tab0_944 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_944
+DROP VIEW IF EXISTS view_2_tab0_944 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_944
+DROP VIEW IF EXISTS view_3_tab0_944 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35015,13 +35015,13 @@ SELECT pk FROM tab1 WHERE col1 < 588.74 AND ((((col4 = 278.77 AND col4 < 697.53)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_944
+DROP VIEW IF EXISTS view_1_tab1_944 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_944
+DROP VIEW IF EXISTS view_2_tab1_944 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_944
+DROP VIEW IF EXISTS view_3_tab1_944 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35107,13 +35107,13 @@ SELECT pk FROM tab2 WHERE col1 < 588.74 AND ((((col4 = 278.77 AND col4 < 697.53)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_944
+DROP VIEW IF EXISTS view_1_tab2_944 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_944
+DROP VIEW IF EXISTS view_2_tab2_944 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_944
+DROP VIEW IF EXISTS view_3_tab2_944 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35199,13 +35199,13 @@ SELECT pk FROM tab3 WHERE col1 < 588.74 AND ((((col4 = 278.77 AND col4 < 697.53)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_944
+DROP VIEW IF EXISTS view_1_tab3_944 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_944
+DROP VIEW IF EXISTS view_2_tab3_944 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_944
+DROP VIEW IF EXISTS view_3_tab3_944 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35291,13 +35291,13 @@ SELECT pk FROM tab4 WHERE col1 < 588.74 AND ((((col4 = 278.77 AND col4 < 697.53)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_944
+DROP VIEW IF EXISTS view_1_tab4_944 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_944
+DROP VIEW IF EXISTS view_2_tab4_944 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_944
+DROP VIEW IF EXISTS view_3_tab4_944 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35383,13 +35383,13 @@ SELECT pk FROM tab0 WHERE col3 = 565
 ----
 
 statement ok
-DROP VIEW view_1_tab0_945
+DROP VIEW IF EXISTS view_1_tab0_945 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_945
+DROP VIEW IF EXISTS view_2_tab0_945 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_945
+DROP VIEW IF EXISTS view_3_tab0_945 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35475,13 +35475,13 @@ SELECT pk FROM tab1 WHERE col3 = 565
 ----
 
 statement ok
-DROP VIEW view_1_tab1_945
+DROP VIEW IF EXISTS view_1_tab1_945 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_945
+DROP VIEW IF EXISTS view_2_tab1_945 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_945
+DROP VIEW IF EXISTS view_3_tab1_945 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35567,13 +35567,13 @@ SELECT pk FROM tab2 WHERE col3 = 565
 ----
 
 statement ok
-DROP VIEW view_1_tab2_945
+DROP VIEW IF EXISTS view_1_tab2_945 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_945
+DROP VIEW IF EXISTS view_2_tab2_945 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_945
+DROP VIEW IF EXISTS view_3_tab2_945 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35659,13 +35659,13 @@ SELECT pk FROM tab3 WHERE col3 = 565
 ----
 
 statement ok
-DROP VIEW view_1_tab3_945
+DROP VIEW IF EXISTS view_1_tab3_945 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_945
+DROP VIEW IF EXISTS view_2_tab3_945 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_945
+DROP VIEW IF EXISTS view_3_tab3_945 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -35751,11 +35751,11 @@ SELECT pk FROM tab4 WHERE col3 = 565
 ----
 
 statement ok
-DROP VIEW view_1_tab4_945
+DROP VIEW IF EXISTS view_1_tab4_945 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_945
+DROP VIEW IF EXISTS view_2_tab4_945 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_945
+DROP VIEW IF EXISTS view_3_tab4_945 CASCADE
 

--- a/test/index/view/1000/slt_good_0.test
+++ b/test/index/view/1000/slt_good_0.test
@@ -3156,13 +3156,13 @@ SELECT pk FROM tab0 WHERE (col0 < 168 AND (col0 >= 6575 AND (((col1 < 3161.1))))
 ----
 
 statement ok
-DROP VIEW view_1_tab0_737
+DROP VIEW IF EXISTS view_1_tab0_737 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_737
+DROP VIEW IF EXISTS view_2_tab0_737 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_737
+DROP VIEW IF EXISTS view_3_tab0_737 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3248,13 +3248,13 @@ SELECT pk FROM tab1 WHERE (col0 < 168 AND (col0 >= 6575 AND (((col1 < 3161.1))))
 ----
 
 statement ok
-DROP VIEW view_1_tab1_737
+DROP VIEW IF EXISTS view_1_tab1_737 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_737
+DROP VIEW IF EXISTS view_2_tab1_737 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_737
+DROP VIEW IF EXISTS view_3_tab1_737 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3340,13 +3340,13 @@ SELECT pk FROM tab2 WHERE (col0 < 168 AND (col0 >= 6575 AND (((col1 < 3161.1))))
 ----
 
 statement ok
-DROP VIEW view_1_tab2_737
+DROP VIEW IF EXISTS view_1_tab2_737 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_737
+DROP VIEW IF EXISTS view_2_tab2_737 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_737
+DROP VIEW IF EXISTS view_3_tab2_737 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3432,13 +3432,13 @@ SELECT pk FROM tab3 WHERE (col0 < 168 AND (col0 >= 6575 AND (((col1 < 3161.1))))
 ----
 
 statement ok
-DROP VIEW view_1_tab3_737
+DROP VIEW IF EXISTS view_1_tab3_737 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_737
+DROP VIEW IF EXISTS view_2_tab3_737 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_737
+DROP VIEW IF EXISTS view_3_tab3_737 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3524,13 +3524,13 @@ SELECT pk FROM tab4 WHERE (col0 < 168 AND (col0 >= 6575 AND (((col1 < 3161.1))))
 ----
 
 statement ok
-DROP VIEW view_1_tab4_737
+DROP VIEW IF EXISTS view_1_tab4_737 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_737
+DROP VIEW IF EXISTS view_2_tab4_737 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_737
+DROP VIEW IF EXISTS view_3_tab4_737 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3621,13 +3621,13 @@ SELECT pk FROM tab0 WHERE col0 > 9042
 88 values hashing to 562c36a9a2f908bf0c81b2226eaf465b
 
 statement ok
-DROP VIEW view_1_tab0_739
+DROP VIEW IF EXISTS view_1_tab0_739 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_739
+DROP VIEW IF EXISTS view_2_tab0_739 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_739
+DROP VIEW IF EXISTS view_3_tab0_739 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3718,13 +3718,13 @@ SELECT pk FROM tab1 WHERE col0 > 9042
 88 values hashing to 562c36a9a2f908bf0c81b2226eaf465b
 
 statement ok
-DROP VIEW view_1_tab1_739
+DROP VIEW IF EXISTS view_1_tab1_739 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_739
+DROP VIEW IF EXISTS view_2_tab1_739 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_739
+DROP VIEW IF EXISTS view_3_tab1_739 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3815,13 +3815,13 @@ SELECT pk FROM tab2 WHERE col0 > 9042
 88 values hashing to 562c36a9a2f908bf0c81b2226eaf465b
 
 statement ok
-DROP VIEW view_1_tab2_739
+DROP VIEW IF EXISTS view_1_tab2_739 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_739
+DROP VIEW IF EXISTS view_2_tab2_739 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_739
+DROP VIEW IF EXISTS view_3_tab2_739 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -3912,13 +3912,13 @@ SELECT pk FROM tab3 WHERE col0 > 9042
 88 values hashing to 562c36a9a2f908bf0c81b2226eaf465b
 
 statement ok
-DROP VIEW view_1_tab3_739
+DROP VIEW IF EXISTS view_1_tab3_739 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_739
+DROP VIEW IF EXISTS view_2_tab3_739 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_739
+DROP VIEW IF EXISTS view_3_tab3_739 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4009,13 +4009,13 @@ SELECT pk FROM tab4 WHERE col0 > 9042
 88 values hashing to 562c36a9a2f908bf0c81b2226eaf465b
 
 statement ok
-DROP VIEW view_1_tab4_739
+DROP VIEW IF EXISTS view_1_tab4_739 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_739
+DROP VIEW IF EXISTS view_2_tab4_739 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_739
+DROP VIEW IF EXISTS view_3_tab4_739 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4106,13 +4106,13 @@ SELECT pk FROM tab0 WHERE col0 > 6294
 374 values hashing to 8d47bb3f60ee9452b6309b3f3733b389
 
 statement ok
-DROP VIEW view_1_tab0_740
+DROP VIEW IF EXISTS view_1_tab0_740 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_740
+DROP VIEW IF EXISTS view_2_tab0_740 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_740
+DROP VIEW IF EXISTS view_3_tab0_740 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4203,13 +4203,13 @@ SELECT pk FROM tab1 WHERE col0 > 6294
 374 values hashing to 8d47bb3f60ee9452b6309b3f3733b389
 
 statement ok
-DROP VIEW view_1_tab1_740
+DROP VIEW IF EXISTS view_1_tab1_740 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_740
+DROP VIEW IF EXISTS view_2_tab1_740 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_740
+DROP VIEW IF EXISTS view_3_tab1_740 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4300,13 +4300,13 @@ SELECT pk FROM tab2 WHERE col0 > 6294
 374 values hashing to 8d47bb3f60ee9452b6309b3f3733b389
 
 statement ok
-DROP VIEW view_1_tab2_740
+DROP VIEW IF EXISTS view_1_tab2_740 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_740
+DROP VIEW IF EXISTS view_2_tab2_740 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_740
+DROP VIEW IF EXISTS view_3_tab2_740 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4397,13 +4397,13 @@ SELECT pk FROM tab3 WHERE col0 > 6294
 374 values hashing to 8d47bb3f60ee9452b6309b3f3733b389
 
 statement ok
-DROP VIEW view_1_tab3_740
+DROP VIEW IF EXISTS view_1_tab3_740 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_740
+DROP VIEW IF EXISTS view_2_tab3_740 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_740
+DROP VIEW IF EXISTS view_3_tab3_740 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4494,13 +4494,13 @@ SELECT pk FROM tab4 WHERE col0 > 6294
 374 values hashing to 8d47bb3f60ee9452b6309b3f3733b389
 
 statement ok
-DROP VIEW view_1_tab4_740
+DROP VIEW IF EXISTS view_1_tab4_740 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_740
+DROP VIEW IF EXISTS view_2_tab4_740 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_740
+DROP VIEW IF EXISTS view_3_tab4_740 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4591,13 +4591,13 @@ SELECT pk FROM tab0 WHERE col3 >= 1102 OR col1 >= 5689.78 AND col3 < 8578
 943 values hashing to 9ab4504d30836e810dacafb0ba100b25
 
 statement ok
-DROP VIEW view_1_tab0_741
+DROP VIEW IF EXISTS view_1_tab0_741 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_741
+DROP VIEW IF EXISTS view_2_tab0_741 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_741
+DROP VIEW IF EXISTS view_3_tab0_741 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4688,13 +4688,13 @@ SELECT pk FROM tab1 WHERE col3 >= 1102 OR col1 >= 5689.78 AND col3 < 8578
 943 values hashing to 9ab4504d30836e810dacafb0ba100b25
 
 statement ok
-DROP VIEW view_1_tab1_741
+DROP VIEW IF EXISTS view_1_tab1_741 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_741
+DROP VIEW IF EXISTS view_2_tab1_741 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_741
+DROP VIEW IF EXISTS view_3_tab1_741 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4785,13 +4785,13 @@ SELECT pk FROM tab2 WHERE col3 >= 1102 OR col1 >= 5689.78 AND col3 < 8578
 943 values hashing to 9ab4504d30836e810dacafb0ba100b25
 
 statement ok
-DROP VIEW view_1_tab2_741
+DROP VIEW IF EXISTS view_1_tab2_741 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_741
+DROP VIEW IF EXISTS view_2_tab2_741 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_741
+DROP VIEW IF EXISTS view_3_tab2_741 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4882,13 +4882,13 @@ SELECT pk FROM tab3 WHERE col3 >= 1102 OR col1 >= 5689.78 AND col3 < 8578
 943 values hashing to 9ab4504d30836e810dacafb0ba100b25
 
 statement ok
-DROP VIEW view_1_tab3_741
+DROP VIEW IF EXISTS view_1_tab3_741 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_741
+DROP VIEW IF EXISTS view_2_tab3_741 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_741
+DROP VIEW IF EXISTS view_3_tab3_741 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -4979,13 +4979,13 @@ SELECT pk FROM tab4 WHERE col3 >= 1102 OR col1 >= 5689.78 AND col3 < 8578
 943 values hashing to 9ab4504d30836e810dacafb0ba100b25
 
 statement ok
-DROP VIEW view_1_tab4_741
+DROP VIEW IF EXISTS view_1_tab4_741 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_741
+DROP VIEW IF EXISTS view_2_tab4_741 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_741
+DROP VIEW IF EXISTS view_3_tab4_741 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5076,13 +5076,13 @@ SELECT pk FROM tab0 WHERE (col0 IN (SELECT col3 FROM tab0 WHERE (col1 < 3863.93)
 436 values hashing to ca4954702fd65cdbc370dc3708141b1f
 
 statement ok
-DROP VIEW view_1_tab0_742
+DROP VIEW IF EXISTS view_1_tab0_742 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_742
+DROP VIEW IF EXISTS view_2_tab0_742 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_742
+DROP VIEW IF EXISTS view_3_tab0_742 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5173,13 +5173,13 @@ SELECT pk FROM tab1 WHERE (col0 IN (SELECT col3 FROM tab1 WHERE (col1 < 3863.93)
 436 values hashing to ca4954702fd65cdbc370dc3708141b1f
 
 statement ok
-DROP VIEW view_1_tab1_742
+DROP VIEW IF EXISTS view_1_tab1_742 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_742
+DROP VIEW IF EXISTS view_2_tab1_742 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_742
+DROP VIEW IF EXISTS view_3_tab1_742 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5270,13 +5270,13 @@ SELECT pk FROM tab2 WHERE (col0 IN (SELECT col3 FROM tab2 WHERE (col1 < 3863.93)
 436 values hashing to ca4954702fd65cdbc370dc3708141b1f
 
 statement ok
-DROP VIEW view_1_tab2_742
+DROP VIEW IF EXISTS view_1_tab2_742 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_742
+DROP VIEW IF EXISTS view_2_tab2_742 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_742
+DROP VIEW IF EXISTS view_3_tab2_742 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5367,13 +5367,13 @@ SELECT pk FROM tab3 WHERE (col0 IN (SELECT col3 FROM tab3 WHERE (col1 < 3863.93)
 436 values hashing to ca4954702fd65cdbc370dc3708141b1f
 
 statement ok
-DROP VIEW view_1_tab3_742
+DROP VIEW IF EXISTS view_1_tab3_742 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_742
+DROP VIEW IF EXISTS view_2_tab3_742 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_742
+DROP VIEW IF EXISTS view_3_tab3_742 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5464,13 +5464,13 @@ SELECT pk FROM tab4 WHERE (col0 IN (SELECT col3 FROM tab4 WHERE (col1 < 3863.93)
 436 values hashing to ca4954702fd65cdbc370dc3708141b1f
 
 statement ok
-DROP VIEW view_1_tab4_742
+DROP VIEW IF EXISTS view_1_tab4_742 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_742
+DROP VIEW IF EXISTS view_2_tab4_742 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_742
+DROP VIEW IF EXISTS view_3_tab4_742 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5561,13 +5561,13 @@ SELECT pk FROM tab0 WHERE col0 >= 8568
 132 values hashing to 5d36621aea17b1bfed75cf54a60906f0
 
 statement ok
-DROP VIEW view_1_tab0_743
+DROP VIEW IF EXISTS view_1_tab0_743 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_743
+DROP VIEW IF EXISTS view_2_tab0_743 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_743
+DROP VIEW IF EXISTS view_3_tab0_743 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5658,13 +5658,13 @@ SELECT pk FROM tab1 WHERE col0 >= 8568
 132 values hashing to 5d36621aea17b1bfed75cf54a60906f0
 
 statement ok
-DROP VIEW view_1_tab1_743
+DROP VIEW IF EXISTS view_1_tab1_743 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_743
+DROP VIEW IF EXISTS view_2_tab1_743 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_743
+DROP VIEW IF EXISTS view_3_tab1_743 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5755,13 +5755,13 @@ SELECT pk FROM tab2 WHERE col0 >= 8568
 132 values hashing to 5d36621aea17b1bfed75cf54a60906f0
 
 statement ok
-DROP VIEW view_1_tab2_743
+DROP VIEW IF EXISTS view_1_tab2_743 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_743
+DROP VIEW IF EXISTS view_2_tab2_743 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_743
+DROP VIEW IF EXISTS view_3_tab2_743 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5852,13 +5852,13 @@ SELECT pk FROM tab3 WHERE col0 >= 8568
 132 values hashing to 5d36621aea17b1bfed75cf54a60906f0
 
 statement ok
-DROP VIEW view_1_tab3_743
+DROP VIEW IF EXISTS view_1_tab3_743 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_743
+DROP VIEW IF EXISTS view_2_tab3_743 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_743
+DROP VIEW IF EXISTS view_3_tab3_743 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -5949,13 +5949,13 @@ SELECT pk FROM tab4 WHERE col0 >= 8568
 132 values hashing to 5d36621aea17b1bfed75cf54a60906f0
 
 statement ok
-DROP VIEW view_1_tab4_743
+DROP VIEW IF EXISTS view_1_tab4_743 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_743
+DROP VIEW IF EXISTS view_2_tab4_743 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_743
+DROP VIEW IF EXISTS view_3_tab4_743 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6046,13 +6046,13 @@ SELECT pk FROM tab0 WHERE col1 >= 9548.8
 45 values hashing to 67923f5c106410b4519ee4294d8ae8cc
 
 statement ok
-DROP VIEW view_1_tab0_744
+DROP VIEW IF EXISTS view_1_tab0_744 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_744
+DROP VIEW IF EXISTS view_2_tab0_744 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_744
+DROP VIEW IF EXISTS view_3_tab0_744 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6143,13 +6143,13 @@ SELECT pk FROM tab1 WHERE col1 >= 9548.8
 45 values hashing to 67923f5c106410b4519ee4294d8ae8cc
 
 statement ok
-DROP VIEW view_1_tab1_744
+DROP VIEW IF EXISTS view_1_tab1_744 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_744
+DROP VIEW IF EXISTS view_2_tab1_744 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_744
+DROP VIEW IF EXISTS view_3_tab1_744 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6240,13 +6240,13 @@ SELECT pk FROM tab2 WHERE col1 >= 9548.8
 45 values hashing to 67923f5c106410b4519ee4294d8ae8cc
 
 statement ok
-DROP VIEW view_1_tab2_744
+DROP VIEW IF EXISTS view_1_tab2_744 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_744
+DROP VIEW IF EXISTS view_2_tab2_744 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_744
+DROP VIEW IF EXISTS view_3_tab2_744 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6337,13 +6337,13 @@ SELECT pk FROM tab3 WHERE col1 >= 9548.8
 45 values hashing to 67923f5c106410b4519ee4294d8ae8cc
 
 statement ok
-DROP VIEW view_1_tab3_744
+DROP VIEW IF EXISTS view_1_tab3_744 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_744
+DROP VIEW IF EXISTS view_2_tab3_744 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_744
+DROP VIEW IF EXISTS view_3_tab3_744 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6434,13 +6434,13 @@ SELECT pk FROM tab4 WHERE col1 >= 9548.8
 45 values hashing to 67923f5c106410b4519ee4294d8ae8cc
 
 statement ok
-DROP VIEW view_1_tab4_744
+DROP VIEW IF EXISTS view_1_tab4_744 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_744
+DROP VIEW IF EXISTS view_2_tab4_744 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_744
+DROP VIEW IF EXISTS view_3_tab4_744 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6533,13 +6533,13 @@ SELECT pk FROM tab0 WHERE (col0 IS NULL) OR col0 = 4667 OR ((col3 IN (3052,8315,
 528
 
 statement ok
-DROP VIEW view_1_tab0_745
+DROP VIEW IF EXISTS view_1_tab0_745 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_745
+DROP VIEW IF EXISTS view_2_tab0_745 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_745
+DROP VIEW IF EXISTS view_3_tab0_745 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6632,13 +6632,13 @@ SELECT pk FROM tab1 WHERE (col0 IS NULL) OR col0 = 4667 OR ((col3 IN (3052,8315,
 528
 
 statement ok
-DROP VIEW view_1_tab1_745
+DROP VIEW IF EXISTS view_1_tab1_745 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_745
+DROP VIEW IF EXISTS view_2_tab1_745 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_745
+DROP VIEW IF EXISTS view_3_tab1_745 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6731,13 +6731,13 @@ SELECT pk FROM tab2 WHERE (col0 IS NULL) OR col0 = 4667 OR ((col3 IN (3052,8315,
 528
 
 statement ok
-DROP VIEW view_1_tab2_745
+DROP VIEW IF EXISTS view_1_tab2_745 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_745
+DROP VIEW IF EXISTS view_2_tab2_745 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_745
+DROP VIEW IF EXISTS view_3_tab2_745 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6830,13 +6830,13 @@ SELECT pk FROM tab3 WHERE (col0 IS NULL) OR col0 = 4667 OR ((col3 IN (3052,8315,
 528
 
 statement ok
-DROP VIEW view_1_tab3_745
+DROP VIEW IF EXISTS view_1_tab3_745 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_745
+DROP VIEW IF EXISTS view_2_tab3_745 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_745
+DROP VIEW IF EXISTS view_3_tab3_745 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -6929,13 +6929,13 @@ SELECT pk FROM tab4 WHERE (col0 IS NULL) OR col0 = 4667 OR ((col3 IN (3052,8315,
 528
 
 statement ok
-DROP VIEW view_1_tab4_745
+DROP VIEW IF EXISTS view_1_tab4_745 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_745
+DROP VIEW IF EXISTS view_2_tab4_745 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_745
+DROP VIEW IF EXISTS view_3_tab4_745 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7026,13 +7026,13 @@ SELECT pk FROM tab0 WHERE col0 <= 2637
 246 values hashing to d63e8cc96dee9d3e733927415506020a
 
 statement ok
-DROP VIEW view_1_tab0_746
+DROP VIEW IF EXISTS view_1_tab0_746 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_746
+DROP VIEW IF EXISTS view_2_tab0_746 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_746
+DROP VIEW IF EXISTS view_3_tab0_746 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7123,13 +7123,13 @@ SELECT pk FROM tab1 WHERE col0 <= 2637
 246 values hashing to d63e8cc96dee9d3e733927415506020a
 
 statement ok
-DROP VIEW view_1_tab1_746
+DROP VIEW IF EXISTS view_1_tab1_746 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_746
+DROP VIEW IF EXISTS view_2_tab1_746 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_746
+DROP VIEW IF EXISTS view_3_tab1_746 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7220,13 +7220,13 @@ SELECT pk FROM tab2 WHERE col0 <= 2637
 246 values hashing to d63e8cc96dee9d3e733927415506020a
 
 statement ok
-DROP VIEW view_1_tab2_746
+DROP VIEW IF EXISTS view_1_tab2_746 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_746
+DROP VIEW IF EXISTS view_2_tab2_746 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_746
+DROP VIEW IF EXISTS view_3_tab2_746 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7317,13 +7317,13 @@ SELECT pk FROM tab3 WHERE col0 <= 2637
 246 values hashing to d63e8cc96dee9d3e733927415506020a
 
 statement ok
-DROP VIEW view_1_tab3_746
+DROP VIEW IF EXISTS view_1_tab3_746 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_746
+DROP VIEW IF EXISTS view_2_tab3_746 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_746
+DROP VIEW IF EXISTS view_3_tab3_746 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7414,13 +7414,13 @@ SELECT pk FROM tab4 WHERE col0 <= 2637
 246 values hashing to d63e8cc96dee9d3e733927415506020a
 
 statement ok
-DROP VIEW view_1_tab4_746
+DROP VIEW IF EXISTS view_1_tab4_746 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_746
+DROP VIEW IF EXISTS view_2_tab4_746 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_746
+DROP VIEW IF EXISTS view_3_tab4_746 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7511,13 +7511,13 @@ SELECT pk FROM tab0 WHERE col4 <= 8494.90
 871 values hashing to 5bab95a34e286f00401c69bef24e6e25
 
 statement ok
-DROP VIEW view_1_tab0_747
+DROP VIEW IF EXISTS view_1_tab0_747 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_747
+DROP VIEW IF EXISTS view_2_tab0_747 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_747
+DROP VIEW IF EXISTS view_3_tab0_747 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7608,13 +7608,13 @@ SELECT pk FROM tab1 WHERE col4 <= 8494.90
 871 values hashing to 5bab95a34e286f00401c69bef24e6e25
 
 statement ok
-DROP VIEW view_1_tab1_747
+DROP VIEW IF EXISTS view_1_tab1_747 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_747
+DROP VIEW IF EXISTS view_2_tab1_747 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_747
+DROP VIEW IF EXISTS view_3_tab1_747 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7705,13 +7705,13 @@ SELECT pk FROM tab2 WHERE col4 <= 8494.90
 871 values hashing to 5bab95a34e286f00401c69bef24e6e25
 
 statement ok
-DROP VIEW view_1_tab2_747
+DROP VIEW IF EXISTS view_1_tab2_747 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_747
+DROP VIEW IF EXISTS view_2_tab2_747 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_747
+DROP VIEW IF EXISTS view_3_tab2_747 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7802,13 +7802,13 @@ SELECT pk FROM tab3 WHERE col4 <= 8494.90
 871 values hashing to 5bab95a34e286f00401c69bef24e6e25
 
 statement ok
-DROP VIEW view_1_tab3_747
+DROP VIEW IF EXISTS view_1_tab3_747 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_747
+DROP VIEW IF EXISTS view_2_tab3_747 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_747
+DROP VIEW IF EXISTS view_3_tab3_747 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7899,13 +7899,13 @@ SELECT pk FROM tab4 WHERE col4 <= 8494.90
 871 values hashing to 5bab95a34e286f00401c69bef24e6e25
 
 statement ok
-DROP VIEW view_1_tab4_747
+DROP VIEW IF EXISTS view_1_tab4_747 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_747
+DROP VIEW IF EXISTS view_2_tab4_747 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_747
+DROP VIEW IF EXISTS view_3_tab4_747 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -7994,13 +7994,13 @@ SELECT pk FROM tab0 WHERE col3 >= 4479 OR col3 <= 9248 OR (col0 IS NULL)
 1000 values hashing to 30a3c33f4078cae93230de944dca2ac9
 
 statement ok
-DROP VIEW view_1_tab0_748
+DROP VIEW IF EXISTS view_1_tab0_748 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_748
+DROP VIEW IF EXISTS view_2_tab0_748 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_748
+DROP VIEW IF EXISTS view_3_tab0_748 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8089,13 +8089,13 @@ SELECT pk FROM tab1 WHERE col3 >= 4479 OR col3 <= 9248 OR (col0 IS NULL)
 1000 values hashing to 30a3c33f4078cae93230de944dca2ac9
 
 statement ok
-DROP VIEW view_1_tab1_748
+DROP VIEW IF EXISTS view_1_tab1_748 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_748
+DROP VIEW IF EXISTS view_2_tab1_748 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_748
+DROP VIEW IF EXISTS view_3_tab1_748 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8184,13 +8184,13 @@ SELECT pk FROM tab2 WHERE col3 >= 4479 OR col3 <= 9248 OR (col0 IS NULL)
 1000 values hashing to 30a3c33f4078cae93230de944dca2ac9
 
 statement ok
-DROP VIEW view_1_tab2_748
+DROP VIEW IF EXISTS view_1_tab2_748 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_748
+DROP VIEW IF EXISTS view_2_tab2_748 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_748
+DROP VIEW IF EXISTS view_3_tab2_748 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8279,13 +8279,13 @@ SELECT pk FROM tab3 WHERE col3 >= 4479 OR col3 <= 9248 OR (col0 IS NULL)
 1000 values hashing to 30a3c33f4078cae93230de944dca2ac9
 
 statement ok
-DROP VIEW view_1_tab3_748
+DROP VIEW IF EXISTS view_1_tab3_748 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_748
+DROP VIEW IF EXISTS view_2_tab3_748 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_748
+DROP VIEW IF EXISTS view_3_tab3_748 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8374,13 +8374,13 @@ SELECT pk FROM tab4 WHERE col3 >= 4479 OR col3 <= 9248 OR (col0 IS NULL)
 1000 values hashing to 30a3c33f4078cae93230de944dca2ac9
 
 statement ok
-DROP VIEW view_1_tab4_748
+DROP VIEW IF EXISTS view_1_tab4_748 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_748
+DROP VIEW IF EXISTS view_2_tab4_748 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_748
+DROP VIEW IF EXISTS view_3_tab4_748 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8471,13 +8471,13 @@ SELECT pk FROM tab0 WHERE (col3 > 2858)
 723 values hashing to aafad247ff4aba683e3cf2a6b01b62bc
 
 statement ok
-DROP VIEW view_1_tab0_749
+DROP VIEW IF EXISTS view_1_tab0_749 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_749
+DROP VIEW IF EXISTS view_2_tab0_749 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_749
+DROP VIEW IF EXISTS view_3_tab0_749 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8568,13 +8568,13 @@ SELECT pk FROM tab1 WHERE (col3 > 2858)
 723 values hashing to aafad247ff4aba683e3cf2a6b01b62bc
 
 statement ok
-DROP VIEW view_1_tab1_749
+DROP VIEW IF EXISTS view_1_tab1_749 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_749
+DROP VIEW IF EXISTS view_2_tab1_749 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_749
+DROP VIEW IF EXISTS view_3_tab1_749 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8665,13 +8665,13 @@ SELECT pk FROM tab2 WHERE (col3 > 2858)
 723 values hashing to aafad247ff4aba683e3cf2a6b01b62bc
 
 statement ok
-DROP VIEW view_1_tab2_749
+DROP VIEW IF EXISTS view_1_tab2_749 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_749
+DROP VIEW IF EXISTS view_2_tab2_749 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_749
+DROP VIEW IF EXISTS view_3_tab2_749 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8762,13 +8762,13 @@ SELECT pk FROM tab3 WHERE (col3 > 2858)
 723 values hashing to aafad247ff4aba683e3cf2a6b01b62bc
 
 statement ok
-DROP VIEW view_1_tab3_749
+DROP VIEW IF EXISTS view_1_tab3_749 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_749
+DROP VIEW IF EXISTS view_2_tab3_749 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_749
+DROP VIEW IF EXISTS view_3_tab3_749 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8859,13 +8859,13 @@ SELECT pk FROM tab4 WHERE (col3 > 2858)
 723 values hashing to aafad247ff4aba683e3cf2a6b01b62bc
 
 statement ok
-DROP VIEW view_1_tab4_749
+DROP VIEW IF EXISTS view_1_tab4_749 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_749
+DROP VIEW IF EXISTS view_2_tab4_749 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_749
+DROP VIEW IF EXISTS view_3_tab4_749 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -8956,13 +8956,13 @@ SELECT pk FROM tab0 WHERE col3 < 5975
 607 values hashing to acb1fe188fac9a20c902bd646089a342
 
 statement ok
-DROP VIEW view_1_tab0_750
+DROP VIEW IF EXISTS view_1_tab0_750 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_750
+DROP VIEW IF EXISTS view_2_tab0_750 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_750
+DROP VIEW IF EXISTS view_3_tab0_750 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9053,13 +9053,13 @@ SELECT pk FROM tab1 WHERE col3 < 5975
 607 values hashing to acb1fe188fac9a20c902bd646089a342
 
 statement ok
-DROP VIEW view_1_tab1_750
+DROP VIEW IF EXISTS view_1_tab1_750 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_750
+DROP VIEW IF EXISTS view_2_tab1_750 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_750
+DROP VIEW IF EXISTS view_3_tab1_750 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9150,13 +9150,13 @@ SELECT pk FROM tab2 WHERE col3 < 5975
 607 values hashing to acb1fe188fac9a20c902bd646089a342
 
 statement ok
-DROP VIEW view_1_tab2_750
+DROP VIEW IF EXISTS view_1_tab2_750 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_750
+DROP VIEW IF EXISTS view_2_tab2_750 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_750
+DROP VIEW IF EXISTS view_3_tab2_750 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9247,13 +9247,13 @@ SELECT pk FROM tab3 WHERE col3 < 5975
 607 values hashing to acb1fe188fac9a20c902bd646089a342
 
 statement ok
-DROP VIEW view_1_tab3_750
+DROP VIEW IF EXISTS view_1_tab3_750 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_750
+DROP VIEW IF EXISTS view_2_tab3_750 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_750
+DROP VIEW IF EXISTS view_3_tab3_750 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9344,13 +9344,13 @@ SELECT pk FROM tab4 WHERE col3 < 5975
 607 values hashing to acb1fe188fac9a20c902bd646089a342
 
 statement ok
-DROP VIEW view_1_tab4_750
+DROP VIEW IF EXISTS view_1_tab4_750 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_750
+DROP VIEW IF EXISTS view_2_tab4_750 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_750
+DROP VIEW IF EXISTS view_3_tab4_750 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9441,13 +9441,13 @@ SELECT pk FROM tab0 WHERE col0 < 5906 OR (col3 = 8656 AND col1 < 6783.22) OR col
 645 values hashing to ca566e0de2d86bc37af7508c97162d17
 
 statement ok
-DROP VIEW view_1_tab0_751
+DROP VIEW IF EXISTS view_1_tab0_751 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_751
+DROP VIEW IF EXISTS view_2_tab0_751 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_751
+DROP VIEW IF EXISTS view_3_tab0_751 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9538,13 +9538,13 @@ SELECT pk FROM tab1 WHERE col0 < 5906 OR (col3 = 8656 AND col1 < 6783.22) OR col
 645 values hashing to ca566e0de2d86bc37af7508c97162d17
 
 statement ok
-DROP VIEW view_1_tab1_751
+DROP VIEW IF EXISTS view_1_tab1_751 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_751
+DROP VIEW IF EXISTS view_2_tab1_751 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_751
+DROP VIEW IF EXISTS view_3_tab1_751 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9635,13 +9635,13 @@ SELECT pk FROM tab2 WHERE col0 < 5906 OR (col3 = 8656 AND col1 < 6783.22) OR col
 645 values hashing to ca566e0de2d86bc37af7508c97162d17
 
 statement ok
-DROP VIEW view_1_tab2_751
+DROP VIEW IF EXISTS view_1_tab2_751 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_751
+DROP VIEW IF EXISTS view_2_tab2_751 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_751
+DROP VIEW IF EXISTS view_3_tab2_751 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9732,13 +9732,13 @@ SELECT pk FROM tab3 WHERE col0 < 5906 OR (col3 = 8656 AND col1 < 6783.22) OR col
 645 values hashing to ca566e0de2d86bc37af7508c97162d17
 
 statement ok
-DROP VIEW view_1_tab3_751
+DROP VIEW IF EXISTS view_1_tab3_751 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_751
+DROP VIEW IF EXISTS view_2_tab3_751 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_751
+DROP VIEW IF EXISTS view_3_tab3_751 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9829,13 +9829,13 @@ SELECT pk FROM tab4 WHERE col0 < 5906 OR (col3 = 8656 AND col1 < 6783.22) OR col
 645 values hashing to ca566e0de2d86bc37af7508c97162d17
 
 statement ok
-DROP VIEW view_1_tab4_751
+DROP VIEW IF EXISTS view_1_tab4_751 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_751
+DROP VIEW IF EXISTS view_2_tab4_751 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_751
+DROP VIEW IF EXISTS view_3_tab4_751 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -9921,13 +9921,13 @@ SELECT pk FROM tab0 WHERE col3 = 7888
 ----
 
 statement ok
-DROP VIEW view_1_tab0_752
+DROP VIEW IF EXISTS view_1_tab0_752 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_752
+DROP VIEW IF EXISTS view_2_tab0_752 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_752
+DROP VIEW IF EXISTS view_3_tab0_752 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10013,13 +10013,13 @@ SELECT pk FROM tab1 WHERE col3 = 7888
 ----
 
 statement ok
-DROP VIEW view_1_tab1_752
+DROP VIEW IF EXISTS view_1_tab1_752 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_752
+DROP VIEW IF EXISTS view_2_tab1_752 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_752
+DROP VIEW IF EXISTS view_3_tab1_752 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10105,13 +10105,13 @@ SELECT pk FROM tab2 WHERE col3 = 7888
 ----
 
 statement ok
-DROP VIEW view_1_tab2_752
+DROP VIEW IF EXISTS view_1_tab2_752 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_752
+DROP VIEW IF EXISTS view_2_tab2_752 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_752
+DROP VIEW IF EXISTS view_3_tab2_752 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10197,13 +10197,13 @@ SELECT pk FROM tab3 WHERE col3 = 7888
 ----
 
 statement ok
-DROP VIEW view_1_tab3_752
+DROP VIEW IF EXISTS view_1_tab3_752 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_752
+DROP VIEW IF EXISTS view_2_tab3_752 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_752
+DROP VIEW IF EXISTS view_3_tab3_752 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10289,13 +10289,13 @@ SELECT pk FROM tab4 WHERE col3 = 7888
 ----
 
 statement ok
-DROP VIEW view_1_tab4_752
+DROP VIEW IF EXISTS view_1_tab4_752 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_752
+DROP VIEW IF EXISTS view_2_tab4_752 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_752
+DROP VIEW IF EXISTS view_3_tab4_752 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10386,13 +10386,13 @@ SELECT pk FROM tab0 WHERE (((((col0 < 94)))))
 10 values hashing to 414be71578cbc70a83b0080cae014a54
 
 statement ok
-DROP VIEW view_1_tab0_753
+DROP VIEW IF EXISTS view_1_tab0_753 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_753
+DROP VIEW IF EXISTS view_2_tab0_753 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_753
+DROP VIEW IF EXISTS view_3_tab0_753 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10483,13 +10483,13 @@ SELECT pk FROM tab1 WHERE (((((col0 < 94)))))
 10 values hashing to 414be71578cbc70a83b0080cae014a54
 
 statement ok
-DROP VIEW view_1_tab1_753
+DROP VIEW IF EXISTS view_1_tab1_753 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_753
+DROP VIEW IF EXISTS view_2_tab1_753 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_753
+DROP VIEW IF EXISTS view_3_tab1_753 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10580,13 +10580,13 @@ SELECT pk FROM tab2 WHERE (((((col0 < 94)))))
 10 values hashing to 414be71578cbc70a83b0080cae014a54
 
 statement ok
-DROP VIEW view_1_tab2_753
+DROP VIEW IF EXISTS view_1_tab2_753 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_753
+DROP VIEW IF EXISTS view_2_tab2_753 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_753
+DROP VIEW IF EXISTS view_3_tab2_753 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10677,13 +10677,13 @@ SELECT pk FROM tab3 WHERE (((((col0 < 94)))))
 10 values hashing to 414be71578cbc70a83b0080cae014a54
 
 statement ok
-DROP VIEW view_1_tab3_753
+DROP VIEW IF EXISTS view_1_tab3_753 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_753
+DROP VIEW IF EXISTS view_2_tab3_753 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_753
+DROP VIEW IF EXISTS view_3_tab3_753 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10774,13 +10774,13 @@ SELECT pk FROM tab4 WHERE (((((col0 < 94)))))
 10 values hashing to 414be71578cbc70a83b0080cae014a54
 
 statement ok
-DROP VIEW view_1_tab4_753
+DROP VIEW IF EXISTS view_1_tab4_753 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_753
+DROP VIEW IF EXISTS view_2_tab4_753 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_753
+DROP VIEW IF EXISTS view_3_tab4_753 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10871,13 +10871,13 @@ SELECT pk FROM tab0 WHERE (col3 = 3650) AND col3 >= 6449 AND (col0 >= 1460) AND 
 507 values hashing to a07ccfeb2a4b707f8da33f8d67f0bfa5
 
 statement ok
-DROP VIEW view_1_tab0_754
+DROP VIEW IF EXISTS view_1_tab0_754 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_754
+DROP VIEW IF EXISTS view_2_tab0_754 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_754
+DROP VIEW IF EXISTS view_3_tab0_754 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -10968,13 +10968,13 @@ SELECT pk FROM tab1 WHERE (col3 = 3650) AND col3 >= 6449 AND (col0 >= 1460) AND 
 507 values hashing to a07ccfeb2a4b707f8da33f8d67f0bfa5
 
 statement ok
-DROP VIEW view_1_tab1_754
+DROP VIEW IF EXISTS view_1_tab1_754 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_754
+DROP VIEW IF EXISTS view_2_tab1_754 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_754
+DROP VIEW IF EXISTS view_3_tab1_754 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11065,13 +11065,13 @@ SELECT pk FROM tab2 WHERE (col3 = 3650) AND col3 >= 6449 AND (col0 >= 1460) AND 
 507 values hashing to a07ccfeb2a4b707f8da33f8d67f0bfa5
 
 statement ok
-DROP VIEW view_1_tab2_754
+DROP VIEW IF EXISTS view_1_tab2_754 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_754
+DROP VIEW IF EXISTS view_2_tab2_754 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_754
+DROP VIEW IF EXISTS view_3_tab2_754 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11162,13 +11162,13 @@ SELECT pk FROM tab3 WHERE (col3 = 3650) AND col3 >= 6449 AND (col0 >= 1460) AND 
 507 values hashing to a07ccfeb2a4b707f8da33f8d67f0bfa5
 
 statement ok
-DROP VIEW view_1_tab3_754
+DROP VIEW IF EXISTS view_1_tab3_754 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_754
+DROP VIEW IF EXISTS view_2_tab3_754 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_754
+DROP VIEW IF EXISTS view_3_tab3_754 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11259,13 +11259,13 @@ SELECT pk FROM tab4 WHERE (col3 = 3650) AND col3 >= 6449 AND (col0 >= 1460) AND 
 507 values hashing to a07ccfeb2a4b707f8da33f8d67f0bfa5
 
 statement ok
-DROP VIEW view_1_tab4_754
+DROP VIEW IF EXISTS view_1_tab4_754 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_754
+DROP VIEW IF EXISTS view_2_tab4_754 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_754
+DROP VIEW IF EXISTS view_3_tab4_754 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11356,13 +11356,13 @@ SELECT pk FROM tab0 WHERE (col3 > 8994 OR col0 < 6080 AND col4 < 7050.75 AND col
 102 values hashing to d1898529783624a9cb5fc72b00ae1015
 
 statement ok
-DROP VIEW view_1_tab0_755
+DROP VIEW IF EXISTS view_1_tab0_755 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_755
+DROP VIEW IF EXISTS view_2_tab0_755 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_755
+DROP VIEW IF EXISTS view_3_tab0_755 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11453,13 +11453,13 @@ SELECT pk FROM tab1 WHERE (col3 > 8994 OR col0 < 6080 AND col4 < 7050.75 AND col
 102 values hashing to d1898529783624a9cb5fc72b00ae1015
 
 statement ok
-DROP VIEW view_1_tab1_755
+DROP VIEW IF EXISTS view_1_tab1_755 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_755
+DROP VIEW IF EXISTS view_2_tab1_755 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_755
+DROP VIEW IF EXISTS view_3_tab1_755 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11550,13 +11550,13 @@ SELECT pk FROM tab2 WHERE (col3 > 8994 OR col0 < 6080 AND col4 < 7050.75 AND col
 102 values hashing to d1898529783624a9cb5fc72b00ae1015
 
 statement ok
-DROP VIEW view_1_tab2_755
+DROP VIEW IF EXISTS view_1_tab2_755 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_755
+DROP VIEW IF EXISTS view_2_tab2_755 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_755
+DROP VIEW IF EXISTS view_3_tab2_755 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11647,13 +11647,13 @@ SELECT pk FROM tab3 WHERE (col3 > 8994 OR col0 < 6080 AND col4 < 7050.75 AND col
 102 values hashing to d1898529783624a9cb5fc72b00ae1015
 
 statement ok
-DROP VIEW view_1_tab3_755
+DROP VIEW IF EXISTS view_1_tab3_755 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_755
+DROP VIEW IF EXISTS view_2_tab3_755 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_755
+DROP VIEW IF EXISTS view_3_tab3_755 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11744,13 +11744,13 @@ SELECT pk FROM tab4 WHERE (col3 > 8994 OR col0 < 6080 AND col4 < 7050.75 AND col
 102 values hashing to d1898529783624a9cb5fc72b00ae1015
 
 statement ok
-DROP VIEW view_1_tab4_755
+DROP VIEW IF EXISTS view_1_tab4_755 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_755
+DROP VIEW IF EXISTS view_2_tab4_755 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_755
+DROP VIEW IF EXISTS view_3_tab4_755 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11841,13 +11841,13 @@ SELECT pk FROM tab0 WHERE col3 < 8859
 882 values hashing to 985b03f3ef4620d90722fdf2b5103841
 
 statement ok
-DROP VIEW view_1_tab0_756
+DROP VIEW IF EXISTS view_1_tab0_756 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_756
+DROP VIEW IF EXISTS view_2_tab0_756 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_756
+DROP VIEW IF EXISTS view_3_tab0_756 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -11938,13 +11938,13 @@ SELECT pk FROM tab1 WHERE col3 < 8859
 882 values hashing to 985b03f3ef4620d90722fdf2b5103841
 
 statement ok
-DROP VIEW view_1_tab1_756
+DROP VIEW IF EXISTS view_1_tab1_756 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_756
+DROP VIEW IF EXISTS view_2_tab1_756 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_756
+DROP VIEW IF EXISTS view_3_tab1_756 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12035,13 +12035,13 @@ SELECT pk FROM tab2 WHERE col3 < 8859
 882 values hashing to 985b03f3ef4620d90722fdf2b5103841
 
 statement ok
-DROP VIEW view_1_tab2_756
+DROP VIEW IF EXISTS view_1_tab2_756 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_756
+DROP VIEW IF EXISTS view_2_tab2_756 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_756
+DROP VIEW IF EXISTS view_3_tab2_756 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12132,13 +12132,13 @@ SELECT pk FROM tab3 WHERE col3 < 8859
 882 values hashing to 985b03f3ef4620d90722fdf2b5103841
 
 statement ok
-DROP VIEW view_1_tab3_756
+DROP VIEW IF EXISTS view_1_tab3_756 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_756
+DROP VIEW IF EXISTS view_2_tab3_756 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_756
+DROP VIEW IF EXISTS view_3_tab3_756 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12229,13 +12229,13 @@ SELECT pk FROM tab4 WHERE col3 < 8859
 882 values hashing to 985b03f3ef4620d90722fdf2b5103841
 
 statement ok
-DROP VIEW view_1_tab4_756
+DROP VIEW IF EXISTS view_1_tab4_756 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_756
+DROP VIEW IF EXISTS view_2_tab4_756 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_756
+DROP VIEW IF EXISTS view_3_tab4_756 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12326,13 +12326,13 @@ SELECT pk FROM tab0 WHERE col3 > 8150
 187 values hashing to af861c0f6d1262224b77aea2a3eac3eb
 
 statement ok
-DROP VIEW view_1_tab0_757
+DROP VIEW IF EXISTS view_1_tab0_757 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_757
+DROP VIEW IF EXISTS view_2_tab0_757 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_757
+DROP VIEW IF EXISTS view_3_tab0_757 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12423,13 +12423,13 @@ SELECT pk FROM tab1 WHERE col3 > 8150
 187 values hashing to af861c0f6d1262224b77aea2a3eac3eb
 
 statement ok
-DROP VIEW view_1_tab1_757
+DROP VIEW IF EXISTS view_1_tab1_757 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_757
+DROP VIEW IF EXISTS view_2_tab1_757 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_757
+DROP VIEW IF EXISTS view_3_tab1_757 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12520,13 +12520,13 @@ SELECT pk FROM tab2 WHERE col3 > 8150
 187 values hashing to af861c0f6d1262224b77aea2a3eac3eb
 
 statement ok
-DROP VIEW view_1_tab2_757
+DROP VIEW IF EXISTS view_1_tab2_757 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_757
+DROP VIEW IF EXISTS view_2_tab2_757 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_757
+DROP VIEW IF EXISTS view_3_tab2_757 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12617,13 +12617,13 @@ SELECT pk FROM tab3 WHERE col3 > 8150
 187 values hashing to af861c0f6d1262224b77aea2a3eac3eb
 
 statement ok
-DROP VIEW view_1_tab3_757
+DROP VIEW IF EXISTS view_1_tab3_757 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_757
+DROP VIEW IF EXISTS view_2_tab3_757 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_757
+DROP VIEW IF EXISTS view_3_tab3_757 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12714,13 +12714,13 @@ SELECT pk FROM tab4 WHERE col3 > 8150
 187 values hashing to af861c0f6d1262224b77aea2a3eac3eb
 
 statement ok
-DROP VIEW view_1_tab4_757
+DROP VIEW IF EXISTS view_1_tab4_757 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_757
+DROP VIEW IF EXISTS view_2_tab4_757 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_757
+DROP VIEW IF EXISTS view_3_tab4_757 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12811,13 +12811,13 @@ SELECT pk FROM tab0 WHERE col0 >= 391
 957 values hashing to 07cf52b6bd3ee600e37c38ade160368f
 
 statement ok
-DROP VIEW view_1_tab0_758
+DROP VIEW IF EXISTS view_1_tab0_758 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_758
+DROP VIEW IF EXISTS view_2_tab0_758 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_758
+DROP VIEW IF EXISTS view_3_tab0_758 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -12908,13 +12908,13 @@ SELECT pk FROM tab1 WHERE col0 >= 391
 957 values hashing to 07cf52b6bd3ee600e37c38ade160368f
 
 statement ok
-DROP VIEW view_1_tab1_758
+DROP VIEW IF EXISTS view_1_tab1_758 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_758
+DROP VIEW IF EXISTS view_2_tab1_758 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_758
+DROP VIEW IF EXISTS view_3_tab1_758 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13005,13 +13005,13 @@ SELECT pk FROM tab2 WHERE col0 >= 391
 957 values hashing to 07cf52b6bd3ee600e37c38ade160368f
 
 statement ok
-DROP VIEW view_1_tab2_758
+DROP VIEW IF EXISTS view_1_tab2_758 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_758
+DROP VIEW IF EXISTS view_2_tab2_758 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_758
+DROP VIEW IF EXISTS view_3_tab2_758 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13102,13 +13102,13 @@ SELECT pk FROM tab3 WHERE col0 >= 391
 957 values hashing to 07cf52b6bd3ee600e37c38ade160368f
 
 statement ok
-DROP VIEW view_1_tab3_758
+DROP VIEW IF EXISTS view_1_tab3_758 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_758
+DROP VIEW IF EXISTS view_2_tab3_758 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_758
+DROP VIEW IF EXISTS view_3_tab3_758 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13199,13 +13199,13 @@ SELECT pk FROM tab4 WHERE col0 >= 391
 957 values hashing to 07cf52b6bd3ee600e37c38ade160368f
 
 statement ok
-DROP VIEW view_1_tab4_758
+DROP VIEW IF EXISTS view_1_tab4_758 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_758
+DROP VIEW IF EXISTS view_2_tab4_758 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_758
+DROP VIEW IF EXISTS view_3_tab4_758 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13291,13 +13291,13 @@ SELECT pk FROM tab0 WHERE col3 = 7402
 ----
 
 statement ok
-DROP VIEW view_1_tab0_759
+DROP VIEW IF EXISTS view_1_tab0_759 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_759
+DROP VIEW IF EXISTS view_2_tab0_759 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_759
+DROP VIEW IF EXISTS view_3_tab0_759 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13383,13 +13383,13 @@ SELECT pk FROM tab1 WHERE col3 = 7402
 ----
 
 statement ok
-DROP VIEW view_1_tab1_759
+DROP VIEW IF EXISTS view_1_tab1_759 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_759
+DROP VIEW IF EXISTS view_2_tab1_759 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_759
+DROP VIEW IF EXISTS view_3_tab1_759 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13475,13 +13475,13 @@ SELECT pk FROM tab2 WHERE col3 = 7402
 ----
 
 statement ok
-DROP VIEW view_1_tab2_759
+DROP VIEW IF EXISTS view_1_tab2_759 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_759
+DROP VIEW IF EXISTS view_2_tab2_759 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_759
+DROP VIEW IF EXISTS view_3_tab2_759 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13567,13 +13567,13 @@ SELECT pk FROM tab3 WHERE col3 = 7402
 ----
 
 statement ok
-DROP VIEW view_1_tab3_759
+DROP VIEW IF EXISTS view_1_tab3_759 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_759
+DROP VIEW IF EXISTS view_2_tab3_759 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_759
+DROP VIEW IF EXISTS view_3_tab3_759 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13659,13 +13659,13 @@ SELECT pk FROM tab4 WHERE col3 = 7402
 ----
 
 statement ok
-DROP VIEW view_1_tab4_759
+DROP VIEW IF EXISTS view_1_tab4_759 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_759
+DROP VIEW IF EXISTS view_2_tab4_759 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_759
+DROP VIEW IF EXISTS view_3_tab4_759 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13756,13 +13756,13 @@ SELECT pk FROM tab0 WHERE col0 >= 3333
 670 values hashing to 1dd5630cba141993f797a342bf1357b5
 
 statement ok
-DROP VIEW view_1_tab0_760
+DROP VIEW IF EXISTS view_1_tab0_760 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_760
+DROP VIEW IF EXISTS view_2_tab0_760 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_760
+DROP VIEW IF EXISTS view_3_tab0_760 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13853,13 +13853,13 @@ SELECT pk FROM tab1 WHERE col0 >= 3333
 670 values hashing to 1dd5630cba141993f797a342bf1357b5
 
 statement ok
-DROP VIEW view_1_tab1_760
+DROP VIEW IF EXISTS view_1_tab1_760 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_760
+DROP VIEW IF EXISTS view_2_tab1_760 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_760
+DROP VIEW IF EXISTS view_3_tab1_760 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -13950,13 +13950,13 @@ SELECT pk FROM tab2 WHERE col0 >= 3333
 670 values hashing to 1dd5630cba141993f797a342bf1357b5
 
 statement ok
-DROP VIEW view_1_tab2_760
+DROP VIEW IF EXISTS view_1_tab2_760 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_760
+DROP VIEW IF EXISTS view_2_tab2_760 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_760
+DROP VIEW IF EXISTS view_3_tab2_760 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14047,13 +14047,13 @@ SELECT pk FROM tab3 WHERE col0 >= 3333
 670 values hashing to 1dd5630cba141993f797a342bf1357b5
 
 statement ok
-DROP VIEW view_1_tab3_760
+DROP VIEW IF EXISTS view_1_tab3_760 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_760
+DROP VIEW IF EXISTS view_2_tab3_760 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_760
+DROP VIEW IF EXISTS view_3_tab3_760 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14144,13 +14144,13 @@ SELECT pk FROM tab4 WHERE col0 >= 3333
 670 values hashing to 1dd5630cba141993f797a342bf1357b5
 
 statement ok
-DROP VIEW view_1_tab4_760
+DROP VIEW IF EXISTS view_1_tab4_760 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_760
+DROP VIEW IF EXISTS view_2_tab4_760 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_760
+DROP VIEW IF EXISTS view_3_tab4_760 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14241,13 +14241,13 @@ SELECT pk FROM tab0 WHERE col0 > 7359
 262 values hashing to 847f54193b9157b8a9029563cb10967f
 
 statement ok
-DROP VIEW view_1_tab0_761
+DROP VIEW IF EXISTS view_1_tab0_761 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_761
+DROP VIEW IF EXISTS view_2_tab0_761 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_761
+DROP VIEW IF EXISTS view_3_tab0_761 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14338,13 +14338,13 @@ SELECT pk FROM tab1 WHERE col0 > 7359
 262 values hashing to 847f54193b9157b8a9029563cb10967f
 
 statement ok
-DROP VIEW view_1_tab1_761
+DROP VIEW IF EXISTS view_1_tab1_761 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_761
+DROP VIEW IF EXISTS view_2_tab1_761 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_761
+DROP VIEW IF EXISTS view_3_tab1_761 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14435,13 +14435,13 @@ SELECT pk FROM tab2 WHERE col0 > 7359
 262 values hashing to 847f54193b9157b8a9029563cb10967f
 
 statement ok
-DROP VIEW view_1_tab2_761
+DROP VIEW IF EXISTS view_1_tab2_761 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_761
+DROP VIEW IF EXISTS view_2_tab2_761 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_761
+DROP VIEW IF EXISTS view_3_tab2_761 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14532,13 +14532,13 @@ SELECT pk FROM tab3 WHERE col0 > 7359
 262 values hashing to 847f54193b9157b8a9029563cb10967f
 
 statement ok
-DROP VIEW view_1_tab3_761
+DROP VIEW IF EXISTS view_1_tab3_761 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_761
+DROP VIEW IF EXISTS view_2_tab3_761 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_761
+DROP VIEW IF EXISTS view_3_tab3_761 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14629,13 +14629,13 @@ SELECT pk FROM tab4 WHERE col0 > 7359
 262 values hashing to 847f54193b9157b8a9029563cb10967f
 
 statement ok
-DROP VIEW view_1_tab4_761
+DROP VIEW IF EXISTS view_1_tab4_761 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_761
+DROP VIEW IF EXISTS view_2_tab4_761 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_761
+DROP VIEW IF EXISTS view_3_tab4_761 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14721,13 +14721,13 @@ SELECT pk FROM tab0 WHERE (col0 = 1660)
 ----
 
 statement ok
-DROP VIEW view_1_tab0_762
+DROP VIEW IF EXISTS view_1_tab0_762 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_762
+DROP VIEW IF EXISTS view_2_tab0_762 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_762
+DROP VIEW IF EXISTS view_3_tab0_762 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14813,13 +14813,13 @@ SELECT pk FROM tab1 WHERE (col0 = 1660)
 ----
 
 statement ok
-DROP VIEW view_1_tab1_762
+DROP VIEW IF EXISTS view_1_tab1_762 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_762
+DROP VIEW IF EXISTS view_2_tab1_762 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_762
+DROP VIEW IF EXISTS view_3_tab1_762 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14905,13 +14905,13 @@ SELECT pk FROM tab2 WHERE (col0 = 1660)
 ----
 
 statement ok
-DROP VIEW view_1_tab2_762
+DROP VIEW IF EXISTS view_1_tab2_762 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_762
+DROP VIEW IF EXISTS view_2_tab2_762 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_762
+DROP VIEW IF EXISTS view_3_tab2_762 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -14997,13 +14997,13 @@ SELECT pk FROM tab3 WHERE (col0 = 1660)
 ----
 
 statement ok
-DROP VIEW view_1_tab3_762
+DROP VIEW IF EXISTS view_1_tab3_762 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_762
+DROP VIEW IF EXISTS view_2_tab3_762 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_762
+DROP VIEW IF EXISTS view_3_tab3_762 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15089,13 +15089,13 @@ SELECT pk FROM tab4 WHERE (col0 = 1660)
 ----
 
 statement ok
-DROP VIEW view_1_tab4_762
+DROP VIEW IF EXISTS view_1_tab4_762 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_762
+DROP VIEW IF EXISTS view_2_tab4_762 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_762
+DROP VIEW IF EXISTS view_3_tab4_762 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15181,13 +15181,13 @@ SELECT pk FROM tab0 WHERE ((col3 IN (4353,9997,8979,9700,3323,3746))) AND col0 =
 ----
 
 statement ok
-DROP VIEW view_1_tab0_763
+DROP VIEW IF EXISTS view_1_tab0_763 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_763
+DROP VIEW IF EXISTS view_2_tab0_763 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_763
+DROP VIEW IF EXISTS view_3_tab0_763 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15273,13 +15273,13 @@ SELECT pk FROM tab1 WHERE ((col3 IN (4353,9997,8979,9700,3323,3746))) AND col0 =
 ----
 
 statement ok
-DROP VIEW view_1_tab1_763
+DROP VIEW IF EXISTS view_1_tab1_763 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_763
+DROP VIEW IF EXISTS view_2_tab1_763 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_763
+DROP VIEW IF EXISTS view_3_tab1_763 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15365,13 +15365,13 @@ SELECT pk FROM tab2 WHERE ((col3 IN (4353,9997,8979,9700,3323,3746))) AND col0 =
 ----
 
 statement ok
-DROP VIEW view_1_tab2_763
+DROP VIEW IF EXISTS view_1_tab2_763 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_763
+DROP VIEW IF EXISTS view_2_tab2_763 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_763
+DROP VIEW IF EXISTS view_3_tab2_763 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15457,13 +15457,13 @@ SELECT pk FROM tab3 WHERE ((col3 IN (4353,9997,8979,9700,3323,3746))) AND col0 =
 ----
 
 statement ok
-DROP VIEW view_1_tab3_763
+DROP VIEW IF EXISTS view_1_tab3_763 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_763
+DROP VIEW IF EXISTS view_2_tab3_763 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_763
+DROP VIEW IF EXISTS view_3_tab3_763 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15549,13 +15549,13 @@ SELECT pk FROM tab4 WHERE ((col3 IN (4353,9997,8979,9700,3323,3746))) AND col0 =
 ----
 
 statement ok
-DROP VIEW view_1_tab4_763
+DROP VIEW IF EXISTS view_1_tab4_763 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_763
+DROP VIEW IF EXISTS view_2_tab4_763 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_763
+DROP VIEW IF EXISTS view_3_tab4_763 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15646,13 +15646,13 @@ SELECT pk FROM tab0 WHERE (col0 < 6636)
 665 values hashing to 12f6eb8f269caef5a4ae15c194a73539
 
 statement ok
-DROP VIEW view_1_tab0_764
+DROP VIEW IF EXISTS view_1_tab0_764 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_764
+DROP VIEW IF EXISTS view_2_tab0_764 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_764
+DROP VIEW IF EXISTS view_3_tab0_764 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15743,13 +15743,13 @@ SELECT pk FROM tab1 WHERE (col0 < 6636)
 665 values hashing to 12f6eb8f269caef5a4ae15c194a73539
 
 statement ok
-DROP VIEW view_1_tab1_764
+DROP VIEW IF EXISTS view_1_tab1_764 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_764
+DROP VIEW IF EXISTS view_2_tab1_764 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_764
+DROP VIEW IF EXISTS view_3_tab1_764 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15840,13 +15840,13 @@ SELECT pk FROM tab2 WHERE (col0 < 6636)
 665 values hashing to 12f6eb8f269caef5a4ae15c194a73539
 
 statement ok
-DROP VIEW view_1_tab2_764
+DROP VIEW IF EXISTS view_1_tab2_764 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_764
+DROP VIEW IF EXISTS view_2_tab2_764 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_764
+DROP VIEW IF EXISTS view_3_tab2_764 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -15937,13 +15937,13 @@ SELECT pk FROM tab3 WHERE (col0 < 6636)
 665 values hashing to 12f6eb8f269caef5a4ae15c194a73539
 
 statement ok
-DROP VIEW view_1_tab3_764
+DROP VIEW IF EXISTS view_1_tab3_764 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_764
+DROP VIEW IF EXISTS view_2_tab3_764 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_764
+DROP VIEW IF EXISTS view_3_tab3_764 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16034,13 +16034,13 @@ SELECT pk FROM tab4 WHERE (col0 < 6636)
 665 values hashing to 12f6eb8f269caef5a4ae15c194a73539
 
 statement ok
-DROP VIEW view_1_tab4_764
+DROP VIEW IF EXISTS view_1_tab4_764 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_764
+DROP VIEW IF EXISTS view_2_tab4_764 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_764
+DROP VIEW IF EXISTS view_3_tab4_764 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16133,13 +16133,13 @@ SELECT pk FROM tab0 WHERE (col3 IN (9749,8825,2254,6180))
 2
 
 statement ok
-DROP VIEW view_1_tab0_765
+DROP VIEW IF EXISTS view_1_tab0_765 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_765
+DROP VIEW IF EXISTS view_2_tab0_765 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_765
+DROP VIEW IF EXISTS view_3_tab0_765 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16232,13 +16232,13 @@ SELECT pk FROM tab1 WHERE (col3 IN (9749,8825,2254,6180))
 2
 
 statement ok
-DROP VIEW view_1_tab1_765
+DROP VIEW IF EXISTS view_1_tab1_765 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_765
+DROP VIEW IF EXISTS view_2_tab1_765 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_765
+DROP VIEW IF EXISTS view_3_tab1_765 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16331,13 +16331,13 @@ SELECT pk FROM tab2 WHERE (col3 IN (9749,8825,2254,6180))
 2
 
 statement ok
-DROP VIEW view_1_tab2_765
+DROP VIEW IF EXISTS view_1_tab2_765 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_765
+DROP VIEW IF EXISTS view_2_tab2_765 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_765
+DROP VIEW IF EXISTS view_3_tab2_765 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16430,13 +16430,13 @@ SELECT pk FROM tab3 WHERE (col3 IN (9749,8825,2254,6180))
 2
 
 statement ok
-DROP VIEW view_1_tab3_765
+DROP VIEW IF EXISTS view_1_tab3_765 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_765
+DROP VIEW IF EXISTS view_2_tab3_765 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_765
+DROP VIEW IF EXISTS view_3_tab3_765 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16529,13 +16529,13 @@ SELECT pk FROM tab4 WHERE (col3 IN (9749,8825,2254,6180))
 2
 
 statement ok
-DROP VIEW view_1_tab4_765
+DROP VIEW IF EXISTS view_1_tab4_765 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_765
+DROP VIEW IF EXISTS view_2_tab4_765 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_765
+DROP VIEW IF EXISTS view_3_tab4_765 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16626,13 +16626,13 @@ SELECT pk FROM tab0 WHERE col4 <= 1977.74
 218 values hashing to 9dddf319abc55ca48850c1b85b2e1fdc
 
 statement ok
-DROP VIEW view_1_tab0_766
+DROP VIEW IF EXISTS view_1_tab0_766 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_766
+DROP VIEW IF EXISTS view_2_tab0_766 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_766
+DROP VIEW IF EXISTS view_3_tab0_766 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16723,13 +16723,13 @@ SELECT pk FROM tab1 WHERE col4 <= 1977.74
 218 values hashing to 9dddf319abc55ca48850c1b85b2e1fdc
 
 statement ok
-DROP VIEW view_1_tab1_766
+DROP VIEW IF EXISTS view_1_tab1_766 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_766
+DROP VIEW IF EXISTS view_2_tab1_766 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_766
+DROP VIEW IF EXISTS view_3_tab1_766 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16820,13 +16820,13 @@ SELECT pk FROM tab2 WHERE col4 <= 1977.74
 218 values hashing to 9dddf319abc55ca48850c1b85b2e1fdc
 
 statement ok
-DROP VIEW view_1_tab2_766
+DROP VIEW IF EXISTS view_1_tab2_766 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_766
+DROP VIEW IF EXISTS view_2_tab2_766 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_766
+DROP VIEW IF EXISTS view_3_tab2_766 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -16917,13 +16917,13 @@ SELECT pk FROM tab3 WHERE col4 <= 1977.74
 218 values hashing to 9dddf319abc55ca48850c1b85b2e1fdc
 
 statement ok
-DROP VIEW view_1_tab3_766
+DROP VIEW IF EXISTS view_1_tab3_766 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_766
+DROP VIEW IF EXISTS view_2_tab3_766 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_766
+DROP VIEW IF EXISTS view_3_tab3_766 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17014,13 +17014,13 @@ SELECT pk FROM tab4 WHERE col4 <= 1977.74
 218 values hashing to 9dddf319abc55ca48850c1b85b2e1fdc
 
 statement ok
-DROP VIEW view_1_tab4_766
+DROP VIEW IF EXISTS view_1_tab4_766 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_766
+DROP VIEW IF EXISTS view_2_tab4_766 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_766
+DROP VIEW IF EXISTS view_3_tab4_766 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17106,13 +17106,13 @@ SELECT pk FROM tab0 WHERE col0 = 1516 AND col4 = 6015.47 AND col3 > 9614 AND col
 ----
 
 statement ok
-DROP VIEW view_1_tab0_767
+DROP VIEW IF EXISTS view_1_tab0_767 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_767
+DROP VIEW IF EXISTS view_2_tab0_767 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_767
+DROP VIEW IF EXISTS view_3_tab0_767 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17198,13 +17198,13 @@ SELECT pk FROM tab1 WHERE col0 = 1516 AND col4 = 6015.47 AND col3 > 9614 AND col
 ----
 
 statement ok
-DROP VIEW view_1_tab1_767
+DROP VIEW IF EXISTS view_1_tab1_767 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_767
+DROP VIEW IF EXISTS view_2_tab1_767 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_767
+DROP VIEW IF EXISTS view_3_tab1_767 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17290,13 +17290,13 @@ SELECT pk FROM tab2 WHERE col0 = 1516 AND col4 = 6015.47 AND col3 > 9614 AND col
 ----
 
 statement ok
-DROP VIEW view_1_tab2_767
+DROP VIEW IF EXISTS view_1_tab2_767 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_767
+DROP VIEW IF EXISTS view_2_tab2_767 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_767
+DROP VIEW IF EXISTS view_3_tab2_767 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17382,13 +17382,13 @@ SELECT pk FROM tab3 WHERE col0 = 1516 AND col4 = 6015.47 AND col3 > 9614 AND col
 ----
 
 statement ok
-DROP VIEW view_1_tab3_767
+DROP VIEW IF EXISTS view_1_tab3_767 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_767
+DROP VIEW IF EXISTS view_2_tab3_767 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_767
+DROP VIEW IF EXISTS view_3_tab3_767 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17474,13 +17474,13 @@ SELECT pk FROM tab4 WHERE col0 = 1516 AND col4 = 6015.47 AND col3 > 9614 AND col
 ----
 
 statement ok
-DROP VIEW view_1_tab4_767
+DROP VIEW IF EXISTS view_1_tab4_767 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_767
+DROP VIEW IF EXISTS view_2_tab4_767 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_767
+DROP VIEW IF EXISTS view_3_tab4_767 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17571,13 +17571,13 @@ SELECT pk FROM tab0 WHERE col3 > 5342
 465 values hashing to 8c57502a07fd787bcf9f0f3bd4f4980b
 
 statement ok
-DROP VIEW view_1_tab0_768
+DROP VIEW IF EXISTS view_1_tab0_768 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_768
+DROP VIEW IF EXISTS view_2_tab0_768 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_768
+DROP VIEW IF EXISTS view_3_tab0_768 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17668,13 +17668,13 @@ SELECT pk FROM tab1 WHERE col3 > 5342
 465 values hashing to 8c57502a07fd787bcf9f0f3bd4f4980b
 
 statement ok
-DROP VIEW view_1_tab1_768
+DROP VIEW IF EXISTS view_1_tab1_768 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_768
+DROP VIEW IF EXISTS view_2_tab1_768 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_768
+DROP VIEW IF EXISTS view_3_tab1_768 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17765,13 +17765,13 @@ SELECT pk FROM tab2 WHERE col3 > 5342
 465 values hashing to 8c57502a07fd787bcf9f0f3bd4f4980b
 
 statement ok
-DROP VIEW view_1_tab2_768
+DROP VIEW IF EXISTS view_1_tab2_768 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_768
+DROP VIEW IF EXISTS view_2_tab2_768 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_768
+DROP VIEW IF EXISTS view_3_tab2_768 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17862,13 +17862,13 @@ SELECT pk FROM tab3 WHERE col3 > 5342
 465 values hashing to 8c57502a07fd787bcf9f0f3bd4f4980b
 
 statement ok
-DROP VIEW view_1_tab3_768
+DROP VIEW IF EXISTS view_1_tab3_768 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_768
+DROP VIEW IF EXISTS view_2_tab3_768 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_768
+DROP VIEW IF EXISTS view_3_tab3_768 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -17959,13 +17959,13 @@ SELECT pk FROM tab4 WHERE col3 > 5342
 465 values hashing to 8c57502a07fd787bcf9f0f3bd4f4980b
 
 statement ok
-DROP VIEW view_1_tab4_768
+DROP VIEW IF EXISTS view_1_tab4_768 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_768
+DROP VIEW IF EXISTS view_2_tab4_768 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_768
+DROP VIEW IF EXISTS view_3_tab4_768 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18051,13 +18051,13 @@ SELECT pk FROM tab0 WHERE (col0 = 3648) AND col4 > 6919.30
 ----
 
 statement ok
-DROP VIEW view_1_tab0_769
+DROP VIEW IF EXISTS view_1_tab0_769 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_769
+DROP VIEW IF EXISTS view_2_tab0_769 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_769
+DROP VIEW IF EXISTS view_3_tab0_769 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18143,13 +18143,13 @@ SELECT pk FROM tab1 WHERE (col0 = 3648) AND col4 > 6919.30
 ----
 
 statement ok
-DROP VIEW view_1_tab1_769
+DROP VIEW IF EXISTS view_1_tab1_769 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_769
+DROP VIEW IF EXISTS view_2_tab1_769 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_769
+DROP VIEW IF EXISTS view_3_tab1_769 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18235,13 +18235,13 @@ SELECT pk FROM tab2 WHERE (col0 = 3648) AND col4 > 6919.30
 ----
 
 statement ok
-DROP VIEW view_1_tab2_769
+DROP VIEW IF EXISTS view_1_tab2_769 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_769
+DROP VIEW IF EXISTS view_2_tab2_769 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_769
+DROP VIEW IF EXISTS view_3_tab2_769 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18327,13 +18327,13 @@ SELECT pk FROM tab3 WHERE (col0 = 3648) AND col4 > 6919.30
 ----
 
 statement ok
-DROP VIEW view_1_tab3_769
+DROP VIEW IF EXISTS view_1_tab3_769 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_769
+DROP VIEW IF EXISTS view_2_tab3_769 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_769
+DROP VIEW IF EXISTS view_3_tab3_769 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18419,13 +18419,13 @@ SELECT pk FROM tab4 WHERE (col0 = 3648) AND col4 > 6919.30
 ----
 
 statement ok
-DROP VIEW view_1_tab4_769
+DROP VIEW IF EXISTS view_1_tab4_769 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_769
+DROP VIEW IF EXISTS view_2_tab4_769 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_769
+DROP VIEW IF EXISTS view_3_tab4_769 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18516,13 +18516,13 @@ SELECT pk FROM tab0 WHERE ((col0 >= 2231))
 794 values hashing to ef1384ce8c66130078d2977ab52c1cd8
 
 statement ok
-DROP VIEW view_1_tab0_770
+DROP VIEW IF EXISTS view_1_tab0_770 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_770
+DROP VIEW IF EXISTS view_2_tab0_770 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_770
+DROP VIEW IF EXISTS view_3_tab0_770 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18613,13 +18613,13 @@ SELECT pk FROM tab1 WHERE ((col0 >= 2231))
 794 values hashing to ef1384ce8c66130078d2977ab52c1cd8
 
 statement ok
-DROP VIEW view_1_tab1_770
+DROP VIEW IF EXISTS view_1_tab1_770 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_770
+DROP VIEW IF EXISTS view_2_tab1_770 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_770
+DROP VIEW IF EXISTS view_3_tab1_770 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18710,13 +18710,13 @@ SELECT pk FROM tab2 WHERE ((col0 >= 2231))
 794 values hashing to ef1384ce8c66130078d2977ab52c1cd8
 
 statement ok
-DROP VIEW view_1_tab2_770
+DROP VIEW IF EXISTS view_1_tab2_770 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_770
+DROP VIEW IF EXISTS view_2_tab2_770 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_770
+DROP VIEW IF EXISTS view_3_tab2_770 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18807,13 +18807,13 @@ SELECT pk FROM tab3 WHERE ((col0 >= 2231))
 794 values hashing to ef1384ce8c66130078d2977ab52c1cd8
 
 statement ok
-DROP VIEW view_1_tab3_770
+DROP VIEW IF EXISTS view_1_tab3_770 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_770
+DROP VIEW IF EXISTS view_2_tab3_770 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_770
+DROP VIEW IF EXISTS view_3_tab3_770 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -18904,13 +18904,13 @@ SELECT pk FROM tab4 WHERE ((col0 >= 2231))
 794 values hashing to ef1384ce8c66130078d2977ab52c1cd8
 
 statement ok
-DROP VIEW view_1_tab4_770
+DROP VIEW IF EXISTS view_1_tab4_770 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_770
+DROP VIEW IF EXISTS view_2_tab4_770 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_770
+DROP VIEW IF EXISTS view_3_tab4_770 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19001,13 +19001,13 @@ SELECT pk FROM tab0 WHERE (col4 >= 9828.60)
 9 values hashing to 65c7ef1c2edf373f9f846ba1bb53b003
 
 statement ok
-DROP VIEW view_1_tab0_771
+DROP VIEW IF EXISTS view_1_tab0_771 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_771
+DROP VIEW IF EXISTS view_2_tab0_771 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_771
+DROP VIEW IF EXISTS view_3_tab0_771 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19098,13 +19098,13 @@ SELECT pk FROM tab1 WHERE (col4 >= 9828.60)
 9 values hashing to 65c7ef1c2edf373f9f846ba1bb53b003
 
 statement ok
-DROP VIEW view_1_tab1_771
+DROP VIEW IF EXISTS view_1_tab1_771 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_771
+DROP VIEW IF EXISTS view_2_tab1_771 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_771
+DROP VIEW IF EXISTS view_3_tab1_771 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19195,13 +19195,13 @@ SELECT pk FROM tab2 WHERE (col4 >= 9828.60)
 9 values hashing to 65c7ef1c2edf373f9f846ba1bb53b003
 
 statement ok
-DROP VIEW view_1_tab2_771
+DROP VIEW IF EXISTS view_1_tab2_771 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_771
+DROP VIEW IF EXISTS view_2_tab2_771 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_771
+DROP VIEW IF EXISTS view_3_tab2_771 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19292,13 +19292,13 @@ SELECT pk FROM tab3 WHERE (col4 >= 9828.60)
 9 values hashing to 65c7ef1c2edf373f9f846ba1bb53b003
 
 statement ok
-DROP VIEW view_1_tab3_771
+DROP VIEW IF EXISTS view_1_tab3_771 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_771
+DROP VIEW IF EXISTS view_2_tab3_771 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_771
+DROP VIEW IF EXISTS view_3_tab3_771 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19389,13 +19389,13 @@ SELECT pk FROM tab4 WHERE (col4 >= 9828.60)
 9 values hashing to 65c7ef1c2edf373f9f846ba1bb53b003
 
 statement ok
-DROP VIEW view_1_tab4_771
+DROP VIEW IF EXISTS view_1_tab4_771 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_771
+DROP VIEW IF EXISTS view_2_tab4_771 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_771
+DROP VIEW IF EXISTS view_3_tab4_771 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19486,13 +19486,13 @@ SELECT pk FROM tab0 WHERE (col1 < 6956.93)
 656 values hashing to a71d8205ee3f817455a967e58cad9ae5
 
 statement ok
-DROP VIEW view_1_tab0_772
+DROP VIEW IF EXISTS view_1_tab0_772 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_772
+DROP VIEW IF EXISTS view_2_tab0_772 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_772
+DROP VIEW IF EXISTS view_3_tab0_772 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19583,13 +19583,13 @@ SELECT pk FROM tab1 WHERE (col1 < 6956.93)
 656 values hashing to a71d8205ee3f817455a967e58cad9ae5
 
 statement ok
-DROP VIEW view_1_tab1_772
+DROP VIEW IF EXISTS view_1_tab1_772 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_772
+DROP VIEW IF EXISTS view_2_tab1_772 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_772
+DROP VIEW IF EXISTS view_3_tab1_772 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19680,13 +19680,13 @@ SELECT pk FROM tab2 WHERE (col1 < 6956.93)
 656 values hashing to a71d8205ee3f817455a967e58cad9ae5
 
 statement ok
-DROP VIEW view_1_tab2_772
+DROP VIEW IF EXISTS view_1_tab2_772 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_772
+DROP VIEW IF EXISTS view_2_tab2_772 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_772
+DROP VIEW IF EXISTS view_3_tab2_772 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19777,13 +19777,13 @@ SELECT pk FROM tab3 WHERE (col1 < 6956.93)
 656 values hashing to a71d8205ee3f817455a967e58cad9ae5
 
 statement ok
-DROP VIEW view_1_tab3_772
+DROP VIEW IF EXISTS view_1_tab3_772 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_772
+DROP VIEW IF EXISTS view_2_tab3_772 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_772
+DROP VIEW IF EXISTS view_3_tab3_772 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19874,13 +19874,13 @@ SELECT pk FROM tab4 WHERE (col1 < 6956.93)
 656 values hashing to a71d8205ee3f817455a967e58cad9ae5
 
 statement ok
-DROP VIEW view_1_tab4_772
+DROP VIEW IF EXISTS view_1_tab4_772 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_772
+DROP VIEW IF EXISTS view_2_tab4_772 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_772
+DROP VIEW IF EXISTS view_3_tab4_772 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -19971,13 +19971,13 @@ SELECT pk FROM tab0 WHERE col3 >= 7083 AND (col0 > 8739) OR col1 < 306.72 OR col
 913 values hashing to 27bb2e047adb4e0a264640fd3abef9ae
 
 statement ok
-DROP VIEW view_1_tab0_773
+DROP VIEW IF EXISTS view_1_tab0_773 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_773
+DROP VIEW IF EXISTS view_2_tab0_773 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_773
+DROP VIEW IF EXISTS view_3_tab0_773 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20068,13 +20068,13 @@ SELECT pk FROM tab1 WHERE col3 >= 7083 AND (col0 > 8739) OR col1 < 306.72 OR col
 913 values hashing to 27bb2e047adb4e0a264640fd3abef9ae
 
 statement ok
-DROP VIEW view_1_tab1_773
+DROP VIEW IF EXISTS view_1_tab1_773 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_773
+DROP VIEW IF EXISTS view_2_tab1_773 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_773
+DROP VIEW IF EXISTS view_3_tab1_773 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20165,13 +20165,13 @@ SELECT pk FROM tab2 WHERE col3 >= 7083 AND (col0 > 8739) OR col1 < 306.72 OR col
 913 values hashing to 27bb2e047adb4e0a264640fd3abef9ae
 
 statement ok
-DROP VIEW view_1_tab2_773
+DROP VIEW IF EXISTS view_1_tab2_773 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_773
+DROP VIEW IF EXISTS view_2_tab2_773 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_773
+DROP VIEW IF EXISTS view_3_tab2_773 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20262,13 +20262,13 @@ SELECT pk FROM tab3 WHERE col3 >= 7083 AND (col0 > 8739) OR col1 < 306.72 OR col
 913 values hashing to 27bb2e047adb4e0a264640fd3abef9ae
 
 statement ok
-DROP VIEW view_1_tab3_773
+DROP VIEW IF EXISTS view_1_tab3_773 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_773
+DROP VIEW IF EXISTS view_2_tab3_773 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_773
+DROP VIEW IF EXISTS view_3_tab3_773 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20359,13 +20359,13 @@ SELECT pk FROM tab4 WHERE col3 >= 7083 AND (col0 > 8739) OR col1 < 306.72 OR col
 913 values hashing to 27bb2e047adb4e0a264640fd3abef9ae
 
 statement ok
-DROP VIEW view_1_tab4_773
+DROP VIEW IF EXISTS view_1_tab4_773 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_773
+DROP VIEW IF EXISTS view_2_tab4_773 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_773
+DROP VIEW IF EXISTS view_3_tab4_773 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20458,13 +20458,13 @@ SELECT pk FROM tab0 WHERE col0 = 5001 AND col4 < 7572.87
 440
 
 statement ok
-DROP VIEW view_1_tab0_774
+DROP VIEW IF EXISTS view_1_tab0_774 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_774
+DROP VIEW IF EXISTS view_2_tab0_774 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_774
+DROP VIEW IF EXISTS view_3_tab0_774 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20557,13 +20557,13 @@ SELECT pk FROM tab1 WHERE col0 = 5001 AND col4 < 7572.87
 440
 
 statement ok
-DROP VIEW view_1_tab1_774
+DROP VIEW IF EXISTS view_1_tab1_774 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_774
+DROP VIEW IF EXISTS view_2_tab1_774 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_774
+DROP VIEW IF EXISTS view_3_tab1_774 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20656,13 +20656,13 @@ SELECT pk FROM tab2 WHERE col0 = 5001 AND col4 < 7572.87
 440
 
 statement ok
-DROP VIEW view_1_tab2_774
+DROP VIEW IF EXISTS view_1_tab2_774 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_774
+DROP VIEW IF EXISTS view_2_tab2_774 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_774
+DROP VIEW IF EXISTS view_3_tab2_774 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20755,13 +20755,13 @@ SELECT pk FROM tab3 WHERE col0 = 5001 AND col4 < 7572.87
 440
 
 statement ok
-DROP VIEW view_1_tab3_774
+DROP VIEW IF EXISTS view_1_tab3_774 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_774
+DROP VIEW IF EXISTS view_2_tab3_774 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_774
+DROP VIEW IF EXISTS view_3_tab3_774 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20854,13 +20854,13 @@ SELECT pk FROM tab4 WHERE col0 = 5001 AND col4 < 7572.87
 440
 
 statement ok
-DROP VIEW view_1_tab4_774
+DROP VIEW IF EXISTS view_1_tab4_774 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_774
+DROP VIEW IF EXISTS view_2_tab4_774 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_774
+DROP VIEW IF EXISTS view_3_tab4_774 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -20951,13 +20951,13 @@ SELECT pk FROM tab0 WHERE col4 < 6593.56 AND col1 > 1043.59
 606 values hashing to 21edb4837bc69d79918f92cf5b7d5474
 
 statement ok
-DROP VIEW view_1_tab0_775
+DROP VIEW IF EXISTS view_1_tab0_775 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_775
+DROP VIEW IF EXISTS view_2_tab0_775 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_775
+DROP VIEW IF EXISTS view_3_tab0_775 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21048,13 +21048,13 @@ SELECT pk FROM tab1 WHERE col4 < 6593.56 AND col1 > 1043.59
 606 values hashing to 21edb4837bc69d79918f92cf5b7d5474
 
 statement ok
-DROP VIEW view_1_tab1_775
+DROP VIEW IF EXISTS view_1_tab1_775 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_775
+DROP VIEW IF EXISTS view_2_tab1_775 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_775
+DROP VIEW IF EXISTS view_3_tab1_775 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21145,13 +21145,13 @@ SELECT pk FROM tab2 WHERE col4 < 6593.56 AND col1 > 1043.59
 606 values hashing to 21edb4837bc69d79918f92cf5b7d5474
 
 statement ok
-DROP VIEW view_1_tab2_775
+DROP VIEW IF EXISTS view_1_tab2_775 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_775
+DROP VIEW IF EXISTS view_2_tab2_775 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_775
+DROP VIEW IF EXISTS view_3_tab2_775 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21242,13 +21242,13 @@ SELECT pk FROM tab3 WHERE col4 < 6593.56 AND col1 > 1043.59
 606 values hashing to 21edb4837bc69d79918f92cf5b7d5474
 
 statement ok
-DROP VIEW view_1_tab3_775
+DROP VIEW IF EXISTS view_1_tab3_775 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_775
+DROP VIEW IF EXISTS view_2_tab3_775 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_775
+DROP VIEW IF EXISTS view_3_tab3_775 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21339,13 +21339,13 @@ SELECT pk FROM tab4 WHERE col4 < 6593.56 AND col1 > 1043.59
 606 values hashing to 21edb4837bc69d79918f92cf5b7d5474
 
 statement ok
-DROP VIEW view_1_tab4_775
+DROP VIEW IF EXISTS view_1_tab4_775 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_775
+DROP VIEW IF EXISTS view_2_tab4_775 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_775
+DROP VIEW IF EXISTS view_3_tab4_775 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21436,13 +21436,13 @@ SELECT pk FROM tab0 WHERE (col1 < 8775.46 AND col0 < 2151) OR col4 = 2911.36 AND
 476 values hashing to 5159f469c10861aae34498377c65e34b
 
 statement ok
-DROP VIEW view_1_tab0_776
+DROP VIEW IF EXISTS view_1_tab0_776 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_776
+DROP VIEW IF EXISTS view_2_tab0_776 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_776
+DROP VIEW IF EXISTS view_3_tab0_776 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21533,13 +21533,13 @@ SELECT pk FROM tab1 WHERE (col1 < 8775.46 AND col0 < 2151) OR col4 = 2911.36 AND
 476 values hashing to 5159f469c10861aae34498377c65e34b
 
 statement ok
-DROP VIEW view_1_tab1_776
+DROP VIEW IF EXISTS view_1_tab1_776 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_776
+DROP VIEW IF EXISTS view_2_tab1_776 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_776
+DROP VIEW IF EXISTS view_3_tab1_776 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21630,13 +21630,13 @@ SELECT pk FROM tab2 WHERE (col1 < 8775.46 AND col0 < 2151) OR col4 = 2911.36 AND
 476 values hashing to 5159f469c10861aae34498377c65e34b
 
 statement ok
-DROP VIEW view_1_tab2_776
+DROP VIEW IF EXISTS view_1_tab2_776 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_776
+DROP VIEW IF EXISTS view_2_tab2_776 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_776
+DROP VIEW IF EXISTS view_3_tab2_776 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21727,13 +21727,13 @@ SELECT pk FROM tab3 WHERE (col1 < 8775.46 AND col0 < 2151) OR col4 = 2911.36 AND
 476 values hashing to 5159f469c10861aae34498377c65e34b
 
 statement ok
-DROP VIEW view_1_tab3_776
+DROP VIEW IF EXISTS view_1_tab3_776 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_776
+DROP VIEW IF EXISTS view_2_tab3_776 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_776
+DROP VIEW IF EXISTS view_3_tab3_776 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21824,13 +21824,13 @@ SELECT pk FROM tab4 WHERE (col1 < 8775.46 AND col0 < 2151) OR col4 = 2911.36 AND
 476 values hashing to 5159f469c10861aae34498377c65e34b
 
 statement ok
-DROP VIEW view_1_tab4_776
+DROP VIEW IF EXISTS view_1_tab4_776 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_776
+DROP VIEW IF EXISTS view_2_tab4_776 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_776
+DROP VIEW IF EXISTS view_3_tab4_776 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -21921,13 +21921,13 @@ SELECT pk FROM tab0 WHERE col3 >= 2704 OR col3 >= 413
 965 values hashing to 6e6e487fd99c516ed3392f9ba9130a92
 
 statement ok
-DROP VIEW view_1_tab0_778
+DROP VIEW IF EXISTS view_1_tab0_778 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_778
+DROP VIEW IF EXISTS view_2_tab0_778 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_778
+DROP VIEW IF EXISTS view_3_tab0_778 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22018,13 +22018,13 @@ SELECT pk FROM tab1 WHERE col3 >= 2704 OR col3 >= 413
 965 values hashing to 6e6e487fd99c516ed3392f9ba9130a92
 
 statement ok
-DROP VIEW view_1_tab1_778
+DROP VIEW IF EXISTS view_1_tab1_778 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_778
+DROP VIEW IF EXISTS view_2_tab1_778 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_778
+DROP VIEW IF EXISTS view_3_tab1_778 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22115,13 +22115,13 @@ SELECT pk FROM tab2 WHERE col3 >= 2704 OR col3 >= 413
 965 values hashing to 6e6e487fd99c516ed3392f9ba9130a92
 
 statement ok
-DROP VIEW view_1_tab2_778
+DROP VIEW IF EXISTS view_1_tab2_778 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_778
+DROP VIEW IF EXISTS view_2_tab2_778 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_778
+DROP VIEW IF EXISTS view_3_tab2_778 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22212,13 +22212,13 @@ SELECT pk FROM tab3 WHERE col3 >= 2704 OR col3 >= 413
 965 values hashing to 6e6e487fd99c516ed3392f9ba9130a92
 
 statement ok
-DROP VIEW view_1_tab3_778
+DROP VIEW IF EXISTS view_1_tab3_778 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_778
+DROP VIEW IF EXISTS view_2_tab3_778 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_778
+DROP VIEW IF EXISTS view_3_tab3_778 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22309,13 +22309,13 @@ SELECT pk FROM tab4 WHERE col3 >= 2704 OR col3 >= 413
 965 values hashing to 6e6e487fd99c516ed3392f9ba9130a92
 
 statement ok
-DROP VIEW view_1_tab4_778
+DROP VIEW IF EXISTS view_1_tab4_778 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_778
+DROP VIEW IF EXISTS view_2_tab4_778 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_778
+DROP VIEW IF EXISTS view_3_tab4_778 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22406,13 +22406,13 @@ SELECT pk FROM tab0 WHERE (col0 <= 9785) OR (col0 = 4136 OR col3 <= 4174 AND col
 987 values hashing to 1c7f5d250962e4966f94f2d4f7b0281b
 
 statement ok
-DROP VIEW view_1_tab0_779
+DROP VIEW IF EXISTS view_1_tab0_779 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_779
+DROP VIEW IF EXISTS view_2_tab0_779 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_779
+DROP VIEW IF EXISTS view_3_tab0_779 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22503,13 +22503,13 @@ SELECT pk FROM tab1 WHERE (col0 <= 9785) OR (col0 = 4136 OR col3 <= 4174 AND col
 987 values hashing to 1c7f5d250962e4966f94f2d4f7b0281b
 
 statement ok
-DROP VIEW view_1_tab1_779
+DROP VIEW IF EXISTS view_1_tab1_779 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_779
+DROP VIEW IF EXISTS view_2_tab1_779 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_779
+DROP VIEW IF EXISTS view_3_tab1_779 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22600,13 +22600,13 @@ SELECT pk FROM tab2 WHERE (col0 <= 9785) OR (col0 = 4136 OR col3 <= 4174 AND col
 987 values hashing to 1c7f5d250962e4966f94f2d4f7b0281b
 
 statement ok
-DROP VIEW view_1_tab2_779
+DROP VIEW IF EXISTS view_1_tab2_779 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_779
+DROP VIEW IF EXISTS view_2_tab2_779 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_779
+DROP VIEW IF EXISTS view_3_tab2_779 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22697,13 +22697,13 @@ SELECT pk FROM tab3 WHERE (col0 <= 9785) OR (col0 = 4136 OR col3 <= 4174 AND col
 987 values hashing to 1c7f5d250962e4966f94f2d4f7b0281b
 
 statement ok
-DROP VIEW view_1_tab3_779
+DROP VIEW IF EXISTS view_1_tab3_779 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_779
+DROP VIEW IF EXISTS view_2_tab3_779 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_779
+DROP VIEW IF EXISTS view_3_tab3_779 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22794,13 +22794,13 @@ SELECT pk FROM tab4 WHERE (col0 <= 9785) OR (col0 = 4136 OR col3 <= 4174 AND col
 987 values hashing to 1c7f5d250962e4966f94f2d4f7b0281b
 
 statement ok
-DROP VIEW view_1_tab4_779
+DROP VIEW IF EXISTS view_1_tab4_779 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_779
+DROP VIEW IF EXISTS view_2_tab4_779 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_779
+DROP VIEW IF EXISTS view_3_tab4_779 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22891,13 +22891,13 @@ SELECT pk FROM tab0 WHERE ((((col0 = 4044 OR col0 >= 7070 AND (col0 > 51)) OR co
 381 values hashing to a1b71f56be41ffb3dca98e1bec2ac7cc
 
 statement ok
-DROP VIEW view_1_tab0_780
+DROP VIEW IF EXISTS view_1_tab0_780 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_780
+DROP VIEW IF EXISTS view_2_tab0_780 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_780
+DROP VIEW IF EXISTS view_3_tab0_780 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -22988,13 +22988,13 @@ SELECT pk FROM tab1 WHERE ((((col0 = 4044 OR col0 >= 7070 AND (col0 > 51)) OR co
 381 values hashing to a1b71f56be41ffb3dca98e1bec2ac7cc
 
 statement ok
-DROP VIEW view_1_tab1_780
+DROP VIEW IF EXISTS view_1_tab1_780 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_780
+DROP VIEW IF EXISTS view_2_tab1_780 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_780
+DROP VIEW IF EXISTS view_3_tab1_780 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23085,13 +23085,13 @@ SELECT pk FROM tab2 WHERE ((((col0 = 4044 OR col0 >= 7070 AND (col0 > 51)) OR co
 381 values hashing to a1b71f56be41ffb3dca98e1bec2ac7cc
 
 statement ok
-DROP VIEW view_1_tab2_780
+DROP VIEW IF EXISTS view_1_tab2_780 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_780
+DROP VIEW IF EXISTS view_2_tab2_780 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_780
+DROP VIEW IF EXISTS view_3_tab2_780 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23182,13 +23182,13 @@ SELECT pk FROM tab3 WHERE ((((col0 = 4044 OR col0 >= 7070 AND (col0 > 51)) OR co
 381 values hashing to a1b71f56be41ffb3dca98e1bec2ac7cc
 
 statement ok
-DROP VIEW view_1_tab3_780
+DROP VIEW IF EXISTS view_1_tab3_780 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_780
+DROP VIEW IF EXISTS view_2_tab3_780 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_780
+DROP VIEW IF EXISTS view_3_tab3_780 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23279,13 +23279,13 @@ SELECT pk FROM tab4 WHERE ((((col0 = 4044 OR col0 >= 7070 AND (col0 > 51)) OR co
 381 values hashing to a1b71f56be41ffb3dca98e1bec2ac7cc
 
 statement ok
-DROP VIEW view_1_tab4_780
+DROP VIEW IF EXISTS view_1_tab4_780 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_780
+DROP VIEW IF EXISTS view_2_tab4_780 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_780
+DROP VIEW IF EXISTS view_3_tab4_780 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23371,13 +23371,13 @@ SELECT pk FROM tab0 WHERE col1 = 7089.83
 ----
 
 statement ok
-DROP VIEW view_1_tab0_781
+DROP VIEW IF EXISTS view_1_tab0_781 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_781
+DROP VIEW IF EXISTS view_2_tab0_781 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_781
+DROP VIEW IF EXISTS view_3_tab0_781 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23463,13 +23463,13 @@ SELECT pk FROM tab1 WHERE col1 = 7089.83
 ----
 
 statement ok
-DROP VIEW view_1_tab1_781
+DROP VIEW IF EXISTS view_1_tab1_781 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_781
+DROP VIEW IF EXISTS view_2_tab1_781 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_781
+DROP VIEW IF EXISTS view_3_tab1_781 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23555,13 +23555,13 @@ SELECT pk FROM tab2 WHERE col1 = 7089.83
 ----
 
 statement ok
-DROP VIEW view_1_tab2_781
+DROP VIEW IF EXISTS view_1_tab2_781 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_781
+DROP VIEW IF EXISTS view_2_tab2_781 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_781
+DROP VIEW IF EXISTS view_3_tab2_781 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23647,13 +23647,13 @@ SELECT pk FROM tab3 WHERE col1 = 7089.83
 ----
 
 statement ok
-DROP VIEW view_1_tab3_781
+DROP VIEW IF EXISTS view_1_tab3_781 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_781
+DROP VIEW IF EXISTS view_2_tab3_781 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_781
+DROP VIEW IF EXISTS view_3_tab3_781 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23739,13 +23739,13 @@ SELECT pk FROM tab4 WHERE col1 = 7089.83
 ----
 
 statement ok
-DROP VIEW view_1_tab4_781
+DROP VIEW IF EXISTS view_1_tab4_781 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_781
+DROP VIEW IF EXISTS view_2_tab4_781 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_781
+DROP VIEW IF EXISTS view_3_tab4_781 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23836,13 +23836,13 @@ SELECT pk FROM tab0 WHERE (((col0 IN (5925,9789)) AND (col1 <= 5378.37 AND col0 
 335 values hashing to 6c5db9666d99e19f3d583c2f59932dd3
 
 statement ok
-DROP VIEW view_1_tab0_782
+DROP VIEW IF EXISTS view_1_tab0_782 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_782
+DROP VIEW IF EXISTS view_2_tab0_782 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_782
+DROP VIEW IF EXISTS view_3_tab0_782 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -23933,13 +23933,13 @@ SELECT pk FROM tab1 WHERE (((col0 IN (5925,9789)) AND (col1 <= 5378.37 AND col0 
 335 values hashing to 6c5db9666d99e19f3d583c2f59932dd3
 
 statement ok
-DROP VIEW view_1_tab1_782
+DROP VIEW IF EXISTS view_1_tab1_782 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_782
+DROP VIEW IF EXISTS view_2_tab1_782 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_782
+DROP VIEW IF EXISTS view_3_tab1_782 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24030,13 +24030,13 @@ SELECT pk FROM tab2 WHERE (((col0 IN (5925,9789)) AND (col1 <= 5378.37 AND col0 
 335 values hashing to 6c5db9666d99e19f3d583c2f59932dd3
 
 statement ok
-DROP VIEW view_1_tab2_782
+DROP VIEW IF EXISTS view_1_tab2_782 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_782
+DROP VIEW IF EXISTS view_2_tab2_782 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_782
+DROP VIEW IF EXISTS view_3_tab2_782 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24127,13 +24127,13 @@ SELECT pk FROM tab3 WHERE (((col0 IN (5925,9789)) AND (col1 <= 5378.37 AND col0 
 335 values hashing to 6c5db9666d99e19f3d583c2f59932dd3
 
 statement ok
-DROP VIEW view_1_tab3_782
+DROP VIEW IF EXISTS view_1_tab3_782 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_782
+DROP VIEW IF EXISTS view_2_tab3_782 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_782
+DROP VIEW IF EXISTS view_3_tab3_782 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24224,13 +24224,13 @@ SELECT pk FROM tab4 WHERE (((col0 IN (5925,9789)) AND (col1 <= 5378.37 AND col0 
 335 values hashing to 6c5db9666d99e19f3d583c2f59932dd3
 
 statement ok
-DROP VIEW view_1_tab4_782
+DROP VIEW IF EXISTS view_1_tab4_782 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_782
+DROP VIEW IF EXISTS view_2_tab4_782 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_782
+DROP VIEW IF EXISTS view_3_tab4_782 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24321,13 +24321,13 @@ SELECT pk FROM tab0 WHERE (col3 > 1461) AND col4 > 3346.51
 555 values hashing to bd3129cffa46cf510552392bdc6fabe3
 
 statement ok
-DROP VIEW view_1_tab0_783
+DROP VIEW IF EXISTS view_1_tab0_783 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_783
+DROP VIEW IF EXISTS view_2_tab0_783 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_783
+DROP VIEW IF EXISTS view_3_tab0_783 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24418,13 +24418,13 @@ SELECT pk FROM tab1 WHERE (col3 > 1461) AND col4 > 3346.51
 555 values hashing to bd3129cffa46cf510552392bdc6fabe3
 
 statement ok
-DROP VIEW view_1_tab1_783
+DROP VIEW IF EXISTS view_1_tab1_783 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_783
+DROP VIEW IF EXISTS view_2_tab1_783 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_783
+DROP VIEW IF EXISTS view_3_tab1_783 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24515,13 +24515,13 @@ SELECT pk FROM tab2 WHERE (col3 > 1461) AND col4 > 3346.51
 555 values hashing to bd3129cffa46cf510552392bdc6fabe3
 
 statement ok
-DROP VIEW view_1_tab2_783
+DROP VIEW IF EXISTS view_1_tab2_783 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_783
+DROP VIEW IF EXISTS view_2_tab2_783 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_783
+DROP VIEW IF EXISTS view_3_tab2_783 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24612,13 +24612,13 @@ SELECT pk FROM tab3 WHERE (col3 > 1461) AND col4 > 3346.51
 555 values hashing to bd3129cffa46cf510552392bdc6fabe3
 
 statement ok
-DROP VIEW view_1_tab3_783
+DROP VIEW IF EXISTS view_1_tab3_783 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_783
+DROP VIEW IF EXISTS view_2_tab3_783 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_783
+DROP VIEW IF EXISTS view_3_tab3_783 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24709,13 +24709,13 @@ SELECT pk FROM tab4 WHERE (col3 > 1461) AND col4 > 3346.51
 555 values hashing to bd3129cffa46cf510552392bdc6fabe3
 
 statement ok
-DROP VIEW view_1_tab4_783
+DROP VIEW IF EXISTS view_1_tab4_783 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_783
+DROP VIEW IF EXISTS view_2_tab4_783 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_783
+DROP VIEW IF EXISTS view_3_tab4_783 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24806,13 +24806,13 @@ SELECT pk FROM tab0 WHERE col1 > 8864.94
 129 values hashing to 06ba729eec17185e49972dc22c67beb4
 
 statement ok
-DROP VIEW view_1_tab0_784
+DROP VIEW IF EXISTS view_1_tab0_784 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_784
+DROP VIEW IF EXISTS view_2_tab0_784 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_784
+DROP VIEW IF EXISTS view_3_tab0_784 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -24903,13 +24903,13 @@ SELECT pk FROM tab1 WHERE col1 > 8864.94
 129 values hashing to 06ba729eec17185e49972dc22c67beb4
 
 statement ok
-DROP VIEW view_1_tab1_784
+DROP VIEW IF EXISTS view_1_tab1_784 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_784
+DROP VIEW IF EXISTS view_2_tab1_784 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_784
+DROP VIEW IF EXISTS view_3_tab1_784 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25000,13 +25000,13 @@ SELECT pk FROM tab2 WHERE col1 > 8864.94
 129 values hashing to 06ba729eec17185e49972dc22c67beb4
 
 statement ok
-DROP VIEW view_1_tab2_784
+DROP VIEW IF EXISTS view_1_tab2_784 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_784
+DROP VIEW IF EXISTS view_2_tab2_784 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_784
+DROP VIEW IF EXISTS view_3_tab2_784 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25097,13 +25097,13 @@ SELECT pk FROM tab3 WHERE col1 > 8864.94
 129 values hashing to 06ba729eec17185e49972dc22c67beb4
 
 statement ok
-DROP VIEW view_1_tab3_784
+DROP VIEW IF EXISTS view_1_tab3_784 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_784
+DROP VIEW IF EXISTS view_2_tab3_784 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_784
+DROP VIEW IF EXISTS view_3_tab3_784 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25194,13 +25194,13 @@ SELECT pk FROM tab4 WHERE col1 > 8864.94
 129 values hashing to 06ba729eec17185e49972dc22c67beb4
 
 statement ok
-DROP VIEW view_1_tab4_784
+DROP VIEW IF EXISTS view_1_tab4_784 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_784
+DROP VIEW IF EXISTS view_2_tab4_784 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_784
+DROP VIEW IF EXISTS view_3_tab4_784 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25291,13 +25291,13 @@ SELECT pk FROM tab0 WHERE col0 < 3061 OR col0 <= 3225
 313 values hashing to b84e2dc02ae2e70d28f746b6cc234d4d
 
 statement ok
-DROP VIEW view_1_tab0_785
+DROP VIEW IF EXISTS view_1_tab0_785 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_785
+DROP VIEW IF EXISTS view_2_tab0_785 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_785
+DROP VIEW IF EXISTS view_3_tab0_785 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25388,13 +25388,13 @@ SELECT pk FROM tab1 WHERE col0 < 3061 OR col0 <= 3225
 313 values hashing to b84e2dc02ae2e70d28f746b6cc234d4d
 
 statement ok
-DROP VIEW view_1_tab1_785
+DROP VIEW IF EXISTS view_1_tab1_785 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_785
+DROP VIEW IF EXISTS view_2_tab1_785 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_785
+DROP VIEW IF EXISTS view_3_tab1_785 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25485,13 +25485,13 @@ SELECT pk FROM tab2 WHERE col0 < 3061 OR col0 <= 3225
 313 values hashing to b84e2dc02ae2e70d28f746b6cc234d4d
 
 statement ok
-DROP VIEW view_1_tab2_785
+DROP VIEW IF EXISTS view_1_tab2_785 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_785
+DROP VIEW IF EXISTS view_2_tab2_785 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_785
+DROP VIEW IF EXISTS view_3_tab2_785 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25582,13 +25582,13 @@ SELECT pk FROM tab3 WHERE col0 < 3061 OR col0 <= 3225
 313 values hashing to b84e2dc02ae2e70d28f746b6cc234d4d
 
 statement ok
-DROP VIEW view_1_tab3_785
+DROP VIEW IF EXISTS view_1_tab3_785 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_785
+DROP VIEW IF EXISTS view_2_tab3_785 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_785
+DROP VIEW IF EXISTS view_3_tab3_785 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25679,13 +25679,13 @@ SELECT pk FROM tab4 WHERE col0 < 3061 OR col0 <= 3225
 313 values hashing to b84e2dc02ae2e70d28f746b6cc234d4d
 
 statement ok
-DROP VIEW view_1_tab4_785
+DROP VIEW IF EXISTS view_1_tab4_785 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_785
+DROP VIEW IF EXISTS view_2_tab4_785 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_785
+DROP VIEW IF EXISTS view_3_tab4_785 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25774,13 +25774,13 @@ SELECT pk FROM tab0 WHERE ((col1 > 4325.40) AND ((col0 <= 3916)) OR col3 IN (SEL
 1000 values hashing to 30a3c33f4078cae93230de944dca2ac9
 
 statement ok
-DROP VIEW view_1_tab0_786
+DROP VIEW IF EXISTS view_1_tab0_786 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_786
+DROP VIEW IF EXISTS view_2_tab0_786 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_786
+DROP VIEW IF EXISTS view_3_tab0_786 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25869,13 +25869,13 @@ SELECT pk FROM tab1 WHERE ((col1 > 4325.40) AND ((col0 <= 3916)) OR col3 IN (SEL
 1000 values hashing to 30a3c33f4078cae93230de944dca2ac9
 
 statement ok
-DROP VIEW view_1_tab1_786
+DROP VIEW IF EXISTS view_1_tab1_786 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_786
+DROP VIEW IF EXISTS view_2_tab1_786 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_786
+DROP VIEW IF EXISTS view_3_tab1_786 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -25964,13 +25964,13 @@ SELECT pk FROM tab2 WHERE ((col1 > 4325.40) AND ((col0 <= 3916)) OR col3 IN (SEL
 1000 values hashing to 30a3c33f4078cae93230de944dca2ac9
 
 statement ok
-DROP VIEW view_1_tab2_786
+DROP VIEW IF EXISTS view_1_tab2_786 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_786
+DROP VIEW IF EXISTS view_2_tab2_786 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_786
+DROP VIEW IF EXISTS view_3_tab2_786 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26059,13 +26059,13 @@ SELECT pk FROM tab3 WHERE ((col1 > 4325.40) AND ((col0 <= 3916)) OR col3 IN (SEL
 1000 values hashing to 30a3c33f4078cae93230de944dca2ac9
 
 statement ok
-DROP VIEW view_1_tab3_786
+DROP VIEW IF EXISTS view_1_tab3_786 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_786
+DROP VIEW IF EXISTS view_2_tab3_786 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_786
+DROP VIEW IF EXISTS view_3_tab3_786 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26154,13 +26154,13 @@ SELECT pk FROM tab4 WHERE ((col1 > 4325.40) AND ((col0 <= 3916)) OR col3 IN (SEL
 1000 values hashing to 30a3c33f4078cae93230de944dca2ac9
 
 statement ok
-DROP VIEW view_1_tab4_786
+DROP VIEW IF EXISTS view_1_tab4_786 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_786
+DROP VIEW IF EXISTS view_2_tab4_786 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_786
+DROP VIEW IF EXISTS view_3_tab4_786 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26251,13 +26251,13 @@ SELECT pk FROM tab0 WHERE col3 < 2187
 213 values hashing to afe3ff6a955f0245b443e3cf968c88b6
 
 statement ok
-DROP VIEW view_1_tab0_787
+DROP VIEW IF EXISTS view_1_tab0_787 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_787
+DROP VIEW IF EXISTS view_2_tab0_787 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_787
+DROP VIEW IF EXISTS view_3_tab0_787 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26348,13 +26348,13 @@ SELECT pk FROM tab1 WHERE col3 < 2187
 213 values hashing to afe3ff6a955f0245b443e3cf968c88b6
 
 statement ok
-DROP VIEW view_1_tab1_787
+DROP VIEW IF EXISTS view_1_tab1_787 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_787
+DROP VIEW IF EXISTS view_2_tab1_787 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_787
+DROP VIEW IF EXISTS view_3_tab1_787 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26445,13 +26445,13 @@ SELECT pk FROM tab2 WHERE col3 < 2187
 213 values hashing to afe3ff6a955f0245b443e3cf968c88b6
 
 statement ok
-DROP VIEW view_1_tab2_787
+DROP VIEW IF EXISTS view_1_tab2_787 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_787
+DROP VIEW IF EXISTS view_2_tab2_787 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_787
+DROP VIEW IF EXISTS view_3_tab2_787 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26542,13 +26542,13 @@ SELECT pk FROM tab3 WHERE col3 < 2187
 213 values hashing to afe3ff6a955f0245b443e3cf968c88b6
 
 statement ok
-DROP VIEW view_1_tab3_787
+DROP VIEW IF EXISTS view_1_tab3_787 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_787
+DROP VIEW IF EXISTS view_2_tab3_787 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_787
+DROP VIEW IF EXISTS view_3_tab3_787 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26639,13 +26639,13 @@ SELECT pk FROM tab4 WHERE col3 < 2187
 213 values hashing to afe3ff6a955f0245b443e3cf968c88b6
 
 statement ok
-DROP VIEW view_1_tab4_787
+DROP VIEW IF EXISTS view_1_tab4_787 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_787
+DROP VIEW IF EXISTS view_2_tab4_787 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_787
+DROP VIEW IF EXISTS view_3_tab4_787 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26736,13 +26736,13 @@ SELECT pk FROM tab0 WHERE col3 < 7244
 733 values hashing to f93f97e29a441fe0bec443c1b2afbfac
 
 statement ok
-DROP VIEW view_1_tab0_789
+DROP VIEW IF EXISTS view_1_tab0_789 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_789
+DROP VIEW IF EXISTS view_2_tab0_789 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_789
+DROP VIEW IF EXISTS view_3_tab0_789 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26833,13 +26833,13 @@ SELECT pk FROM tab1 WHERE col3 < 7244
 733 values hashing to f93f97e29a441fe0bec443c1b2afbfac
 
 statement ok
-DROP VIEW view_1_tab1_789
+DROP VIEW IF EXISTS view_1_tab1_789 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_789
+DROP VIEW IF EXISTS view_2_tab1_789 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_789
+DROP VIEW IF EXISTS view_3_tab1_789 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -26930,13 +26930,13 @@ SELECT pk FROM tab2 WHERE col3 < 7244
 733 values hashing to f93f97e29a441fe0bec443c1b2afbfac
 
 statement ok
-DROP VIEW view_1_tab2_789
+DROP VIEW IF EXISTS view_1_tab2_789 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_789
+DROP VIEW IF EXISTS view_2_tab2_789 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_789
+DROP VIEW IF EXISTS view_3_tab2_789 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27027,13 +27027,13 @@ SELECT pk FROM tab3 WHERE col3 < 7244
 733 values hashing to f93f97e29a441fe0bec443c1b2afbfac
 
 statement ok
-DROP VIEW view_1_tab3_789
+DROP VIEW IF EXISTS view_1_tab3_789 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_789
+DROP VIEW IF EXISTS view_2_tab3_789 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_789
+DROP VIEW IF EXISTS view_3_tab3_789 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27124,13 +27124,13 @@ SELECT pk FROM tab4 WHERE col3 < 7244
 733 values hashing to f93f97e29a441fe0bec443c1b2afbfac
 
 statement ok
-DROP VIEW view_1_tab4_789
+DROP VIEW IF EXISTS view_1_tab4_789 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_789
+DROP VIEW IF EXISTS view_2_tab4_789 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_789
+DROP VIEW IF EXISTS view_3_tab4_789 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27221,13 +27221,13 @@ SELECT pk FROM tab0 WHERE col0 > 9359
 56 values hashing to 0a6c8143f9b8b7a36b7237fc901ea6ee
 
 statement ok
-DROP VIEW view_1_tab0_790
+DROP VIEW IF EXISTS view_1_tab0_790 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_790
+DROP VIEW IF EXISTS view_2_tab0_790 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_790
+DROP VIEW IF EXISTS view_3_tab0_790 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27318,13 +27318,13 @@ SELECT pk FROM tab1 WHERE col0 > 9359
 56 values hashing to 0a6c8143f9b8b7a36b7237fc901ea6ee
 
 statement ok
-DROP VIEW view_1_tab1_790
+DROP VIEW IF EXISTS view_1_tab1_790 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_790
+DROP VIEW IF EXISTS view_2_tab1_790 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_790
+DROP VIEW IF EXISTS view_3_tab1_790 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27415,13 +27415,13 @@ SELECT pk FROM tab2 WHERE col0 > 9359
 56 values hashing to 0a6c8143f9b8b7a36b7237fc901ea6ee
 
 statement ok
-DROP VIEW view_1_tab2_790
+DROP VIEW IF EXISTS view_1_tab2_790 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_790
+DROP VIEW IF EXISTS view_2_tab2_790 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_790
+DROP VIEW IF EXISTS view_3_tab2_790 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27512,13 +27512,13 @@ SELECT pk FROM tab3 WHERE col0 > 9359
 56 values hashing to 0a6c8143f9b8b7a36b7237fc901ea6ee
 
 statement ok
-DROP VIEW view_1_tab3_790
+DROP VIEW IF EXISTS view_1_tab3_790 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_790
+DROP VIEW IF EXISTS view_2_tab3_790 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_790
+DROP VIEW IF EXISTS view_3_tab3_790 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27609,13 +27609,13 @@ SELECT pk FROM tab4 WHERE col0 > 9359
 56 values hashing to 0a6c8143f9b8b7a36b7237fc901ea6ee
 
 statement ok
-DROP VIEW view_1_tab4_790
+DROP VIEW IF EXISTS view_1_tab4_790 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_790
+DROP VIEW IF EXISTS view_2_tab4_790 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_790
+DROP VIEW IF EXISTS view_3_tab4_790 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27706,13 +27706,13 @@ SELECT pk FROM tab0 WHERE col0 > 8958
 95 values hashing to 52c7e545f3faadc8172a6bd5825f852e
 
 statement ok
-DROP VIEW view_1_tab0_791
+DROP VIEW IF EXISTS view_1_tab0_791 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_791
+DROP VIEW IF EXISTS view_2_tab0_791 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_791
+DROP VIEW IF EXISTS view_3_tab0_791 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27803,13 +27803,13 @@ SELECT pk FROM tab1 WHERE col0 > 8958
 95 values hashing to 52c7e545f3faadc8172a6bd5825f852e
 
 statement ok
-DROP VIEW view_1_tab1_791
+DROP VIEW IF EXISTS view_1_tab1_791 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_791
+DROP VIEW IF EXISTS view_2_tab1_791 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_791
+DROP VIEW IF EXISTS view_3_tab1_791 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27900,13 +27900,13 @@ SELECT pk FROM tab2 WHERE col0 > 8958
 95 values hashing to 52c7e545f3faadc8172a6bd5825f852e
 
 statement ok
-DROP VIEW view_1_tab2_791
+DROP VIEW IF EXISTS view_1_tab2_791 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_791
+DROP VIEW IF EXISTS view_2_tab2_791 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_791
+DROP VIEW IF EXISTS view_3_tab2_791 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -27997,13 +27997,13 @@ SELECT pk FROM tab3 WHERE col0 > 8958
 95 values hashing to 52c7e545f3faadc8172a6bd5825f852e
 
 statement ok
-DROP VIEW view_1_tab3_791
+DROP VIEW IF EXISTS view_1_tab3_791 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_791
+DROP VIEW IF EXISTS view_2_tab3_791 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_791
+DROP VIEW IF EXISTS view_3_tab3_791 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28094,13 +28094,13 @@ SELECT pk FROM tab4 WHERE col0 > 8958
 95 values hashing to 52c7e545f3faadc8172a6bd5825f852e
 
 statement ok
-DROP VIEW view_1_tab4_791
+DROP VIEW IF EXISTS view_1_tab4_791 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_791
+DROP VIEW IF EXISTS view_2_tab4_791 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_791
+DROP VIEW IF EXISTS view_3_tab4_791 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28191,13 +28191,13 @@ SELECT pk FROM tab0 WHERE (col0 > 9039 AND ((col3 < 528)) AND ((col1 >= 5308.10 
 802 values hashing to 61ee14a01c10cd353f01586b4da32c89
 
 statement ok
-DROP VIEW view_1_tab0_792
+DROP VIEW IF EXISTS view_1_tab0_792 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_792
+DROP VIEW IF EXISTS view_2_tab0_792 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_792
+DROP VIEW IF EXISTS view_3_tab0_792 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28288,13 +28288,13 @@ SELECT pk FROM tab1 WHERE (col0 > 9039 AND ((col3 < 528)) AND ((col1 >= 5308.10 
 802 values hashing to 61ee14a01c10cd353f01586b4da32c89
 
 statement ok
-DROP VIEW view_1_tab1_792
+DROP VIEW IF EXISTS view_1_tab1_792 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_792
+DROP VIEW IF EXISTS view_2_tab1_792 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_792
+DROP VIEW IF EXISTS view_3_tab1_792 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28385,13 +28385,13 @@ SELECT pk FROM tab2 WHERE (col0 > 9039 AND ((col3 < 528)) AND ((col1 >= 5308.10 
 802 values hashing to 61ee14a01c10cd353f01586b4da32c89
 
 statement ok
-DROP VIEW view_1_tab2_792
+DROP VIEW IF EXISTS view_1_tab2_792 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_792
+DROP VIEW IF EXISTS view_2_tab2_792 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_792
+DROP VIEW IF EXISTS view_3_tab2_792 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28482,13 +28482,13 @@ SELECT pk FROM tab3 WHERE (col0 > 9039 AND ((col3 < 528)) AND ((col1 >= 5308.10 
 802 values hashing to 61ee14a01c10cd353f01586b4da32c89
 
 statement ok
-DROP VIEW view_1_tab3_792
+DROP VIEW IF EXISTS view_1_tab3_792 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_792
+DROP VIEW IF EXISTS view_2_tab3_792 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_792
+DROP VIEW IF EXISTS view_3_tab3_792 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28579,13 +28579,13 @@ SELECT pk FROM tab4 WHERE (col0 > 9039 AND ((col3 < 528)) AND ((col1 >= 5308.10 
 802 values hashing to 61ee14a01c10cd353f01586b4da32c89
 
 statement ok
-DROP VIEW view_1_tab4_792
+DROP VIEW IF EXISTS view_1_tab4_792 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_792
+DROP VIEW IF EXISTS view_2_tab4_792 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_792
+DROP VIEW IF EXISTS view_3_tab4_792 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28676,13 +28676,13 @@ SELECT pk FROM tab0 WHERE col0 <= 2869
 269 values hashing to 108fd734c7b51af7687409dd170d608a
 
 statement ok
-DROP VIEW view_1_tab0_793
+DROP VIEW IF EXISTS view_1_tab0_793 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_793
+DROP VIEW IF EXISTS view_2_tab0_793 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_793
+DROP VIEW IF EXISTS view_3_tab0_793 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28773,13 +28773,13 @@ SELECT pk FROM tab1 WHERE col0 <= 2869
 269 values hashing to 108fd734c7b51af7687409dd170d608a
 
 statement ok
-DROP VIEW view_1_tab1_793
+DROP VIEW IF EXISTS view_1_tab1_793 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_793
+DROP VIEW IF EXISTS view_2_tab1_793 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_793
+DROP VIEW IF EXISTS view_3_tab1_793 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28870,13 +28870,13 @@ SELECT pk FROM tab2 WHERE col0 <= 2869
 269 values hashing to 108fd734c7b51af7687409dd170d608a
 
 statement ok
-DROP VIEW view_1_tab2_793
+DROP VIEW IF EXISTS view_1_tab2_793 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_793
+DROP VIEW IF EXISTS view_2_tab2_793 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_793
+DROP VIEW IF EXISTS view_3_tab2_793 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -28967,13 +28967,13 @@ SELECT pk FROM tab3 WHERE col0 <= 2869
 269 values hashing to 108fd734c7b51af7687409dd170d608a
 
 statement ok
-DROP VIEW view_1_tab3_793
+DROP VIEW IF EXISTS view_1_tab3_793 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_793
+DROP VIEW IF EXISTS view_2_tab3_793 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_793
+DROP VIEW IF EXISTS view_3_tab3_793 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29064,13 +29064,13 @@ SELECT pk FROM tab4 WHERE col0 <= 2869
 269 values hashing to 108fd734c7b51af7687409dd170d608a
 
 statement ok
-DROP VIEW view_1_tab4_793
+DROP VIEW IF EXISTS view_1_tab4_793 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_793
+DROP VIEW IF EXISTS view_2_tab4_793 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_793
+DROP VIEW IF EXISTS view_3_tab4_793 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29161,13 +29161,13 @@ SELECT pk FROM tab0 WHERE col0 > 8362
 157 values hashing to 0da4d4228dff670f3cbf2f8a72488d3d
 
 statement ok
-DROP VIEW view_1_tab0_794
+DROP VIEW IF EXISTS view_1_tab0_794 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_794
+DROP VIEW IF EXISTS view_2_tab0_794 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_794
+DROP VIEW IF EXISTS view_3_tab0_794 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29258,13 +29258,13 @@ SELECT pk FROM tab1 WHERE col0 > 8362
 157 values hashing to 0da4d4228dff670f3cbf2f8a72488d3d
 
 statement ok
-DROP VIEW view_1_tab1_794
+DROP VIEW IF EXISTS view_1_tab1_794 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_794
+DROP VIEW IF EXISTS view_2_tab1_794 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_794
+DROP VIEW IF EXISTS view_3_tab1_794 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29355,13 +29355,13 @@ SELECT pk FROM tab2 WHERE col0 > 8362
 157 values hashing to 0da4d4228dff670f3cbf2f8a72488d3d
 
 statement ok
-DROP VIEW view_1_tab2_794
+DROP VIEW IF EXISTS view_1_tab2_794 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_794
+DROP VIEW IF EXISTS view_2_tab2_794 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_794
+DROP VIEW IF EXISTS view_3_tab2_794 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29452,13 +29452,13 @@ SELECT pk FROM tab3 WHERE col0 > 8362
 157 values hashing to 0da4d4228dff670f3cbf2f8a72488d3d
 
 statement ok
-DROP VIEW view_1_tab3_794
+DROP VIEW IF EXISTS view_1_tab3_794 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_794
+DROP VIEW IF EXISTS view_2_tab3_794 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_794
+DROP VIEW IF EXISTS view_3_tab3_794 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29549,13 +29549,13 @@ SELECT pk FROM tab4 WHERE col0 > 8362
 157 values hashing to 0da4d4228dff670f3cbf2f8a72488d3d
 
 statement ok
-DROP VIEW view_1_tab4_794
+DROP VIEW IF EXISTS view_1_tab4_794 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_794
+DROP VIEW IF EXISTS view_2_tab4_794 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_794
+DROP VIEW IF EXISTS view_3_tab4_794 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29641,13 +29641,13 @@ SELECT pk FROM tab0 WHERE (((((col0 >= 3109 AND col1 = 1545.89))))) AND col4 >= 
 ----
 
 statement ok
-DROP VIEW view_1_tab0_795
+DROP VIEW IF EXISTS view_1_tab0_795 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_795
+DROP VIEW IF EXISTS view_2_tab0_795 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_795
+DROP VIEW IF EXISTS view_3_tab0_795 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29733,13 +29733,13 @@ SELECT pk FROM tab1 WHERE (((((col0 >= 3109 AND col1 = 1545.89))))) AND col4 >= 
 ----
 
 statement ok
-DROP VIEW view_1_tab1_795
+DROP VIEW IF EXISTS view_1_tab1_795 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_795
+DROP VIEW IF EXISTS view_2_tab1_795 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_795
+DROP VIEW IF EXISTS view_3_tab1_795 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29825,13 +29825,13 @@ SELECT pk FROM tab2 WHERE (((((col0 >= 3109 AND col1 = 1545.89))))) AND col4 >= 
 ----
 
 statement ok
-DROP VIEW view_1_tab2_795
+DROP VIEW IF EXISTS view_1_tab2_795 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_795
+DROP VIEW IF EXISTS view_2_tab2_795 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_795
+DROP VIEW IF EXISTS view_3_tab2_795 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -29917,13 +29917,13 @@ SELECT pk FROM tab3 WHERE (((((col0 >= 3109 AND col1 = 1545.89))))) AND col4 >= 
 ----
 
 statement ok
-DROP VIEW view_1_tab3_795
+DROP VIEW IF EXISTS view_1_tab3_795 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_795
+DROP VIEW IF EXISTS view_2_tab3_795 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_795
+DROP VIEW IF EXISTS view_3_tab3_795 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30009,13 +30009,13 @@ SELECT pk FROM tab4 WHERE (((((col0 >= 3109 AND col1 = 1545.89))))) AND col4 >= 
 ----
 
 statement ok
-DROP VIEW view_1_tab4_795
+DROP VIEW IF EXISTS view_1_tab4_795 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_795
+DROP VIEW IF EXISTS view_2_tab4_795 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_795
+DROP VIEW IF EXISTS view_3_tab4_795 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30106,13 +30106,13 @@ SELECT pk FROM tab0 WHERE (col4 < 1512.63 OR ((((((((col0 = 2515) AND col0 > 184
 833 values hashing to a77284df67c9a890033d826b2f9225c1
 
 statement ok
-DROP VIEW view_1_tab0_796
+DROP VIEW IF EXISTS view_1_tab0_796 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_796
+DROP VIEW IF EXISTS view_2_tab0_796 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_796
+DROP VIEW IF EXISTS view_3_tab0_796 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30203,13 +30203,13 @@ SELECT pk FROM tab1 WHERE (col4 < 1512.63 OR ((((((((col0 = 2515) AND col0 > 184
 833 values hashing to a77284df67c9a890033d826b2f9225c1
 
 statement ok
-DROP VIEW view_1_tab1_796
+DROP VIEW IF EXISTS view_1_tab1_796 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_796
+DROP VIEW IF EXISTS view_2_tab1_796 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_796
+DROP VIEW IF EXISTS view_3_tab1_796 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30300,13 +30300,13 @@ SELECT pk FROM tab2 WHERE (col4 < 1512.63 OR ((((((((col0 = 2515) AND col0 > 184
 833 values hashing to a77284df67c9a890033d826b2f9225c1
 
 statement ok
-DROP VIEW view_1_tab2_796
+DROP VIEW IF EXISTS view_1_tab2_796 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_796
+DROP VIEW IF EXISTS view_2_tab2_796 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_796
+DROP VIEW IF EXISTS view_3_tab2_796 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30397,13 +30397,13 @@ SELECT pk FROM tab3 WHERE (col4 < 1512.63 OR ((((((((col0 = 2515) AND col0 > 184
 833 values hashing to a77284df67c9a890033d826b2f9225c1
 
 statement ok
-DROP VIEW view_1_tab3_796
+DROP VIEW IF EXISTS view_1_tab3_796 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_796
+DROP VIEW IF EXISTS view_2_tab3_796 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_796
+DROP VIEW IF EXISTS view_3_tab3_796 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30494,13 +30494,13 @@ SELECT pk FROM tab4 WHERE (col4 < 1512.63 OR ((((((((col0 = 2515) AND col0 > 184
 833 values hashing to a77284df67c9a890033d826b2f9225c1
 
 statement ok
-DROP VIEW view_1_tab4_796
+DROP VIEW IF EXISTS view_1_tab4_796 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_796
+DROP VIEW IF EXISTS view_2_tab4_796 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_796
+DROP VIEW IF EXISTS view_3_tab4_796 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30586,13 +30586,13 @@ SELECT pk FROM tab0 WHERE col1 > 3749.54 AND (col0 > 9386 AND col0 BETWEEN 123 A
 ----
 
 statement ok
-DROP VIEW view_1_tab0_797
+DROP VIEW IF EXISTS view_1_tab0_797 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_797
+DROP VIEW IF EXISTS view_2_tab0_797 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_797
+DROP VIEW IF EXISTS view_3_tab0_797 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30678,13 +30678,13 @@ SELECT pk FROM tab1 WHERE col1 > 3749.54 AND (col0 > 9386 AND col0 BETWEEN 123 A
 ----
 
 statement ok
-DROP VIEW view_1_tab1_797
+DROP VIEW IF EXISTS view_1_tab1_797 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_797
+DROP VIEW IF EXISTS view_2_tab1_797 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_797
+DROP VIEW IF EXISTS view_3_tab1_797 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30770,13 +30770,13 @@ SELECT pk FROM tab2 WHERE col1 > 3749.54 AND (col0 > 9386 AND col0 BETWEEN 123 A
 ----
 
 statement ok
-DROP VIEW view_1_tab2_797
+DROP VIEW IF EXISTS view_1_tab2_797 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_797
+DROP VIEW IF EXISTS view_2_tab2_797 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_797
+DROP VIEW IF EXISTS view_3_tab2_797 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30862,13 +30862,13 @@ SELECT pk FROM tab3 WHERE col1 > 3749.54 AND (col0 > 9386 AND col0 BETWEEN 123 A
 ----
 
 statement ok
-DROP VIEW view_1_tab3_797
+DROP VIEW IF EXISTS view_1_tab3_797 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_797
+DROP VIEW IF EXISTS view_2_tab3_797 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_797
+DROP VIEW IF EXISTS view_3_tab3_797 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30954,11 +30954,11 @@ SELECT pk FROM tab4 WHERE col1 > 3749.54 AND (col0 > 9386 AND col0 BETWEEN 123 A
 ----
 
 statement ok
-DROP VIEW view_1_tab4_797
+DROP VIEW IF EXISTS view_1_tab4_797 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_797
+DROP VIEW IF EXISTS view_2_tab4_797 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_797
+DROP VIEW IF EXISTS view_3_tab4_797 CASCADE
 

--- a/test/index/view/10000/slt_good_0.test
+++ b/test/index/view/10000/slt_good_0.test
@@ -30158,13 +30158,13 @@ SELECT pk FROM tab0 WHERE col3 > 34542
 6540 values hashing to a123c81dc3204a05a931624cc0a10638
 
 statement ok
-DROP VIEW view_1_tab0_1
+DROP VIEW IF EXISTS view_1_tab0_1 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_1
+DROP VIEW IF EXISTS view_2_tab0_1 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_1
+DROP VIEW IF EXISTS view_3_tab0_1 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30255,13 +30255,13 @@ SELECT pk FROM tab1 WHERE col3 > 34542
 6540 values hashing to a123c81dc3204a05a931624cc0a10638
 
 statement ok
-DROP VIEW view_1_tab1_1
+DROP VIEW IF EXISTS view_1_tab1_1 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_1
+DROP VIEW IF EXISTS view_2_tab1_1 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_1
+DROP VIEW IF EXISTS view_3_tab1_1 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30352,13 +30352,13 @@ SELECT pk FROM tab2 WHERE col3 > 34542
 6540 values hashing to a123c81dc3204a05a931624cc0a10638
 
 statement ok
-DROP VIEW view_1_tab2_1
+DROP VIEW IF EXISTS view_1_tab2_1 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_1
+DROP VIEW IF EXISTS view_2_tab2_1 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_1
+DROP VIEW IF EXISTS view_3_tab2_1 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30449,13 +30449,13 @@ SELECT pk FROM tab3 WHERE col3 > 34542
 6540 values hashing to a123c81dc3204a05a931624cc0a10638
 
 statement ok
-DROP VIEW view_1_tab3_1
+DROP VIEW IF EXISTS view_1_tab3_1 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_1
+DROP VIEW IF EXISTS view_2_tab3_1 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_1
+DROP VIEW IF EXISTS view_3_tab3_1 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30546,13 +30546,13 @@ SELECT pk FROM tab4 WHERE col3 > 34542
 6540 values hashing to a123c81dc3204a05a931624cc0a10638
 
 statement ok
-DROP VIEW view_1_tab4_1
+DROP VIEW IF EXISTS view_1_tab4_1 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_1
+DROP VIEW IF EXISTS view_2_tab4_1 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_1
+DROP VIEW IF EXISTS view_3_tab4_1 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30643,13 +30643,13 @@ SELECT pk FROM tab0 WHERE col0 > 88751 AND (col3 <= 71643 AND (col4 < 36251.98) 
 1129 values hashing to 4c3a25bc538e204723e305bba7da55a4
 
 statement ok
-DROP VIEW view_1_tab0_2
+DROP VIEW IF EXISTS view_1_tab0_2 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_2
+DROP VIEW IF EXISTS view_2_tab0_2 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_2
+DROP VIEW IF EXISTS view_3_tab0_2 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30740,13 +30740,13 @@ SELECT pk FROM tab1 WHERE col0 > 88751 AND (col3 <= 71643 AND (col4 < 36251.98) 
 1129 values hashing to 4c3a25bc538e204723e305bba7da55a4
 
 statement ok
-DROP VIEW view_1_tab1_2
+DROP VIEW IF EXISTS view_1_tab1_2 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_2
+DROP VIEW IF EXISTS view_2_tab1_2 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_2
+DROP VIEW IF EXISTS view_3_tab1_2 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30837,13 +30837,13 @@ SELECT pk FROM tab2 WHERE col0 > 88751 AND (col3 <= 71643 AND (col4 < 36251.98) 
 1129 values hashing to 4c3a25bc538e204723e305bba7da55a4
 
 statement ok
-DROP VIEW view_1_tab2_2
+DROP VIEW IF EXISTS view_1_tab2_2 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_2
+DROP VIEW IF EXISTS view_2_tab2_2 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_2
+DROP VIEW IF EXISTS view_3_tab2_2 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -30934,13 +30934,13 @@ SELECT pk FROM tab3 WHERE col0 > 88751 AND (col3 <= 71643 AND (col4 < 36251.98) 
 1129 values hashing to 4c3a25bc538e204723e305bba7da55a4
 
 statement ok
-DROP VIEW view_1_tab3_2
+DROP VIEW IF EXISTS view_1_tab3_2 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_2
+DROP VIEW IF EXISTS view_2_tab3_2 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_2
+DROP VIEW IF EXISTS view_3_tab3_2 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31031,13 +31031,13 @@ SELECT pk FROM tab4 WHERE col0 > 88751 AND (col3 <= 71643 AND (col4 < 36251.98) 
 1129 values hashing to 4c3a25bc538e204723e305bba7da55a4
 
 statement ok
-DROP VIEW view_1_tab4_2
+DROP VIEW IF EXISTS view_1_tab4_2 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_2
+DROP VIEW IF EXISTS view_2_tab4_2 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_2
+DROP VIEW IF EXISTS view_3_tab4_2 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31128,13 +31128,13 @@ SELECT pk FROM tab0 WHERE (col3 < 79840)
 8040 values hashing to 7089e47856a3e07d35773e88dad826b9
 
 statement ok
-DROP VIEW view_1_tab0_3
+DROP VIEW IF EXISTS view_1_tab0_3 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_3
+DROP VIEW IF EXISTS view_2_tab0_3 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_3
+DROP VIEW IF EXISTS view_3_tab0_3 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31225,13 +31225,13 @@ SELECT pk FROM tab1 WHERE (col3 < 79840)
 8040 values hashing to 7089e47856a3e07d35773e88dad826b9
 
 statement ok
-DROP VIEW view_1_tab1_3
+DROP VIEW IF EXISTS view_1_tab1_3 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_3
+DROP VIEW IF EXISTS view_2_tab1_3 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_3
+DROP VIEW IF EXISTS view_3_tab1_3 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31322,13 +31322,13 @@ SELECT pk FROM tab2 WHERE (col3 < 79840)
 8040 values hashing to 7089e47856a3e07d35773e88dad826b9
 
 statement ok
-DROP VIEW view_1_tab2_3
+DROP VIEW IF EXISTS view_1_tab2_3 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_3
+DROP VIEW IF EXISTS view_2_tab2_3 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_3
+DROP VIEW IF EXISTS view_3_tab2_3 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31419,13 +31419,13 @@ SELECT pk FROM tab3 WHERE (col3 < 79840)
 8040 values hashing to 7089e47856a3e07d35773e88dad826b9
 
 statement ok
-DROP VIEW view_1_tab3_3
+DROP VIEW IF EXISTS view_1_tab3_3 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_3
+DROP VIEW IF EXISTS view_2_tab3_3 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_3
+DROP VIEW IF EXISTS view_3_tab3_3 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31516,13 +31516,13 @@ SELECT pk FROM tab4 WHERE (col3 < 79840)
 8040 values hashing to 7089e47856a3e07d35773e88dad826b9
 
 statement ok
-DROP VIEW view_1_tab4_3
+DROP VIEW IF EXISTS view_1_tab4_3 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_3
+DROP VIEW IF EXISTS view_2_tab4_3 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_3
+DROP VIEW IF EXISTS view_3_tab4_3 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31613,13 +31613,13 @@ SELECT pk FROM tab0 WHERE (col1 > 2688.41 AND col1 <= 64297.25)
 6173 values hashing to cc3b240eaaab5f7bb22e8467e0ca55f1
 
 statement ok
-DROP VIEW view_1_tab0_4
+DROP VIEW IF EXISTS view_1_tab0_4 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_4
+DROP VIEW IF EXISTS view_2_tab0_4 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_4
+DROP VIEW IF EXISTS view_3_tab0_4 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31710,13 +31710,13 @@ SELECT pk FROM tab1 WHERE (col1 > 2688.41 AND col1 <= 64297.25)
 6173 values hashing to cc3b240eaaab5f7bb22e8467e0ca55f1
 
 statement ok
-DROP VIEW view_1_tab1_4
+DROP VIEW IF EXISTS view_1_tab1_4 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_4
+DROP VIEW IF EXISTS view_2_tab1_4 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_4
+DROP VIEW IF EXISTS view_3_tab1_4 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31807,13 +31807,13 @@ SELECT pk FROM tab2 WHERE (col1 > 2688.41 AND col1 <= 64297.25)
 6173 values hashing to cc3b240eaaab5f7bb22e8467e0ca55f1
 
 statement ok
-DROP VIEW view_1_tab2_4
+DROP VIEW IF EXISTS view_1_tab2_4 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_4
+DROP VIEW IF EXISTS view_2_tab2_4 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_4
+DROP VIEW IF EXISTS view_3_tab2_4 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -31904,13 +31904,13 @@ SELECT pk FROM tab3 WHERE (col1 > 2688.41 AND col1 <= 64297.25)
 6173 values hashing to cc3b240eaaab5f7bb22e8467e0ca55f1
 
 statement ok
-DROP VIEW view_1_tab3_4
+DROP VIEW IF EXISTS view_1_tab3_4 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_4
+DROP VIEW IF EXISTS view_2_tab3_4 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_4
+DROP VIEW IF EXISTS view_3_tab3_4 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32001,13 +32001,13 @@ SELECT pk FROM tab4 WHERE (col1 > 2688.41 AND col1 <= 64297.25)
 6173 values hashing to cc3b240eaaab5f7bb22e8467e0ca55f1
 
 statement ok
-DROP VIEW view_1_tab4_4
+DROP VIEW IF EXISTS view_1_tab4_4 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_4
+DROP VIEW IF EXISTS view_2_tab4_4 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_4
+DROP VIEW IF EXISTS view_3_tab4_4 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32098,13 +32098,13 @@ SELECT pk FROM tab0 WHERE (col0 <= 5584)
 573 values hashing to 5d5d44ed077fc88c3b83a67cc5482644
 
 statement ok
-DROP VIEW view_1_tab0_5
+DROP VIEW IF EXISTS view_1_tab0_5 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_5
+DROP VIEW IF EXISTS view_2_tab0_5 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_5
+DROP VIEW IF EXISTS view_3_tab0_5 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32195,13 +32195,13 @@ SELECT pk FROM tab1 WHERE (col0 <= 5584)
 573 values hashing to 5d5d44ed077fc88c3b83a67cc5482644
 
 statement ok
-DROP VIEW view_1_tab1_5
+DROP VIEW IF EXISTS view_1_tab1_5 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_5
+DROP VIEW IF EXISTS view_2_tab1_5 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_5
+DROP VIEW IF EXISTS view_3_tab1_5 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32292,13 +32292,13 @@ SELECT pk FROM tab2 WHERE (col0 <= 5584)
 573 values hashing to 5d5d44ed077fc88c3b83a67cc5482644
 
 statement ok
-DROP VIEW view_1_tab2_5
+DROP VIEW IF EXISTS view_1_tab2_5 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_5
+DROP VIEW IF EXISTS view_2_tab2_5 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_5
+DROP VIEW IF EXISTS view_3_tab2_5 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32389,13 +32389,13 @@ SELECT pk FROM tab3 WHERE (col0 <= 5584)
 573 values hashing to 5d5d44ed077fc88c3b83a67cc5482644
 
 statement ok
-DROP VIEW view_1_tab3_5
+DROP VIEW IF EXISTS view_1_tab3_5 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_5
+DROP VIEW IF EXISTS view_2_tab3_5 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_5
+DROP VIEW IF EXISTS view_3_tab3_5 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32486,13 +32486,13 @@ SELECT pk FROM tab4 WHERE (col0 <= 5584)
 573 values hashing to 5d5d44ed077fc88c3b83a67cc5482644
 
 statement ok
-DROP VIEW view_1_tab4_5
+DROP VIEW IF EXISTS view_1_tab4_5 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_5
+DROP VIEW IF EXISTS view_2_tab4_5 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_5
+DROP VIEW IF EXISTS view_3_tab4_5 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32583,13 +32583,13 @@ SELECT pk FROM tab0 WHERE (col0 < 86532)
 8644 values hashing to 06715b2e774760af2c864d2796ea2cdd
 
 statement ok
-DROP VIEW view_1_tab0_6
+DROP VIEW IF EXISTS view_1_tab0_6 CASCADE
 
 statement ok
-DROP VIEW view_2_tab0_6
+DROP VIEW IF EXISTS view_2_tab0_6 CASCADE
 
 statement ok
-DROP VIEW view_3_tab0_6
+DROP VIEW IF EXISTS view_3_tab0_6 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32680,13 +32680,13 @@ SELECT pk FROM tab1 WHERE (col0 < 86532)
 8644 values hashing to 06715b2e774760af2c864d2796ea2cdd
 
 statement ok
-DROP VIEW view_1_tab1_6
+DROP VIEW IF EXISTS view_1_tab1_6 CASCADE
 
 statement ok
-DROP VIEW view_2_tab1_6
+DROP VIEW IF EXISTS view_2_tab1_6 CASCADE
 
 statement ok
-DROP VIEW view_3_tab1_6
+DROP VIEW IF EXISTS view_3_tab1_6 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32777,13 +32777,13 @@ SELECT pk FROM tab2 WHERE (col0 < 86532)
 8644 values hashing to 06715b2e774760af2c864d2796ea2cdd
 
 statement ok
-DROP VIEW view_1_tab2_6
+DROP VIEW IF EXISTS view_1_tab2_6 CASCADE
 
 statement ok
-DROP VIEW view_2_tab2_6
+DROP VIEW IF EXISTS view_2_tab2_6 CASCADE
 
 statement ok
-DROP VIEW view_3_tab2_6
+DROP VIEW IF EXISTS view_3_tab2_6 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32874,13 +32874,13 @@ SELECT pk FROM tab3 WHERE (col0 < 86532)
 8644 values hashing to 06715b2e774760af2c864d2796ea2cdd
 
 statement ok
-DROP VIEW view_1_tab3_6
+DROP VIEW IF EXISTS view_1_tab3_6 CASCADE
 
 statement ok
-DROP VIEW view_2_tab3_6
+DROP VIEW IF EXISTS view_2_tab3_6 CASCADE
 
 statement ok
-DROP VIEW view_3_tab3_6
+DROP VIEW IF EXISTS view_3_tab3_6 CASCADE
 
 onlyif mssql # IF EXISTS support: 
 statement ok
@@ -32971,11 +32971,11 @@ SELECT pk FROM tab4 WHERE (col0 < 86532)
 8644 values hashing to 06715b2e774760af2c864d2796ea2cdd
 
 statement ok
-DROP VIEW view_1_tab4_6
+DROP VIEW IF EXISTS view_1_tab4_6 CASCADE
 
 statement ok
-DROP VIEW view_2_tab4_6
+DROP VIEW IF EXISTS view_2_tab4_6 CASCADE
 
 statement ok
-DROP VIEW view_3_tab4_6
+DROP VIEW IF EXISTS view_3_tab4_6 CASCADE
 


### PR DESCRIPTION
sqlite doesn't require that views with dependencies get dropped in
reverse topological order. Rather than reorder all of the drop views in
the tests, this commit just adds `IF NOT EXISTS ... CASCADE` to all of
the relevant spots.